### PR TITLE
ui: fix files preview in records view

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -276,13 +276,13 @@ RECORDS_UI_ENDPOINTS = {
         'route': '/records/<pid_value>',
         'template': 'invenio_app_rdm/record_view_page.html'
     },
-    'recid_file': {
+    'recid_files': {
         'pid_type': 'recid',
         'record_class': 'invenio_records_files.api:Record',
         'route': '/records/<pid_value>/files/<path:filename>',
         'view_imp': 'invenio_records_files.utils.file_download_ui',
     },
-    'recid_preview': {
+    'recid_previewer': {
         'pid_type': 'recid',
         'record_class': 'invenio_records_files.api:Record',
         'route': '/records/<pid_value>/preview/<path:filename>',

--- a/invenio_app_rdm/theme/templates/invenio_app_rdm/record_view_page.html
+++ b/invenio_app_rdm/theme/templates/invenio_app_rdm/record_view_page.html
@@ -28,7 +28,7 @@
     <tbody>
     {% for file in files %}
       {%- set file = file.dumps() %}
-      {%- set file_uri = url_for('invenio_records_ui.recid_file', pid_value=pid.pid_value, filename=file.key, download=1) %}
+      {%- set file_uri = url_for('invenio_records_ui.recid_files', pid_value=pid.pid_value, filename=file.key, download=1) %}
       <tr class="">
         <td>
           <a class="forcewrap" href="{{ file_uri }}">
@@ -96,7 +96,7 @@
           {{_('Preview')}} - {{ selected_file.key }}
         </div>
         <div class="panel-body">
-          {{- preview_file('invenio_records_ui.recid_preview', pid=pid, filename=selected_file.key) }}
+          {{- preview_file('invenio_records_ui.recid_previewer', pid=pid, filename=selected_file.key) }}
         </div>
       </div>
 


### PR DESCRIPTION
Changes:
* `RECORDS_UI_ENDPOINTS` naming. Since some code is reused from `invenio-previewers` it was looking for `recid_files` and `recid_previewer` endpoing and not finding them. Now it is consistent.

Example:

``` console
curl -k -XPUT https://localhost:5000/api/records/54t33-38526/files/test.pdf -H "Content-Type: application/octet-stream" --data-binary @test.pdf
```

![image](https://user-images.githubusercontent.com/6756943/72161832-1f984900-33c1-11ea-9f37-740bb4d06a7f.png)

Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/51