### PR TITLE
dependencies: update invenio-records-permissions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 Babel = ">=2.4.0"
 Flask-BabelEx = ">=0.9.3"
 invenio = { version = "==3.1.0", extras = ["base", "metadata", "postgresql", "auth", "elasticsearch6" ]}
+invenio-records-permissions = ">= 1.0.0a3"
 uwsgi = ">=2.0"
 uwsgitop = ">=0.11"
 uwsgi-tools = ">=1.1.1"

--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -151,3 +151,56 @@ OAISERVER_ID_PREFIX = 'oai:invenio-app-rdm.org:'
 
 #: Switches off incept of redirects by Flask-DebugToolbar.
 DEBUG_TB_INTERCEPT_REDIRECTS = False
+
+
+# Records REST API endpoints.
+
+RECORDS_REST_ENDPOINTS = dict(
+    recid=dict(
+        pid_type='recid',
+        pid_minter='recid',
+        pid_fetcher='recid',
+        search_class=RecordsSearch,
+        indexer_class=RecordIndexer,
+        record_class=Record,
+        search_index=None,
+        search_type=None,
+        record_serializers={
+            'application/json': ('invenio_records_rest.serializers'
+                                 ':json_v1_response'),
+        },
+        search_serializers={
+            'application/json': ('invenio_records_rest.serializers'
+                                 ':json_v1_search'),
+        },
+        list_route='/records/',
+        item_route='/records/<pid(recid,'
+                   'record_class="invenio_records_files.api.Record")'
+                   ':pid_value>',
+        default_media_type='application/json',
+        max_result_window=10000,
+        error_handlers=dict(),
+        read_permission_factory_imp=record_read_permission_factory,
+        list_permission_factory_imp=record_list_permission_factory,
+        create_permission_factory_imp=record_create_permission_factory,
+        update_permission_factory_imp=record_update_permission_factory,
+        delete_permission_factory_imp=record_delete_permission_factory,
+    ),
+)
+
+# Records Permissions
+
+RECORDS_PERMISSIONS_RECORD_POLICY = 'invenio_app_rdm.permissions:' \
+    'RDMRecordPermissionPolicy'
+
+# Files REST
+
+FILES_REST_PERMISSION_FACTORY = record_read_files_permission_factory
+
+# Records Files
+
+RECORDS_FILES_REST_ENDPOINTS = {
+    'RECORDS_REST_ENDPOINTS': {
+        'recid': '/files',
+    }
+}

--- a/invenio_app_rdm/permissions.py
+++ b/invenio_app_rdm/permissions.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Permissions."""
+
+from invenio_records_permissions.generators import AnyUser
+from invenio_records_permissions.permissions.records import \
+    RecordPermissionPolicy
+
+
+class RDMRecordPermissionPolicy(RecordPermissionPolicy):
+    """Access control configuration for records.
+
+    Note that even if the array is empty, the invenio_access Permission class
+    always adds the ``superuser-access``, so admins will always be allowed.
+
+    - Create action given to everyone. NOTE: just for testing purposes.
+    - Read access given to everyone if public record/files and owners always.
+      (inherited)
+    - Update access given to record owners. (inherited)
+    - Delete access given to admins only. (inherited)
+    """
+
+    can_create = [AnyUser]


### PR DESCRIPTION
Depend on invenio-records-permissions with updated config. Travis will fail until that version is released. Blocked by: https://github.com/inveniosoftware/invenio-records-permissions/pull/19
