### PR TITLE
resources: integrate drafts resource

### DIFF
--- a/invenio_app_rdm/theme/views.py
+++ b/invenio_app_rdm/theme/views.py
@@ -15,9 +15,12 @@ this file.
 
 from flask import Blueprint, current_app, render_template
 from flask_menu import current_menu
+from invenio_pidstore.models import PIDStatus
+from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
 from invenio_rdm_records.marshmallow.json import MetadataSchemaV1, dump_empty
-from invenio_rdm_records.resources import BibliographicRecordResource
-from invenio_rdm_records.services import BibliographicRecordService
+from invenio_rdm_records.resources import BibliographicDraftActionResource, \
+    BibliographicDraftResource, BibliographicRecordResource
+from invenio_rdm_records.services import BibliographicRecordDraftService
 from invenio_rdm_records.vocabularies import Vocabularies
 
 blueprint = Blueprint(
@@ -114,7 +117,16 @@ def deposits_user():
         searchbar_config=dict(searchUrl='/search')
     )
 
+# New implementation
+RecordIdProviderV2.default_status_with_obj = PIDStatus.NEW
 
-bibliographic_bp = BibliographicRecordResource(
-    service=BibliographicRecordService()).as_blueprint(
-        "bibliographic-resource")
+record_draft_service = BibliographicRecordDraftService()
+record_bp = BibliographicRecordResource(
+    service=record_draft_service
+).as_blueprint("bibliographic_record_resource")
+draft_bp = BibliographicDraftResource(
+    service=record_draft_service
+).as_blueprint("bibliographic_draft_resource")
+draft_action_bp = BibliographicDraftActionResource(
+    service=record_draft_service
+).as_blueprint("bibliographic_draft_action_resource")

--- a/invenio_app_rdm/version.py
+++ b/invenio_app_rdm/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_app_rdm.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.10.1'
+__version__ = '0.11.0'

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ for name, reqs in extras_require.items():
 
 install_requires = [
     'invenio[base,auth,metadata,files]{}'.format(invenio_version),
-    'invenio-rdm-records~=0.16.0',
+    'invenio-rdm-records~=0.17.0',
     'invenio-records-permissions~=0.9.0'
 ]
 
@@ -100,7 +100,10 @@ setup(
             'invenio_app_rdm = invenio_app_rdm.theme.views:blueprint',
         ],
         'invenio_base.api_blueprints': [
-            'invenio_app_rdm_bibl = invenio_app_rdm.theme.views:bibliographic_bp',
+            'invenio_app_rdm_record = invenio_app_rdm.theme.views:record_bp',
+            'invenio_app_rdm_draft = invenio_app_rdm.theme.views:draft_bp',
+            'invenio_app_rdm_draft_action = \
+                invenio_app_rdm.theme.views:draft_action_bp',
         ],
         'invenio_assets.webpack': [
             'invenio_app_rdm_theme = invenio_app_rdm.theme.webpack:theme',


### PR DESCRIPTION
requires https://github.com/inveniosoftware/invenio-rdm-records/pull/139

tests: 
- removed `test_record_read_unregistered_pid` since it is the same than create a draft and read it (i.e. the PID is still not registered since it is a draft).