### PR TITLE
ui: several css fixes on color and default text changes

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -117,7 +117,7 @@ THEME_FRONTPAGE = True
 THEME_FRONTPAGE_TEMPLATE = 'invenio_app_rdm/frontpage.html'
 """Frontpage template."""
 
-THEME_FRONTPAGE_TITLE = _('Invenio App RDM')
+THEME_FRONTPAGE_TITLE = _('The turn-key research data management repository')
 """Frontpage title."""
 
 THEME_HEADER_TEMPLATE = 'invenio_theme/header.html'

--- a/invenio_app_rdm/theme/assets/scss/invenio_app_rdm/footer.scss
+++ b/invenio_app_rdm/theme/assets/scss/invenio_app_rdm/footer.scss
@@ -10,7 +10,7 @@
    color: #fff;
 
   &.footer-bottom {
-    background-color: rgb(1, 98, 170);
+    background-color: #0377cd;
     padding-top: 15px;
     padding-bottom: 15px;
     font-weight: 300;

--- a/invenio_app_rdm/theme/assets/scss/invenio_app_rdm/theme.scss
+++ b/invenio_app_rdm/theme/assets/scss/invenio_app_rdm/theme.scss
@@ -31,14 +31,14 @@ h6 {
 }
 
 .navbar {
-  background-image: linear-gradient(348deg, rgba(3, 119, 205, 1), rgba(3, 119, 205, 1) 52.52%, rgba(251, 130, 115, 1));
+  background-image: linear-gradient(20deg, rgba(3, 119, 205, 1), rgba(3, 119, 205, 1) 52.52%, rgba(251, 130, 115, 1));
   background-color: unset;
   border-color: transparent;
-}
 
-.navbar .btn-warning {
-    background-color: #fb8172;
-    border-color: #fb8172;
+  .btn[href^="/signup"] {
+    background-color: #44a244;
+    border-color: #44a244;
+  }
 }
 
 .centered {

--- a/invenio_app_rdm/theme/templates/invenio_app_rdm/footer.html
+++ b/invenio_app_rdm/theme/templates/invenio_app_rdm/footer.html
@@ -16,7 +16,7 @@
         {%- endif %}
       </div>
       <div class="col-xs-6 col-xs-pull-6">
-        {% trans invenio_rdm="http://inveniosoftware.org/products/rdm", invenio="http://inveniosoftware.org/products/framework" %}<a href="{{invenio_rdm}}">InvenioRDM</a> instance powered by <a href="{{invenio}}">Invenio</a>{% endtrans %}
+        {% trans invenio_rdm="http://inveniosoftware.org/products/rdm" %}Powered by <a href="{{invenio_rdm}}">InvenioRDM</a>{% endtrans %}
       </div>
     </div>
   </div>

--- a/invenio_app_rdm/theme/templates/invenio_app_rdm/record_view_page.html
+++ b/invenio_app_rdm/theme/templates/invenio_app_rdm/record_view_page.html
@@ -59,8 +59,6 @@
       <br>
       <br>
 
-      <div class="pull-right"><small>Updated: <time datetime="{{ record.model.updated|dateformat(format='long') }}">{{record.model.updated|dateformat(format='long')}}</time></small></div>
-
       {%- endblock record_body %}
     </div>
   </div>


### PR DESCRIPTION
Changes:

- Navbar gradient inverted again in order to have the blue background behind `InvenioRDM` logo.
- Footer color was not matching. Now it follows the same blue.
- In the main page the app text has been changed to reflect the product page ("The turn-key...").
- "Powered by InvenioRDM" text in the footer.
- Removed update date from record view.
- Changed "Sign up" button color. Lars pointed out that red might reflect "negative" actions. Changed to green. The original "orange/yellow" did not match at all. We should work on a palette of colors. Feel free to change this color if needed.

Ready to be merged :)