### PR TITLE
ui: enlarge description rich text editor height

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/deposit.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/deposit.less
@@ -34,4 +34,8 @@
     }
   }
 
+  .ck-editor__editable {
+    min-height: 8.5em;
+  }
+
 }


### PR DESCRIPTION
closes https://github.com/inveniosoftware/react-invenio-deposit/issues/87

Screenshot:

![rich_editor_height](https://user-images.githubusercontent.com/1932651/100152169-df6e7780-2e67-11eb-8f4b-8d4a5a65c3bb.png)

It's essentially 3 lines high rather than 1.