### PR TITLE
ui, search: replace most recent sorting option by newest

### DIFF
--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/search.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/search.html
@@ -72,9 +72,9 @@
     {
       "default": false,
       "defaultOnEmptyString": true,
-      "sortBy": "mostrecent",
+      "sortBy": "newest",
       "sortOrder": "asc",
-      "text": "Most recent"
+      "text": "Newest"
     }
   ]
 }'></div>


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/288

**NOTE**: I personally prefer "Most recent" as text. But put "newest" since is the name that was given in `records-resources`

WAIT TO RELEASE TO INCLUDE RDM-RECORDS BUMP