### PR TITLE
119 style deposit page first pass

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,8 +28,8 @@ skip = .eggs
 [*.rst]
 indent_size = 4
 
-# CSS, HTML, JS, JSON, YML
-[*.{css,html,js,json,yml}]
+# CSS, HTML, JS, JSON, YML, LESS
+[*.{css,html,js,json,yml,less}]
 indent_size = 2
 
 # Matches the exact files either package.json or .travis.yml

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
@@ -6,7 +6,7 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import React, { Component } from "react";
-import { Message, Grid } from "semantic-ui-react";
+import { Button, Card, Grid, Icon } from "semantic-ui-react";
 import { Field } from "formik";
 import {
   AccessRightField,
@@ -145,6 +145,24 @@ export class RDMDepositForm extends Component {
             <AccordionField
               fieldPath=""
               active={true}
+              label={"Files"}
+            >
+              <p>COMING SOON</p>
+              <br/>
+            </AccordionField>
+
+            <AccordionField
+              fieldPath=""
+              active={true}
+              label={"Identifiers"}
+            >
+              <p>COMING SOON</p>
+              <br />
+            </AccordionField>
+
+            <AccordionField
+              fieldPath=""
+              active={true}
               label={"Basic Information"}
             >
               <div>
@@ -197,20 +215,32 @@ export class RDMDepositForm extends Component {
                 /> */}
               </div>
             </AccordionField>
+
+            <AccordionField
+              fieldPath=""
+              active={true}
+              label={"Recommended Information"}
+            >
+              <p>COMING SOON</p>
+              <br />
+            </AccordionField>
           </Grid.Column>
 
           <Grid.Column width={4}>
-            <Grid.Row>
-              <SaveButton />
-              <PublishButton />
-            </Grid.Row>
-            <Grid.Row>
-              <AccessRightField
-                fieldPath="access_right"
-                label={"Protection"}
-                labelIcon={"shield"}
-                options={vocabularies.access_right}
-              />
+            <Card className="actions">
+              <Card.Content>
+                <SaveButton fluid className="save-button" />
+                <PublishButton fluid />
+              </Card.Content>
+            </Card>
+            <AccessRightField
+              fieldPath="access_right"
+              label={"Protection"}
+              labelIcon={"shield"}
+              options={vocabularies.access_right}
+            />
+            <Grid.Row centered>
+              <Button className="disabled contact-support"><Icon name='mail outline' />Contact Support</Button>
             </Grid.Row>
           </Grid.Column>
         </Grid>

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/deposit.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/deposit.less
@@ -1,0 +1,37 @@
+/*
+ *   Copyright (C) 2020 CERN.
+ *   Copyright (C) 2020 Northwestern University.
+ *
+ * Invenio App RDM is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+/** Deposit page styles */
+
+#deposit-form {
+
+  .field label.title {
+    background-color: #5aaad9;
+    color: white;
+    font-size: 1.05em;
+
+    label {
+      margin-left: 0.5rem;
+    }
+  }
+
+  .save-button {
+    margin-bottom: 0.5em;
+  }
+
+  .access-right {
+    .inline.fields {
+      margin-bottom: .75em;
+
+      &:first-of-type {
+        margin-top: 1em;
+      }
+    }
+  }
+
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
@@ -10,6 +10,7 @@
 
 @import "footer.less";
 @import "frontpage.less";
+@import "deposit.less";
 
 
 html,

--- a/invenio_app_rdm/theme/templates/invenio_app_rdm/deposits/forms/deposits.html
+++ b/invenio_app_rdm/theme/templates/invenio_app_rdm/deposits/forms/deposits.html
@@ -13,8 +13,8 @@
 {%- endblock head_links %}
 
 {%- block css %}
-    {{ webpack['theme.css']}}
-    {{ webpack['invenio-app-rdm-search-theme.css']}}
+    {{ webpack['theme.css'] }}
+    {{ webpack['invenio-app-rdm-theme.css'] }}
 {%-endblock %}
 
 {%- block page_header %}


### PR DESCRIPTION
First pass at deposit page styling.

- styles:
    * action buttons
    * accordion label + dropdown
    * access-right
- adds placeholders
    * contact support
    * Files, Identifiers, Recommended Information sections

Looks like:

![image](https://user-images.githubusercontent.com/1932651/83206728-106b2b00-a117-11ea-851c-d3fb12768689.png)


Needs: https://github.com/inveniosoftware/react-invenio-deposit/pull/28 merged in first

closes #119 