### PR TITLE
dependencies: bump invenio-rdm-records to 0.15.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ for name, reqs in extras_require.items():
 
 install_requires = [
     'invenio[base,auth,metadata,files]{}'.format(invenio_version),
-    'invenio-rdm-records~=0.14.1',
+    'invenio-rdm-records~=0.15.0',
     'invenio-records-permissions~=0.8.0'
 ]
 


### PR DESCRIPTION
This adds the version of invenio-rdm-records that has the bibliographic records Resource. It is now up to invenio-app-rdm to register it on the application.

From here on, @zzacharo is on it from what I understood. You can continue on this branch if you want, I won't touch it anymore.