### PR TITLE
Add title and resource type fields

### DIFF
--- a/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositApiController.js
+++ b/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositApiController.js
@@ -2,6 +2,7 @@ import { DepositApiController } from "../../../react_invenio_deposit";
 
 export class RDMDepositApiController extends DepositApiController {
   constructor(apiClient) {
+    super(apiClient);
     console.log("RDM Deposit Controller");
   }
 }

--- a/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Message, Container, Grid } from "semantic-ui-react";
+import { Message, Container, Grid, Icon } from "semantic-ui-react";
 
 import { RDMDepositApiClient } from "./RDMDepositAPIClient";
 import { RDMDepositApiController } from "./RDMDepositApiController";
@@ -9,6 +9,9 @@ import {
   SaveButton,
   connect,
 } from "../../../react_invenio_deposit";
+import { AccordionField, ArrayField, GroupField } from "../../../react_invenio_forms";
+import { ResourceTypeField } from "./components";
+import { ArrayTitlesItem } from "./components";
 
 class RecordPreviewer extends Component {
   render() {
@@ -33,6 +36,8 @@ export class RDMDepositForm extends Component {
   }
 
   render() {
+    const vocabularies = this.config.vocabularies;
+
     return (
       <DepositFormApp
         apiController={this.controller}
@@ -42,9 +47,37 @@ export class RDMDepositForm extends Component {
         <RecordPreviewer />
         <Grid columns={2}>
           <Grid.Column>
-            {
-              // Insert form fields here
-            }
+              {/* <ArrayField
+                fieldPath="titles"
+                defaultNewValue={{ title: '', type: '', lang: '' }}
+                label={<span><Icon disabled name="book" />Title</span>}
+                renderArrayItem={DepositArrayTitlesItem} />
+
+                <DepositResourceTypeField
+                fieldPath="resource_type"
+                label={<span><Icon disabled name="tag" />Resource type</span>}
+                options={vocabularies.resource_type}
+              /> */}
+            <AccordionField fieldPath='' active={true} label={'Basic Information'} content={
+              <div>
+                <ArrayField
+                  fieldPath="titles"
+                  defaultNewValue={{ title: '', type: '', lang: '' }}
+                  // <span><Icon disabled name="book" />Title</span>
+                  label={'Title'} // TODO: allow <Icon>
+                  renderArrayItem={ArrayTitlesItem} />
+
+                <ResourceTypeField
+                  fieldPath="resource_type"
+                  // <span><Icon disabled name="tag" />Resource type</span>
+                  label={'Resource type'}
+                  options={vocabularies.resource_type}
+                />
+              </div>
+            } />
+
+              {/* header={<h3>Required Information</h3>} */}
+
           </Grid.Column>
           <Grid.Column>
             <Container>

--- a/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/components/ArrayTitlesItem.js
+++ b/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/components/ArrayTitlesItem.js
@@ -1,0 +1,9 @@
+import React, { Component } from 'react';
+
+import { TextField } from "../../../../react_invenio_forms";
+
+export function ArrayTitlesItem(invenioArrayBag) {
+    const { key } = invenioArrayBag;
+    return <TextField fluid fieldPath={`${key}.title`} />;
+    //TODO: Add <SelectField options={[Main, alternative,...]}/> <SelectField options={languages} />
+}

--- a/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/components/ResourceTypeField.js
+++ b/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/components/ResourceTypeField.js
@@ -1,0 +1,58 @@
+import { getIn, Field } from 'formik';
+import React, { Component } from 'react';
+
+import { GroupField, SelectField } from "../../../../react_invenio_forms";
+
+export class ResourceTypeField extends Component {
+  // NOTE: We use formik.form.values as the state for field components
+
+  renderResourceTypeField = (formikBag) => {
+    const resource_type_fieldpath = `${this.props.fieldPath}.type`;
+    const resource_subtype_fieldpath = `${this.props.fieldPath}.subtype`;
+
+    const resource_type = getIn(
+      formikBag.form.values,
+      resource_type_fieldpath,
+      ''
+
+    );
+
+    const handleChange = (event, selectedOption) => {
+      formikBag.form.setFieldValue(
+        resource_type_fieldpath,
+        selectedOption.value
+      );
+      formikBag.form.setFieldValue(resource_subtype_fieldpath, '');
+    }
+
+    const subtype_options = this.props.options.subtype.filter(
+      (e) => e['parent-value'] === resource_type
+    )
+
+    return (
+      <div>
+        <SelectField
+          fieldPath={resource_type_fieldpath}
+          label={this.props.label}
+          options={this.props.options.type}
+          onChange={handleChange}
+          placeholder='Select general resource type'
+        />
+        {subtype_options.length > 0 ?
+          <SelectField
+            fieldPath={resource_subtype_fieldpath}
+            placeholder='Select resource subtype'
+            options={subtype_options}
+          />
+          : null}
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <Field name={this.props.fieldPath} component={this.renderResourceTypeField} />
+    );
+  }
+
+}

--- a/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/components/index.js
+++ b/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/components/index.js
@@ -4,3 +4,6 @@
 //
 // Invenio App RDM is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
+
+export { ArrayTitlesItem } from "./ArrayTitlesItem";
+export { ResourceTypeField } from "./ResourceTypeField";

--- a/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/AccordionField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/AccordionField.js
@@ -4,7 +4,10 @@ import { Field } from "formik";
 import { Accordion, Form, Icon } from "semantic-ui-react";
 
 export class AccordionField extends Component {
-  state = { active: false };
+  constructor(props) {
+    super(props);
+    this.state = { active: props.active || false };
+  }
 
   iconActive = (
     <Icon name="angle down" size="large" style={{ float: "right" }} />
@@ -61,6 +64,7 @@ export class AccordionField extends Component {
 }
 
 AccordionField.propTypes = {
+  active: PropTypes.bool,
   content: PropTypes.object.isRequired,
   fieldPath: PropTypes.string.isRequired,
   label: PropTypes.string,
@@ -68,6 +72,7 @@ AccordionField.propTypes = {
 };
 
 AccordionField.defaultProps = {
+  active: false,
   label: "",
   required: false,
 };

--- a/invenio_app_rdm/theme/views.py
+++ b/invenio_app_rdm/theme/views.py
@@ -17,6 +17,9 @@ from __future__ import absolute_import, print_function
 
 from flask import Blueprint, current_app, render_template
 
+from invenio_rdm_records.marshmallow.json import MetadataSchemaV1, dump_empty
+from invenio_rdm_records.vocabularies import Vocabulary, dump_vocabularies
+
 blueprint = Blueprint(
     'invenio_app_rdm',
     __name__,
@@ -34,8 +37,11 @@ def search():
 @blueprint.route('/deposit/new')
 def records_create():
     """Record creation page."""
-    config = dict(apiUrl='/api/records/')
-    empty_record = {"version": ""}
+    config = dict(
+        apiUrl='/api/records/',
+        vocabularies=dump_vocabularies(Vocabulary)
+    )
+    empty_record = dump_empty(MetadataSchemaV1)
     return render_template(
         current_app.config['DEPOSITS_FORMS_BASE_TEMPLATE'],
         ui_config=config,


### PR DESCRIPTION
This adds the title and resource type field on the deposit/new endpoint.

![image](https://user-images.githubusercontent.com/1932651/80265437-335c7800-865d-11ea-8ee9-5e55e1f9b661.png)


**Requirement**

- Requires fenekku/dump_vocabularies branch from invenio-rdm-records (see inveniosoftware/invenio-rdm-records#91) to get the empty record dump and the vocabulary dump

**TODO**

- add it on the edit endpoint
- investigate the null initial values

It can nevertheless be reviewed and merged (at least once this email_validator issue is fixed upstream) 

