### PR TITLE
Fix upload and search results item

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposits/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposits/search/components.js
@@ -70,10 +70,11 @@ export const RDMDepositResults = ({ sortOptions, currentResultsState }) => {
 };
 
 export const RDMRecordResultsListItem = ({ result, index }) => {
-  const resource_type = _get(
+  const resource_type = _get(result, "ui.resource_type", "No resource type");
+  const publicationDate = _get(
     result,
-    "ui.resource_type.title",
-    "No resource type"
+    "ui.publication_date_l10n_long",
+    "No publication date found."
   );
   const createdDate = _get(
     result,
@@ -81,14 +82,21 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
     "No creation date found."
   );
   const access = _get(result, "ui.access_right.title", "Open Access");
-  const creator = result.ui.creators.creators[0]
+  const access_right_category = _get(
+    result,
+    "ui.access_right.category",
+    "open"
+  );
+  const access_right_icon = _get(result, "ui.access_right.icon", "open");
+  const creator = result.ui.creators.creators[0];
   const title = _get(result, "metadata.title", "No title");
   const author = _get(result, "metadata._internal_notes[0].user", "anonymous");
   const id = _get(result, "id");
   const EditLink = `/uploads/${id}`;
+  const version = _get(result, "metadata.version", null);
 
   return (
-    <Item key={index} className="deposits-list-item">
+    <Item key={index} href={EditLink} className="deposits-list-item">
       <Item.Content>
         <Grid>
           <Grid.Row columns={2}>
@@ -99,12 +107,16 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
               <Item.Extra>
                 <div>
                   <Label size="tiny" color="blue">
-                    {createdDate}
+                    {publicationDate} {version ? `(${version})` : null}
                   </Label>
                   <Label size="tiny" color="grey">
                     {resource_type}
                   </Label>
-                  <Label size="tiny" color="green">
+                  <Label
+                    size="tiny"
+                    className={`access-right ${access_right_category}`}
+                  >
+                    <i className={`icon ${access_right_icon}`}></i>
                     {access}
                   </Label>
                   <div className="ui right floated actions">

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -85,7 +85,7 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
           {_truncate(description, { length: 350 })}
         </Item.Description>
         <Item.Extra>
-          {subjects.map((subject, index) => (
+          {subjects && subjects.map((subject, index) => (
             <Label key={index} size="tiny">
               {subject.subject}
             </Label>


### PR DESCRIPTION
Closes #390

All UI labels/info are used now. for each item the entire area is clickable and goes to the upload edit page:

![image](https://user-images.githubusercontent.com/1814661/98820713-d1176900-242e-11eb-9c8c-1f61458ee157.png)