### PR TITLE
Manual testing fixes

### DIFF
--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/deposits/uploads.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/deposits/uploads.html
@@ -17,12 +17,30 @@
 {%- endblock javascript %}
 
 {%- block page_body %}
-<div data-invenio-search-config='{{
-  search_app_helpers.invenio_records_rest.generate(
-    dict(
-      endpoint_id="recid",
-      app_id="rdm-deposits-search"
-    )
-  ) | tojson(indent=2) }}'></div>
 
+<div class="ui container page_body" style="margin-top: 35px">
+  <h1>Your deposits</h1>
+  <div class="ui menu">
+    <div class="ui action left icon input">
+      <i class="search icon"></i>
+      <input type="text" placeholder="Search">
+      <button class="ui button">Search</button>
+    </div>
+
+    <div class="right menu">
+      <div class="item">
+        <a class="ui button primary" role="button" href="{{ url_for('invenio_app_rdm.deposits_create') }}">
+          New Deposit
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="ui text container">
+    <img width="600" src="{{ url_for('static', filename='images/coming-soon.svg')}}" />
+  </div>
+
+  {# TODO: Place user/records here #}
+
+</div>
 {%- endblock page_body %}

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/search.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/search.html
@@ -55,7 +55,7 @@
       "default": true,
       "defaultOnEmptyString": false,
       "sortBy": "bestmatch",
-      "sortOrder": "desc",
+      "sortOrder": "asc",
       "text": "Best match"
     },
     {

--- a/invenio_app_rdm/theme/webpack.py
+++ b/invenio_app_rdm/theme/webpack.py
@@ -30,7 +30,7 @@ theme = WebpackThemeBundle(
                 'luxon': '^1.23.0',
                 'path': '^0.12.7',
                 'prop-types': '^15.7.2',
-                'react-invenio-deposit': '^0.4.0',
+                'react-invenio-deposit': '^0.5.0',
                 'react-invenio-forms': '^0.3.0',
             },
             aliases={

--- a/invenio_app_rdm/version.py
+++ b/invenio_app_rdm/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_app_rdm.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.12.4'
+__version__ = '0.12.5'

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ for name, reqs in extras_require.items():
 
 install_requires = [
     'invenio[base,auth,metadata,files]{}'.format(invenio_version),
-    'invenio-rdm-records~=0.18.2',
+    'invenio-rdm-records~=0.18.3',
     'invenio-records-permissions~=0.9.0',
 ]
 


### PR DESCRIPTION
- correct `bestmatch` search order to work with new records-resources backend
  * :WARNING: `bestmatch` is now used on the UI AND the API as opposed
    to `bestmatch` in the UI and `-bestmatch` in the API. This is a breaking
    change from the prior Invenio search interface. Made an issue to revisit
    and discuss: https://github.com/inveniosoftware/invenio-records-resources/issues/74
- revert uploads page since user/records search is not implemented yet
- bump react-invenio-deposit to v0.5.0 to fix missing publication date
- release v0.12.5