### PR TITLE
assets: fix header spacing

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
@@ -35,6 +35,7 @@ h6 {
   background-image: @navbar_background_image;
   background-color: @navbar_background_color;
   border-color: transparent;
+  padding: 8px;
 
   .button[href^="/signup"] {
     background-color: @signup_background_color;


### PR DESCRIPTION
It is due to the `outer_nav` that was placed in the header overwrite. Therefore it is RDM specific. 

*Need more testing: I am on the process of doing so, my setup just broke, need to re-install from a fresh state.*