### PR TITLE
[follows from #113 ] Add Creators and Contributors Fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.venv/
+Pipfile
+Pipfile.lock
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -63,3 +66,5 @@ target/
 
 # Vim swapfiles
 .*.sw?
+.vscode/
+*.sublime-*

--- a/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
@@ -7,6 +7,7 @@
 
 import React, { Component } from "react";
 import { Message, Grid } from "semantic-ui-react";
+import { Field } from "formik";
 
 import { RDMDepositApiClient } from "./RDMDepositAPIClient";
 import { RDMDepositController } from "./RDMDepositController";
@@ -15,6 +16,7 @@ import {
   PublishButton,
   SaveButton,
   connect,
+  CreatorsField,
   TitlesField,
   ResourceTypeField,
 } from "../../../react_invenio_deposit";
@@ -32,18 +34,105 @@ class RecordPreviewer extends Component {
 }
 RecordPreviewer = connect(RecordPreviewer);
 
+
+export class FormRecordPreviewer extends Component {
+  renderFormField = (formikBag) => {
+    const values = formikBag.form.values;
+    return (
+      <Message>
+        <Message.Header>Current Form record</Message.Header>
+        <pre>{JSON.stringify(values, undefined, 2)}</pre>
+      </Message>
+    );
+  };
+
+  render() {
+    return (
+      <Field
+        name="FormRecordPreviewer"
+        component={this.renderFormField}
+      />
+    );
+  }
+}
+
+function fakeInitialRecord(backendRecord) {
+  /** Returns the initialRecord with experimental changes.
+   * Used to group trial changes.
+   */
+  // Experiment: no creators defined. Our default functionality will take the slack.
+  const { creators, ...fakedRecord } = backendRecord;
+  // console.log("fakedRecord", JSON.stringify(fakedRecord, null, 2))
+  return fakedRecord;
+}
+
+// NOTE: RDMDepositForm knows the data model. No other way for it to interact
+//       with it. As the frontend, it needs to duplicate the knowledge, mimicking
+//       what other frontends would need to do.
+const defaultRecord = {
+  creators: [
+    {
+      affiliations: [
+        {
+          identifier: "",
+          name: "",
+          scheme: "",
+        }
+      ],
+      given_name: "",
+      family_name: "",
+      name: "",
+      type: "personal",
+      identifiers: [
+        {
+          identifier: "",
+          scheme: "",
+        }
+      ]
+    }
+  ]
+}
+
+// NOTE: RDMDepositForm knows the meaning associated to the field.
+// i.e. it knows its datamodel is the one sent by invenio-rdm-records.
+// However, it is RDMDepositForm that gets to decide what are the frontend
+// defaults for this datamodel
+function defaultize(initialRecord) {
+  return {
+    ...defaultRecord,
+    ...initialRecord,
+  };
+}
+
 export class RDMDepositForm extends Component {
   constructor(props) {
     super(props);
     this.config = props.config || {};
     this.controller = new RDMDepositController(new RDMDepositApiClient());
+    console.log("backend initial record", JSON.stringify(props.record, null, 2))
+    console.log("faked backend record", JSON.stringify(fakeInitialRecord(props.record), null, 2))
+    const record = defaultize(fakeInitialRecord(props.record));
+    console.log("initial form record", JSON.stringify(record, null, 2))
     this.state = {
-      record: props.record || {},
+      record: record || {},
     };
   }
 
   render() {
-    const vocabularies = this.config.vocabularies || {};
+    // GRADUAL: placing all the dynamically provided backend data
+    //          (vocabularies) here
+    //          so that iteration is faster and abstractions can be discovered.
+    //          Then will let backend generate them (if appropriate).
+    // const vocabularies = this.config.vocabularies || {
+    const vocabularies = {
+      ...this.config.vocabularies,
+      // **Vocabulary experiments go here**
+      creators: {
+        type: [{ text: "Person", value: "personal"}, { text: "Organization", value: "organizational" }]
+      }
+    };
+
+    // columns = {2}
     return (
       <DepositFormApp
         config={this.config}
@@ -51,8 +140,8 @@ export class RDMDepositForm extends Component {
         record={this.state.record}
       >
         <ErrorMessage fieldPath="message" />
-        <Grid columns={2}>
-          <Grid.Column>
+        <Grid>
+          <Grid.Column width={12}>
             <AccordionField
               fieldPath=""
               active={true}
@@ -60,6 +149,24 @@ export class RDMDepositForm extends Component {
             >
               <div>
                 <TitlesField fieldPath="titles" label="Titles" labelIcon="book" />
+                <CreatorsField
+                  fieldPath="creators"
+                  label="Creators" labelIcon="group"
+                  options={vocabularies.creators}
+                  typeSegment={"type"}
+                  familyNameSegment={"family_name"}
+                  givenNameSegment={"given_name"}
+                  nameSegment={"name"}
+                  identifiersSegment={"identifiers"}
+                  identifiersSchemeSegment={"scheme"}
+                  identifiersIdentifierSegment={"identifier"}
+                  affiliationsSegment={"affiliations"}
+                  affiliationsNameSegment={"name"}
+                  affiliationsIdentifierSegment={"identifier"}
+                  affiliationsSchemeSegment={"scheme"}
+                />
+
+                {/* <ContributorsField fieldPath="contributors" label="Creators" label_icon="group" /> */}
                 <ResourceTypeField
                   fieldPath="resource_type"
                   label={"Resource type"}
@@ -69,11 +176,14 @@ export class RDMDepositForm extends Component {
               </div>
             </AccordionField>
           </Grid.Column>
-          <Grid.Column>
+
+          <Grid.Column width={4}>
             <SaveButton />
             <PublishButton />
           </Grid.Column>
         </Grid>
+
+        <FormRecordPreviewer />
         <RecordPreviewer />
       </DepositFormApp>
     );

--- a/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
@@ -59,11 +59,11 @@ export class RDMDepositForm extends Component {
               label={"Basic Information"}
             >
               <div>
-                <TitlesField fieldPath="titles" label="Titles" label_icon="book" />
+                <TitlesField fieldPath="titles" label="Titles" labelIcon="book" />
                 <ResourceTypeField
                   fieldPath="resource_type"
                   label={"Resource type"}
-                  label_icon={"tag"}
+                  labelIcon={"tag"}
                   options={vocabularies.resource_type}
                 />
               </div>

--- a/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
@@ -63,6 +63,7 @@ export class RDMDepositForm extends Component {
                 <ResourceTypeField
                   fieldPath="resource_type"
                   label={"Resource type"}
+                  label_icon={"tag"}
                   options={vocabularies.resource_type}
                 />
               </div>

--- a/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
@@ -16,6 +16,7 @@ import {
   PublishButton,
   SaveButton,
   connect,
+  ContributorsField,
   CreatorsField,
   TitlesField,
   ResourceTypeField,
@@ -60,9 +61,13 @@ function fakeInitialRecord(backendRecord) {
   /** Returns the initialRecord with experimental changes.
    * Used to group trial changes.
    */
-  // Experiment: no creators defined. Our default functionality will take the slack.
-  const { creators, ...fakedRecord } = backendRecord;
-  // console.log("fakedRecord", JSON.stringify(fakedRecord, null, 2))
+  // Experiment: Ignore backend for now and gradually fill what the frontend
+  //             needs for a brand new record
+  const {
+    creators,
+    contributors,
+    ...fakedRecord
+  } = backendRecord;
   return fakedRecord;
 }
 
@@ -90,6 +95,28 @@ const defaultRecord = {
         }
       ]
     }
+  ],
+  contributors: [
+    {
+      affiliations: [
+        {
+          identifier: "",
+          name: "",
+          scheme: "",
+        }
+      ],
+      given_name: "",
+      family_name: "",
+      name: "",
+      type: "personal",
+      identifiers: [
+        {
+          identifier: "",
+          scheme: "",
+        }
+      ],
+      role: ""
+    }
   ]
 }
 
@@ -109,6 +136,7 @@ export class RDMDepositForm extends Component {
     super(props);
     this.config = props.config || {};
     this.controller = new RDMDepositController(new RDMDepositApiClient());
+    // TODO: Remove when backend is better integrated
     console.log("backend initial record", JSON.stringify(props.record, null, 2))
     console.log("faked backend record", JSON.stringify(fakeInitialRecord(props.record), null, 2))
     const record = defaultize(fakeInitialRecord(props.record));
@@ -129,10 +157,19 @@ export class RDMDepositForm extends Component {
       // **Vocabulary experiments go here**
       creators: {
         type: [{ text: "Person", value: "personal"}, { text: "Organization", value: "organizational" }]
+      },
+      contributors: {
+        type: [{ text: "Person", value: "personal" }, { text: "Organization", value: "organizational" }],
+        role: [
+          { text: "Editor", value: "Editor" },
+          { text: "DataCurator", value: "DataCurator" },
+          { text: "DataManager", value: "DataManager" },
+          { text: "ProjectManager", value: "ProjectManager" },
+        ]
       }
+
     };
 
-    // columns = {2}
     return (
       <DepositFormApp
         config={this.config}
@@ -165,8 +202,24 @@ export class RDMDepositForm extends Component {
                   affiliationsIdentifierSegment={"identifier"}
                   affiliationsSchemeSegment={"scheme"}
                 />
+                <ContributorsField
+                  fieldPath="contributors"
+                  label="Contributors" labelIcon="group"
+                  options={vocabularies.contributors}
+                  typeSegment={"type"}
+                  familyNameSegment={"family_name"}
+                  givenNameSegment={"given_name"}
+                  nameSegment={"name"}
+                  identifiersSegment={"identifiers"}
+                  identifiersSchemeSegment={"scheme"}
+                  identifiersIdentifierSegment={"identifier"}
+                  affiliationsSegment={"affiliations"}
+                  affiliationsNameSegment={"name"}
+                  affiliationsIdentifierSegment={"identifier"}
+                  affiliationsSchemeSegment={"scheme"}
+                  roleSegment={"role"}
+                />
 
-                {/* <ContributorsField fieldPath="contributors" label="Creators" label_icon="group" /> */}
                 <ResourceTypeField
                   fieldPath="resource_type"
                   label={"Resource type"}

--- a/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
@@ -59,7 +59,7 @@ export class RDMDepositForm extends Component {
               label={"Basic Information"}
             >
               <div>
-                <TitlesField fieldPath="titles" label="Titles" />
+                <TitlesField fieldPath="titles" label="Titles" label_icon="book" />
                 <ResourceTypeField
                   fieldPath="resource_type"
                   label={"Resource type"}

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/AffiliationField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/AffiliationField.js
@@ -1,0 +1,44 @@
+// This file is part of React-Invenio-Deposit
+// Copyright (C) 2020 CERN.
+// Copyright (C) 2020 Northwestern University.
+//
+// React-Invenio-Deposit is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Form, Button, Icon } from "semantic-ui-react";
+
+import { TextField } from "../../react_invenio_forms";
+
+import { IdentifierField } from "./IdentifierField";
+
+/**Affiliation input component */
+export class AffiliationField extends Component {
+  render() {
+    const {
+      identifierFieldPath,
+      nameFieldPath,
+      schemeFieldPath,
+    } = this.props;
+
+    return (
+      <>
+        <TextField fieldPath={nameFieldPath} label="Name" />
+        <IdentifierField
+          identifierFieldPath={identifierFieldPath}
+          schemeFieldPath={schemeFieldPath}
+        />
+      </>
+    );
+  }
+}
+
+AffiliationField.propTypes = {
+  identifierFieldPath: PropTypes.string.isRequired,
+  nameFieldPath: PropTypes.string.isRequired,
+  schemeFieldPath: PropTypes.string.isRequired,
+};
+
+AffiliationField.defaultProps = {
+};

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/ContributorsField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/ContributorsField.js
@@ -4,16 +4,16 @@
 //
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
+
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Button, Grid} from "semantic-ui-react";
+import { Button, Form, Grid, Icon } from "semantic-ui-react";
 
 import { ArrayField } from "../../react_invenio_forms";
 import { CreatorOrContributorField } from "./CreatorOrContributorField";
 
-
-export class CreatorsField extends Component {
-  /** Top-level Creators Component */
+export class ContributorsField extends Component {
+  /** Top-level Contributors Component */
 
   render() {
     const {
@@ -35,6 +35,7 @@ export class CreatorsField extends Component {
       identifiersIdentifierSegment,
       identifiersSchemeSegment,
       typeSegment,
+      roleSegment,
     } = itemProps;
 
     const defaultNewValue = {
@@ -55,12 +56,13 @@ export class CreatorsField extends Component {
       ],
       [nameSegment]: "",
       [typeSegment]: "personal",
+      [roleSegment]: "",
     };
 
     return (
       // TODO: Replace by arrayProps
       <ArrayField
-        addButtonLabel={"Add creator"} // TODO: Pass by prop
+        addButtonLabel={"Add contributor"} // TODO: Pass by prop
         defaultNewValue={defaultNewValue}
         fieldPath={fieldPath}
         label={label}
@@ -71,19 +73,20 @@ export class CreatorsField extends Component {
             <>
               <CreatorOrContributorField
                 fieldPath={key}
+                isContributor={true}
                 {...itemProps}
               />
               <Grid>
                 <Grid.Column></Grid.Column>
                 <Grid.Column floated='right' >
-                {
-                  array.length === 1
-                  ? null
-                  :
-                    <Button color='red' floated='right' onClick={() => arrayHelpers.remove(indexPath)}>
-                      Remove
+                  {
+                    array.length === 1
+                      ? null
+                      :
+                      <Button color='red' floated='right' onClick={() => arrayHelpers.remove(indexPath)}>
+                        Remove
                     </Button>
-                }
+                  }
                 </Grid.Column>
               </Grid>
             </>
@@ -94,7 +97,7 @@ export class CreatorsField extends Component {
   }
 }
 
-CreatorsField.propTypes = {
+ContributorsField.propTypes = {
   fieldPath: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   labelIcon: PropTypes.string,
@@ -123,5 +126,6 @@ CreatorsField.propTypes = {
   nameSegment: PropTypes.string.isRequired,
   identifiersSegment: PropTypes.string.isRequired,
   affiliationsSegment: PropTypes.string.isRequired,
+  roleSegment: PropTypes.string.isRequired,
   // TODO: pass labels as props
 };

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/CreatorOrContributorField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/CreatorOrContributorField.js
@@ -1,0 +1,251 @@
+// This file is part of React-Invenio-Deposit
+// Copyright (C) 2020 CERN.
+// Copyright (C) 2020 Northwestern University.
+//
+// React-Invenio-Deposit is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { getIn, Field } from "formik";
+import { Button, Form, Grid, Icon } from "semantic-ui-react";
+
+import { ArrayField, SelectField, TextField } from "../../react_invenio_forms";
+import { AffiliationField } from "./AffiliationField";
+import { IdentifierField } from "./IdentifierField";
+
+// NOTE: We push formik Field as low as possible in the component hierarchy
+// i.e. as long as you can don't need the Formik form, don't use
+// <Field ... />
+
+const _CreatorOrContributorField = ({ field, form, ...props }) => {
+  /** Creator or Contributor Formik + Semantic-UI Field Component
+   *
+   * field: current Formik field (CreatorField instance)
+   * form: current Formik form (holds formik state that drives the UI)
+   * props: all props passed to the component
+  */
+
+  const {
+    fieldPath,
+    typeSegment,
+    familyNameSegment,
+    givenNameSegment,
+    nameSegment,
+    affiliationsSegment,
+    affiliationsNameSegment,
+    affiliationsIdentifierSegment,
+    affiliationsSchemeSegment,
+    identifiersSegment,
+    identifiersIdentifierSegment,
+    identifiersSchemeSegment,
+    isContributor,
+    options,
+    roleSegment,
+  } = props;
+
+  const typeFieldPath = `${fieldPath}.${typeSegment}`;
+  const familyNameFieldPath = `${fieldPath}.${familyNameSegment}`;
+  const givenNameFieldPath = `${fieldPath}.${givenNameSegment}`;
+  const nameFieldPath = `${fieldPath}.${nameSegment}`;
+  const identifiersFieldPath = `${fieldPath}.${identifiersSegment}`;
+  const affiliationsFieldPath = `${fieldPath}.${affiliationsSegment}`;
+  const roleFieldPath = `${fieldPath}.${roleSegment}`;
+
+  const handleGivenOrFamilyNameChange = (event, data) => {
+    /**
+     * Fills nameFieldPath in form with combination of given and
+     * family names.
+     * */
+    form.setFieldValue(data.name, data.value);
+    const givenName = (
+      data.name === givenNameFieldPath
+        ? data.value
+        : getIn(form.values, givenNameFieldPath, "")
+    );
+    const familyName = (
+      data.name === familyNameFieldPath
+        ? data.value
+        : getIn(form.values, familyNameFieldPath, "")
+    );
+    form.setFieldValue(
+      nameFieldPath, `${givenName} ${familyName}`
+    );
+
+  };
+
+  const personValue = "personal";
+
+  return (
+    // TODO: pass labels as props
+    <>
+      <SelectField
+        fieldPath={typeFieldPath}
+        label={"Type"}
+        options={props.options.type}
+        placeholder="Select type of creator"
+      />
+
+      {
+        getIn(form.values, typeFieldPath, null) === personValue ? (
+          <>
+            <TextField
+              fieldPath={familyNameFieldPath}
+              onChange={handleGivenOrFamilyNameChange}
+              label={"Family Name"}
+            />
+            <TextField
+              fieldPath={givenNameFieldPath}
+              onChange={handleGivenOrFamilyNameChange}
+              label={"Given Name"}
+            />
+            {
+              isContributor && (
+                <SelectField
+                  fieldPath={roleFieldPath}
+                  label={"Role"}
+                  options={options.role}
+                  placeholder="Select contributor role"
+                />
+              )
+            }
+            <ArrayField
+              addButtonLabel={"Add affiliation"}
+              defaultNewValue={{ [affiliationsNameSegment]: "", [affiliationsIdentifierSegment]: "", [affiliationsSchemeSegment]: "" }}
+              fieldPath={affiliationsFieldPath}
+              label={"Affiliation(s)"}
+            >
+              {
+                ({ array, arrayHelpers, indexPath, key }) => (
+                  <Form.Group inline>
+                    <AffiliationField
+                      nameFieldPath={`${key}.${affiliationsNameSegment}`}
+                      identifierFieldPath={`${key}.${affiliationsIdentifierSegment}`}
+                      schemeFieldPath={`${key}.${affiliationsSchemeSegment}`}
+                    />
+                    {
+                      array.length !== 1 && (
+                        <Form.Field>
+                          <Form.Field>
+                            <label>&nbsp;</label>
+                            <Button icon>
+                              <Icon name="close" size="large" onClick={() => arrayHelpers.remove(indexPath)} />
+                            </Button>
+                          </Form.Field>
+                        </Form.Field>
+                      )
+                    }
+                  </Form.Group>
+                )
+              }
+            </ArrayField>
+          </>
+        )
+        : (
+          <>
+            <TextField
+              fieldPath={nameFieldPath}
+              label={"Name"}
+            />
+            {
+              isContributor && (
+                <SelectField
+                  fieldPath={roleFieldPath}
+                  label={"Role"}
+                  options={options.role}
+                  placeholder="Select contributor role"
+                />
+              )
+            }
+          </>
+        )
+      }
+
+      <ArrayField
+        addButtonLabel={"Add identifiers"}
+        defaultNewValue={{ [identifiersIdentifierSegment]: "", [identifiersSchemeSegment]: "" }}
+        fieldPath={identifiersFieldPath}
+        label={"Identifier(s)"}
+      >
+        {
+          ({ array, arrayHelpers, indexPath, key }) => (
+            <Form.Group>
+              {/*
+                NOTE: These are people or organizations' identifiers
+                TODO: Differentiate this kind of IdentifierField with
+                      identifiers from the related identifier field.
+              */}
+              <IdentifierField
+                identifierFieldPath={`${key}.${identifiersIdentifierSegment}`}
+                schemeFieldPath={`${key}.${identifiersSchemeSegment}`}
+              />
+              {
+                array.length === 1
+                  ? null
+                  :
+                  <Form.Field>
+                    <Form.Field>
+                      <label>&nbsp;</label>
+                      <Button icon>
+                        <Icon name="close" size="large" onClick={() => arrayHelpers.remove(indexPath)} />
+                      </Button>
+                    </Form.Field>
+                  </Form.Field>
+              }
+            </Form.Group>
+          )
+        }
+      </ArrayField>
+    </>
+  );
+};
+
+export class CreatorOrContributorField extends Component {
+  /** Creator Component */
+
+  render() {
+    return (
+      <Field
+        component={_CreatorOrContributorField}
+        {...this.props}
+      />
+    );
+  }
+}
+
+CreatorOrContributorField.propTypes = {
+  isContributor: PropTypes.bool,
+  fieldPath: PropTypes.string.isRequired,
+  options: PropTypes.shape({
+    // NOTE: It is fine for the interface to ask for 'type', because it doesn't
+    //       presuppose the knowledge of the data model. It simply defines
+    //       what it expects.
+    //       Other requirement: one of these options must have value "personal"
+    //       Alternative is to pass the "person-equivalent" option as a prop
+    type: PropTypes.arrayOf(
+      PropTypes.shape({
+        icon: PropTypes.string,
+        text: PropTypes.string,
+        value: PropTypes.string,
+      })
+    ),
+  }),
+
+  // **EXPERIMENTAL**
+  // NOTE: We decouple the name of the fields with their functionality.
+  // This allows a different data model to re-use this component, as long
+  // as it passes the names of its fields that correspond to this functionality.
+  typeSegment: PropTypes.string.isRequired,
+  familyNameSegment: PropTypes.string.isRequired,
+  givenNameSegment: PropTypes.string.isRequired,
+  nameSegment: PropTypes.string.isRequired,
+  identifiersSegment: PropTypes.string.isRequired,
+  affiliationsSegment: PropTypes.string.isRequired,
+  roleSegment: PropTypes.string,
+  // TODO: pass labels as props
+};
+
+CreatorOrContributorField.defaultProps = {
+  isContributor: false,
+  roleSegment: "",
+};

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/CreatorsField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/CreatorsField.js
@@ -1,0 +1,338 @@
+// This file is part of React-Invenio-Deposit
+// Copyright (C) 2020 CERN.
+// Copyright (C) 2020 Northwestern University.
+//
+// React-Invenio-Deposit is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { getIn, Field } from "formik";
+import { Button, Form, Grid, Icon } from "semantic-ui-react";
+
+import { ArrayField, SelectField, TextField } from "../../react_invenio_forms";
+import { AffiliationField } from "./AffiliationField";
+import { IdentifierField } from "./IdentifierField";
+
+// NOTE: We push formik Field as low as possible in the component hierarchy
+// i.e. as long as you can don't need the Formik form, don't use
+// <Field ... />
+
+const _CreatorField = ({ field, form, ...props }) => {
+  /** Creator Formik + Semantic-UI Field Component
+   *
+   * field: current Formik field (CreatorField instance)
+   * form: current Formik form (holds formik state that drives the UI)
+   * props: all props passed to the component
+  */
+
+  const {
+    fieldPath,
+    typeSegment,
+    familyNameSegment,
+    givenNameSegment,
+    nameSegment,
+    affiliationsSegment,
+    affiliationsNameSegment,
+    affiliationsIdentifierSegment,
+    affiliationsSchemeSegment,
+    identifiersSegment,
+    identifiersIdentifierSegment,
+    identifiersSchemeSegment,
+  } = props;
+
+  const typeFieldPath = `${fieldPath}.${typeSegment}`;
+  const familyNameFieldPath = `${fieldPath}.${familyNameSegment}`;
+  const givenNameFieldPath = `${fieldPath}.${givenNameSegment}`;
+  const nameFieldPath = `${fieldPath}.${nameSegment}`;
+  const identifiersFieldPath = `${fieldPath}.${identifiersSegment}`;
+  const affiliationsFieldPath = `${fieldPath}.${affiliationsSegment}`;
+
+  // TODO:
+  // const role_fieldPath = `${props.fieldPath}.role`;
+
+  const handleGivenOrFamilyNameChange = (event, data) => {
+    /**
+     * Fills nameFieldPath in form with combination of given and
+     * family names.
+     * */
+    form.setFieldValue(data.name, data.value);
+    const givenName = (
+      data.name === givenNameFieldPath
+        ? data.value
+        : getIn(form.values, givenNameFieldPath, "")
+    );
+    const familyName = (
+      data.name === familyNameFieldPath
+        ? data.value
+        : getIn(form.values, familyNameFieldPath, "")
+    );
+    form.setFieldValue(
+      nameFieldPath, `${givenName} ${familyName}`
+    );
+
+  };
+
+  const personValue = "personal";
+
+  return (
+    // TODO: pass labels as props
+    <>
+      <SelectField
+        fieldPath={typeFieldPath}
+        label={"Type"}
+        options={props.options.type}
+        placeholder="Select type of creator"
+      />
+
+      {
+        getIn(form.values, typeFieldPath, null) === personValue
+          ? (
+            <>
+              <TextField
+                fieldPath={familyNameFieldPath}
+                onChange={handleGivenOrFamilyNameChange}
+                label={"Family Name"}
+              />
+              <TextField
+                fieldPath={givenNameFieldPath}
+                onChange={handleGivenOrFamilyNameChange}
+                label={"Given Name"}
+              />
+              <ArrayField
+                addButtonLabel={"Add affiliation"}
+                defaultNewValue={{ [affiliationsNameSegment]: "", [affiliationsIdentifierSegment]: "", [affiliationsSchemeSegment]: "" }}
+                fieldPath={affiliationsFieldPath}
+                label={"Affiliation(s)"}
+              >
+                {
+                  ({ array, arrayHelpers, indexPath, key }) => (
+                    <Form.Group inline>
+                      <AffiliationField
+                        nameFieldPath={`${key}.${affiliationsNameSegment}`}
+                        identifierFieldPath={`${key}.${affiliationsIdentifierSegment}`}
+                        schemeFieldPath={`${key}.${affiliationsSchemeSegment}`}
+                      />
+                      {
+                        array.length === 1
+                          ? null
+                          :
+                          <Form.Field>
+                            <Form.Field>
+                              <label>&nbsp;</label>
+                              <Button icon>
+                                <Icon name="close" size="large" onClick={() => arrayHelpers.remove(indexPath)} />
+                              </Button>
+                            </Form.Field>
+                          </Form.Field>
+                      }
+                    </Form.Group>
+                  )
+                }
+              </ArrayField>
+            </>
+          )
+          : (
+            <TextField
+              fieldPath={nameFieldPath}
+              label={"Name"}
+            />
+          )
+      }
+      <ArrayField
+        addButtonLabel={"Add identifiers"}
+        defaultNewValue={{ [identifiersIdentifierSegment]: "", [identifiersSchemeSegment]: "" }}
+        fieldPath={identifiersFieldPath}
+        label={"Identifier(s)"}
+      >
+        {
+          ({ array, arrayHelpers, indexPath, key }) => (
+            <Form.Group>
+              {/*
+                NOTE: These are people or organizations' identifiers
+                TODO: Differentiate this kind of IdentifierField with
+                      identifiers from the related identifier field.
+              */}
+              <IdentifierField
+                identifierFieldPath={`${key}.${identifiersIdentifierSegment}`}
+                schemeFieldPath={`${key}.${identifiersSchemeSegment}`}
+              />
+              {
+                array.length === 1
+                  ? null
+                  :
+                  <Form.Field>
+                    <Form.Field>
+                      <label>&nbsp;</label>
+                      <Button icon>
+                        <Icon name="close" size="large" onClick={() => arrayHelpers.remove(indexPath)} />
+                      </Button>
+                    </Form.Field>
+                  </Form.Field>
+              }
+            </Form.Group>
+          )
+        }
+      </ArrayField>
+    </>
+  );
+};
+
+export class CreatorField extends Component {
+  /** Creator Component */
+
+  render() {
+    return (
+      <Field
+        component={_CreatorField}
+        {...this.props}
+      />
+    );
+  }
+}
+
+CreatorField.propTypes = {
+  fieldPath: PropTypes.string.isRequired,
+  options: PropTypes.shape({
+    // NOTE: It is fine for the interface to ask for 'type', because it doesn't
+    //       presuppose the knowledge of the data model. It simply defines
+    //       what it expects.
+    //       Other requirement: one of these options must have value "personal"
+    //       Alternative is to pass the "person-equivalent" option as a prop
+    type: PropTypes.arrayOf(
+      PropTypes.shape({
+        icon: PropTypes.string,
+        text: PropTypes.string,
+        value: PropTypes.string,
+      })
+    ),
+  }),
+
+  // **EXPERIMENTAL**
+  // NOTE: We decouple the name of the fields with their functionality.
+  // This allows a different data model to re-use this component, as long
+  // as it passes the names of its fields that correspond to this functionality.
+  typeSegment: PropTypes.string.isRequired,
+  familyNameSegment: PropTypes.string.isRequired,
+  givenNameSegment: PropTypes.string.isRequired,
+  nameSegment: PropTypes.string.isRequired,
+  identifiersSegment: PropTypes.string.isRequired,
+  affiliationsSegment: PropTypes.string.isRequired,
+  // TODO: pass labels as props
+};
+
+
+/**Formik Field component wrapping semantic-ui Creators component */
+export class CreatorsField extends Component {
+  /** Semantic-UI Creators Component */
+
+  render() {
+    const {
+      fieldPath,
+      label,
+      labelIcon,
+      ...creatorProps
+    } = this.props;
+
+    const {
+      familyNameSegment,
+      givenNameSegment,
+      nameSegment,
+      affiliationsSegment,
+      affiliationsIdentifierSegment,
+      affiliationsNameSegment,
+      affiliationsSchemeSegment,
+      identifiersSegment,
+      identifiersIdentifierSegment,
+      identifiersSchemeSegment,
+      typeSegment,
+    } = creatorProps;
+
+    const defaultNewValue = {
+      [affiliationsSegment]: [
+        {
+          [affiliationsIdentifierSegment]: "",
+          [affiliationsNameSegment]: "",
+          [affiliationsSchemeSegment]: "",
+        }
+      ],
+      [familyNameSegment]: "",
+      [givenNameSegment]: "",
+      [identifiersSegment]: [
+        {
+          [identifiersIdentifierSegment]: "",
+          [identifiersSchemeSegment]: "",
+        }
+      ],
+      [nameSegment]: "",
+      [typeSegment]: "personal",
+    };
+
+    return (
+      // TODO: Replace by arrayProps
+      <ArrayField
+        addButtonLabel={"Add creator"} // TODO: Pass by prop
+        defaultNewValue={defaultNewValue}
+        fieldPath={fieldPath}
+        label={label}
+        labelIcon={labelIcon}
+      >
+        {
+          ({ array, arrayHelpers, indexPath, key }) => (
+            <>
+              <CreatorField
+                fieldPath={key}
+                {...creatorProps}
+              />
+              <Grid>
+                <Grid.Column></Grid.Column>
+                <Grid.Column floated='right' >
+                {
+                  array.length === 1
+                  ? null
+                  :
+                    <Button color='red' floated='right' onClick={() => arrayHelpers.remove(indexPath)}>
+                      Remove
+                    </Button>
+                }
+                </Grid.Column>
+              </Grid>
+            </>
+          )
+        }
+      </ArrayField>
+    );
+  }
+}
+
+CreatorsField.propTypes = {
+  fieldPath: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  labelIcon: PropTypes.string,
+  options: PropTypes.shape({
+    // NOTE: It is fine for the interface to ask for 'type', because it doesn't
+    //       presuppose the knowledge of the data model. It simply defines
+    //       what it expects.
+    //       Other requirement: one of these options must have value "personal"
+    //       Alternative is to pass the "person-equivalent" option as a prop
+    type: PropTypes.arrayOf(
+      PropTypes.shape({
+        icon: PropTypes.string,
+        text: PropTypes.string,
+        value: PropTypes.string,
+      })
+    ),
+  }),
+
+  // **EXPERIMENTAL**
+  // NOTE: We decouple the name of the fields with their functionality.
+  // This allows a different data model to re-use this component, as long
+  // as it passes the name of its fields that correspond to this functionality.
+  typeSegment: PropTypes.string.isRequired,
+  familyNameSegment: PropTypes.string.isRequired,
+  givenNameSegment: PropTypes.string.isRequired,
+  nameSegment: PropTypes.string.isRequired,
+  identifiersSegment: PropTypes.string.isRequired,
+  affiliationsSegment: PropTypes.string.isRequired,
+  // TODO: pass labels as props
+};

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/IdentifierField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/IdentifierField.js
@@ -1,0 +1,37 @@
+// This file is part of React-Invenio-Deposit
+// Copyright (C) 2020 CERN.
+// Copyright (C) 2020 Northwestern University.
+//
+// React-Invenio-Deposit is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+import { TextField } from "../../react_invenio_forms";
+
+/**Identifier input component */
+export class IdentifierField extends Component {
+  render() {
+    const {
+      identifierFieldPath,
+      schemeFieldPath,
+    } = this.props;
+
+    return (
+      <>
+        <TextField fieldPath={schemeFieldPath} label="Scheme" />
+        <TextField fieldPath={identifierFieldPath} label="Identifier" />
+      </>
+    );
+  }
+}
+
+IdentifierField.propTypes = {
+  identifierFieldPath: PropTypes.string.isRequired,
+  schemeFieldPath: PropTypes.string.isRequired,
+  // TODO: Pass labels as props
+};
+
+IdentifierField.defaultProps = {
+};

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/ResourceTypeField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/ResourceTypeField.js
@@ -10,6 +10,7 @@ import PropTypes from "prop-types";
 import { getIn, Field } from "formik";
 import { Form, Icon } from "semantic-ui-react";
 
+import { FieldLabel } from "../../react_invenio_forms";
 import { SelectField } from "../../react_invenio_forms";
 
 
@@ -37,7 +38,7 @@ export class ResourceTypeField extends Component {
     );
     return (
       <div>
-        <label><Icon name={this.props.labelIcon} />{this.props.label}</label>
+        <FieldLabel htmlFor={this.props.fieldPath} icon={this.props.labelIcon} label={this.props.label} />
         <SelectField
           fieldPath={typeFieldPath}
           label={this.props.typeLabel}
@@ -69,7 +70,7 @@ export class ResourceTypeField extends Component {
 
 ResourceTypeField.propTypes = {
   fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   labelIcon: PropTypes.string,
   options: PropTypes.shape({
     type: PropTypes.arrayOf(

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/ResourceTypeField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/ResourceTypeField.js
@@ -15,41 +15,41 @@ import { SelectField } from "../../react_invenio_forms";
 
 export class ResourceTypeField extends Component {
   renderResourceTypeField = (formikBag) => {
-    const resource_type_fieldpath = `${this.props.fieldPath}.type`;
-    const resource_subtype_fieldpath = `${this.props.fieldPath}.subtype`;
+    const typeFieldPath = `${this.props.fieldPath}.type`;
+    const subtypeFieldPath = `${this.props.fieldPath}.subtype`;
 
     const resource_type = getIn(
       formikBag.form.values,
-      resource_type_fieldpath,
+      typeFieldPath,
       ""
     );
 
     const handleChange = (event, selectedOption) => {
       formikBag.form.setFieldValue(
-        resource_type_fieldpath,
+        typeFieldPath,
         selectedOption.value
       );
-      formikBag.form.setFieldValue(resource_subtype_fieldpath, "");
+      formikBag.form.setFieldValue(subtypeFieldPath, "");
     };
 
-    const subtype_options = this.props.options.subtype.filter(
+    const subtypeOptions = this.props.options.subtype.filter(
       (e) => e["parent-value"] === resource_type
     );
     return (
       <div>
-        <label><Icon name={this.props.label_icon} />{this.props.label}</label>
+        <label><Icon name={this.props.labelIcon} />{this.props.label}</label>
         <SelectField
-          fieldPath={resource_type_fieldpath}
-          label={this.props.parent_label}
+          fieldPath={typeFieldPath}
+          label={this.props.typeLabel}
           options={this.props.options.type}
           onChange={handleChange}
           placeholder="Select general resource type"
         />
-        {subtype_options.length > 0 ? (
+        {subtypeOptions.length > 0 ? (
           <SelectField
-            fieldPath={resource_subtype_fieldpath}
-            label={this.props.child_label}
-            options={subtype_options}
+            fieldPath={subtypeFieldPath}
+            label={this.props.subtypeLabel}
+            options={subtypeOptions}
             placeholder="Select resource subtype"
           />
         ) : null}
@@ -68,10 +68,9 @@ export class ResourceTypeField extends Component {
 }
 
 ResourceTypeField.propTypes = {
-  child_label: PropTypes.string,
   fieldPath: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
-  label_icon: PropTypes.string,
+  labelIcon: PropTypes.string,
   options: PropTypes.shape({
     type: PropTypes.arrayOf(
       PropTypes.shape({
@@ -89,6 +88,6 @@ ResourceTypeField.propTypes = {
       })
     ),
   }).isRequired,
-  parent_label: PropTypes.string,
-
+  subtypeLabel: PropTypes.string,
+  typeLabel: PropTypes.string,
 };

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/ResourceTypeField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/ResourceTypeField.js
@@ -8,8 +8,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { getIn, Field } from "formik";
+import { Form, Icon } from "semantic-ui-react";
 
 import { SelectField } from "../../react_invenio_forms";
+
 
 export class ResourceTypeField extends Component {
   renderResourceTypeField = (formikBag) => {
@@ -35,9 +37,10 @@ export class ResourceTypeField extends Component {
     );
     return (
       <div>
+        <label><Icon name={this.props.label_icon} />{this.props.label}</label>
         <SelectField
           fieldPath={resource_type_fieldpath}
-          label={this.props.label}
+          label={this.props.parent_label}
           options={this.props.options.type}
           onChange={handleChange}
           placeholder="Select general resource type"
@@ -45,8 +48,9 @@ export class ResourceTypeField extends Component {
         {subtype_options.length > 0 ? (
           <SelectField
             fieldPath={resource_subtype_fieldpath}
-            placeholder="Select resource subtype"
+            label={this.props.child_label}
             options={subtype_options}
+            placeholder="Select resource subtype"
           />
         ) : null}
       </div>
@@ -64,8 +68,10 @@ export class ResourceTypeField extends Component {
 }
 
 ResourceTypeField.propTypes = {
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  child_label: PropTypes.string,
   fieldPath: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  label_icon: PropTypes.string,
   options: PropTypes.shape({
     type: PropTypes.arrayOf(
       PropTypes.shape({
@@ -83,4 +89,6 @@ ResourceTypeField.propTypes = {
       })
     ),
   }).isRequired,
+  parent_label: PropTypes.string,
+
 };

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/TitlesField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/TitlesField.js
@@ -26,18 +26,19 @@ export class TitlesField extends Component {
     return (
       <ArrayField
         addButtonLabel={"Add another title"}
-        fieldPath={this.props.fieldPath}
         defaultNewValue={this.props.defaultNewValue}
-        // <span><Icon disabled name="book" />Title</span>
+        fieldPath={this.props.fieldPath}
         label={this.props.label}
+        label_icon={this.props.label_icon}
       >
         {
           ({ array, arrayHelpers, indexPath, key }) => (
             <Form.Group inline>
               <TextField fieldPath={`${key}.title`} />
               {
-                array.length === 1 ?
-                null :
+                array.length === 1
+                ? null
+                :
                 <Button icon>
                   <Icon name="close" size="large" onClick={() => arrayHelpers.remove(indexPath)} />
                 </Button>

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/TitlesField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/TitlesField.js
@@ -56,7 +56,7 @@ TitlesField.propTypes = {
     title: PropTypes.string.isRequired,
   }),
   fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   labelIcon: PropTypes.string,
 };
 

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/TitlesField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/TitlesField.js
@@ -29,7 +29,7 @@ export class TitlesField extends Component {
         defaultNewValue={this.props.defaultNewValue}
         fieldPath={this.props.fieldPath}
         label={this.props.label}
-        label_icon={this.props.label_icon}
+        labelIcon={this.props.labelIcon}
       >
         {
           ({ array, arrayHelpers, indexPath, key }) => (
@@ -52,11 +52,12 @@ export class TitlesField extends Component {
 }
 
 TitlesField.propTypes = {
-  label: PropTypes.string.isRequired,
-  fieldPath: PropTypes.string.isRequired,
   defaultNewValue: PropTypes.shape({
     title: PropTypes.string.isRequired,
   }),
+  fieldPath: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  labelIcon: PropTypes.string,
 };
 
 TitlesField.defaultProps = {

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/index.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/index.js
@@ -6,6 +6,8 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 export { AffiliationField } from "./AffiliationField";
+export { CreatorOrContributorField } from "./CreatorOrContributorField";
+export { ContributorsField } from "./ContributorsField";
 export { CreatorsField } from "./CreatorsField";
 export { IdentifierField } from "./IdentifierField";
 export { ResourceTypeField } from "./ResourceTypeField";

--- a/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/index.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_deposit/components/index.js
@@ -5,5 +5,8 @@
 // React-Invenio-Deposit is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-export { TitlesField } from "./TitlesField";
+export { AffiliationField } from "./AffiliationField";
+export { CreatorsField } from "./CreatorsField";
+export { IdentifierField } from "./IdentifierField";
 export { ResourceTypeField } from "./ResourceTypeField";
+export { TitlesField } from "./TitlesField";

--- a/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/ArrayField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/ArrayField.js
@@ -17,16 +17,17 @@ export class ArrayField extends Component {
       ...arrayHelpers
     } = props;
     const {
-      fieldPath,
       addButtonLabel,
-      defaultNewValue,
-      label,
       children,
+      defaultNewValue,
+      fieldPath,
+      label,
+      label_icon,
       ...uiProps
     } = this.props;
     return (
       <Form.Field {...uiProps}>
-        <label>{label}</label>
+        <label><Icon name={label_icon} />{label}</label>
         {getIn(values, fieldPath, []).map((value, index, array) => {
           const arrayPath = fieldPath;
           const indexPath = index;

--- a/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/ArrayField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/ArrayField.js
@@ -10,6 +10,8 @@ import PropTypes from "prop-types";
 import { getIn, FieldArray } from "formik";
 import { Form, Button, Icon } from "semantic-ui-react";
 
+import { FieldLabel } from "./FieldLabel";
+
 export class ArrayField extends Component {
   renderFormField = (props) => {
     const {
@@ -27,7 +29,7 @@ export class ArrayField extends Component {
     } = this.props;
     return (
       <Form.Field {...uiProps}>
-        <label><Icon name={labelIcon} />{label}</label>
+        <FieldLabel htmlFor={fieldPath} icon={labelIcon} label={label} />
         {getIn(values, fieldPath, []).map((value, index, array) => {
           const arrayPath = fieldPath;
           const indexPath = index;

--- a/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/ArrayField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/ArrayField.js
@@ -22,12 +22,12 @@ export class ArrayField extends Component {
       defaultNewValue,
       fieldPath,
       label,
-      label_icon,
+      labelIcon,
       ...uiProps
     } = this.props;
     return (
       <Form.Field {...uiProps}>
-        <label><Icon name={label_icon} />{label}</label>
+        <label><Icon name={labelIcon} />{label}</label>
         {getIn(values, fieldPath, []).map((value, index, array) => {
           const arrayPath = fieldPath;
           const indexPath = index;
@@ -65,12 +65,13 @@ export class ArrayField extends Component {
 }
 
 ArrayField.propTypes = {
-  fieldPath: PropTypes.string.isRequired,
-  label: PropTypes.string,
   addButtonLabel: PropTypes.string,
+  children: PropTypes.func.isRequired,
   defaultNewValue: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
     .isRequired,
-  children: PropTypes.func.isRequired,
+  fieldPath: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  labelIcon: PropTypes.string,
 };
 
 ArrayField.defaultProps = {

--- a/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/FieldLabel.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/FieldLabel.js
@@ -1,0 +1,25 @@
+// This file is part of React-Invenio-Forms
+// Copyright (C) 2020 CERN.
+// Copyright (C) 2020 Northwestern University.
+//
+// React-Invenio-Forms is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Icon } from "semantic-ui-react";
+
+export class FieldLabel extends Component {
+  render() {
+    const {htmlFor, icon, label} = this.props;
+    return (
+      <label htmlFor={htmlFor}>{icon ? <Icon name={icon} /> : null}{label}</label>
+    )
+  }
+}
+
+FieldLabel.propTypes = {
+  htmlFor: PropTypes.string,
+  label: PropTypes.string,
+  labelIcon: PropTypes.string,
+};

--- a/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/SelectField.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/SelectField.js
@@ -92,20 +92,20 @@ export class SelectField extends Component {
       <Form.Dropdown
         fluid
         selection
-        searchInput={{ id: fieldPath }}
-        label={{ children: label, htmlFor: fieldPath }}
+        error={error || this.renderError(errors, fieldPath, value)}
+        id={fieldPath}
+        label={{ children: label, htmlFor: fieldPath}}
         loading={loading}
         multiple={multiple}
-        id={fieldPath}
         name={fieldPath}
+        onBlur={handleBlur}
         onChange={(event, data) => {
           setFieldValue(fieldPath, data.value);
         }}
-        onBlur={handleBlur}
-        value={value}
-        error={error || this.renderError(errors, fieldPath, value)}
         options={this.getAllOptions(options, value)}
         renderLabel={this.renderLabel}
+        searchInput={{ id: fieldPath }}
+        value={value}
         {...uiProps}
       />
     );

--- a/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/index.js
+++ b/invenio_app_rdm/theme/assets/js/react_invenio_forms/core/index.js
@@ -10,6 +10,7 @@ export { ArrayField } from "./ArrayField";
 export { BaseForm } from "./BaseForm";
 export { BooleanField } from "./BooleanField";
 export { ErrorMessage } from "./ErrorMessage";
+export { FieldLabel } from "./FieldLabel";
 export { GroupField } from "./GroupField";
 export { SelectField } from "./SelectField";
 export { TextField } from "./TextField";

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,6 +14,6 @@
 
 pydocstyle invenio_app_rdm tests docs && \
 isort -rc -c -df && \
-# check-manifest --ignore ".travis-*" && \
+check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 pytest

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,6 +14,6 @@
 
 pydocstyle invenio_app_rdm tests docs && \
 isort -rc -c -df && \
-check-manifest --ignore ".travis-*" && \
+# check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test
+pytest

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tests_require = [
     'pydocstyle>=2.0.0',
     'pytest-cov>=2.5.1',
     'pytest-pep8>=1.0.6',
-    'pytest-invenio>=1.2.0',
+    'pytest-invenio>=1.3.0',
     'pytest>=4.0.0,<5.0.0',
 ]
 


### PR DESCRIPTION
Adds the Creators and the Contributors Fields. In so doing also adds: IdentifierField and AffiliationField. These fields will be moved to react-invenio-deposit when the package is deployable.

A lot of structuring / decisions / experiments were made that would be worth discussing:

- **Current invenio-rdm-records more than mockups is followed.** Rather than go for all the niceties of the mockup, re-use of existing components mapping *directly* to the data model was favoured. For example, since the current invenio-rdm-records API expects an identifier value and its scheme to be passed to it, so does the form. The form does not try to guess the scheme from the identifier or hide the scheme field. There is pressure to just get a deposit page, so letting all fields be manually "fillable" is easier right now. 

- **The RDMDepositForm conveys the data model to its components via explicit props**: If I understood correctly, react-invenio-deposit should not know/assume the data model. In our case this means, the components don't know internally the fields of the formik form that should correspond to them. For instance, the CreatorsField should not know that the field `'creators'` in the formik form corresponds to the concept of "the list of creators". The deposit form should tell this component that this is the case. Otherwise, the react-invenio-deposit components are not really reusable: they can only be re-used if your formik form follows that "shape/interface" or if the form's initialValues are re-arranged to make it fit which just means pushing that work upstream and letting it be *very implicit* at the component level. Note that the conclusion from this is: large number of props at the component level. It could be mitigated by default props.

- **The RDMDepositForm knows the invenio-rdm-records data model**. This seems pretty straightforward, but has implications. What this means is that it knows what fields correspond to what concept, so that it can make decisions like what the defaults should be. For example, it knows that `'titles'` received from backend corresponds to the array of (title, type) that must be shown on the deposit page and knows the default title type for instance (I haven't touched the TitlesField but I will :man_dancing: ). Why not let the backend do this? Because we want to make them independent (as they should be) and having the deep recess of the backend in a different module determine the frontend is such a long reach/bad development experience. The frontend is the best place to make these decisions because it knows what needs to be done to display defaults and such correctly. Note that the conclusion from this is: if the backend data model changes, the frontend will need to change (but this is expected of a frontend that interacts with a backend through an agreed interface).

- **Initial record is temporarily overridden**. This is a consequence of the above that is worth a separate point. For development purposes, the backend's initial empty record is "temporarily" overridden. It makes it much easier to experiment with how the form interacts with it. This "override" will probably settle as a frontend transformation function from backend record to formik/frontent ready record.      

- **Additional Current Form Record is displayed**. This is for debugging purposes for now. A couple of other console.logs have been left for debugging purposes too. This Current Form Record shows the status of the formik form. I am working under the assumption that any form *UI* business logic (not saving or publishing, but "what fields are shown when") is the sole responsibility of our Formik field wrappers (e.g. IdentifierField). Redux or record state is never touched, so having introspection in the form values is helpful while developing the components.

- **You must have known it was coming: it's slow**. Filling out form fields is noticeably slow. Not "we can't live with this slow" but "oh typing in this textbox is laggy". I can see how react controlled fields might be a little bit slower, but I don't think that would explain all of it. I suspect formik of doing a bunch of things on every input... 

- **Pushing Formik Component field down the hierarchy**. Waiting until we absolutely need the formikBag (`{field, form, props}`) reduces the amount of props to pass along, shortens cascades of sub components and scopes its reach. 

- **Not all of the above have been fully implemented**. These thoughts / decisions occurred as I went, so they are not consistently implemented, but they should be aimed for. Covering my changes I guess ;)

Here is a screenshot. It's not yet pretty but the UI logic is functional.
![creators_contributors_field](https://user-images.githubusercontent.com/1932651/81977774-28f42500-95f0-11ea-8c5a-f9f25e69b06f.png)
