### PR TITLE
dependencies: expand metadata and files bundles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,23 @@ setup_requires = [
 ]
 
 install_requires = [
-    'Invenio[base,metadata,files,auth]==3.2.0a4',
-    'invenio-rdm-records>=1.0.0a3'
+    'Invenio[base,auth]==3.2.0a9',
+    'invenio-rdm-records>=1.0.0a5',
+    'invenio-records-permissions>=1.0.0a4',
+    # metadata
+    'invenio-indexer>=1.1.0,<1.2.0',
+    'invenio-jsonschemas>=1.0.0,<1.1.0',
+    'invenio-oaiserver>=1.0.0,<1.2.0',
+    'invenio-pidstore>=1.0.0,<1.2.0',
+    'invenio-records-rest>=1.5.0,<1.6.0',
+    'invenio-records-ui>=1.0.1,<1.1.0',
+    'invenio-records>=1.3.0,<1.4.0',
+    'invenio-search-ui>=1.1.1,<1.2.0',
+    #files
+    'invenio-files-rest>=1.0.5,<1.1.0',
+    'invenio-records-files<1.2.0,>=1.1.1',
+    'invenio-previewer>=1.0.0,<1.1.0',
+    'invenio-iiif>=1.0.0,<1.1.0',
 ]
 
 packages = find_packages()

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup_requires = [
 
 install_requires = [
     'Invenio[base,auth]==3.2.0a9',
-    'invenio-rdm-records>=1.0.0a5',
+    'invenio-rdm-records>=1.0.0a6',
     'invenio-records-permissions>=1.0.0a4',
     # metadata
     'invenio-indexer>=1.1.0,<1.2.0',
@@ -76,7 +76,7 @@ install_requires = [
     'invenio-search-ui>=1.1.1,<1.2.0',
     #files
     'invenio-files-rest>=1.0.5,<1.1.0',
-    'invenio-records-files<1.2.0,>=1.1.1',
+    'invenio-records-files>=1.1.1,<1.2.0',
     'invenio-previewer>=1.0.0,<1.1.0',
     'invenio-iiif>=1.0.0,<1.1.0',
 ]

--- a/tests/api/test_record_api.py
+++ b/tests/api/test_record_api.py
@@ -6,7 +6,10 @@
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""Module tests."""
+"""Module tests.
+
+TODO: Remove tests below because they are now covered in invenio-rdm-records.
+"""
 
 from __future__ import absolute_import, print_function
 

--- a/tests/api/test_record_api.py
+++ b/tests/api/test_record_api.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University,
-#                    Galter Health Sciences Library & Learning Center.
+# Copyright (C) 2019 Northwestern University.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -16,7 +15,24 @@ import json
 from invenio_search import current_search
 
 
-# TODO: Align this with invenio-rdm-records tests
+def assert_single_hit(response, expected_record):
+    assert response.status_code == 200
+
+    search_hits = response.json['hits']['hits']
+
+    # Kept for debugging
+    for hit in search_hits:
+        print("Search hit:", json.dumps(hit, indent=4, sort_keys=True))
+
+    assert len(search_hits) == 1
+
+    search_hit = search_hits[0]
+    for key in ['created', 'updated', 'metadata', 'links']:
+        assert key in search_hit
+
+    assert search_hit['metadata']['title'] == expected_record['title']
+
+
 def test_simple_flow(client, location):
     """Test simple flow using REST API."""
     # TODO pass headers and data to fixture
@@ -42,6 +58,6 @@ def test_simple_flow(client, location):
     assert response.status_code == 201
     current_search.flush_and_refresh('records')
 
-    # retrieve record
-    res = client.get('https://localhost:5000/records/1')
-    assert res.status_code == 200
+    # retrieve records
+    response = client.get('https://localhost:5000/records/')
+    assert_single_hit(response, data)


### PR DESCRIPTION
@fenekku  you might wanna change the deps pinned:

- invenio to just >= on the bundle to avoid future releases cuz of it. Or just expand all bundles.
- rdm-records accordingly to what its released.