### PR TITLE
deposit: move initial license to the serializer

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposits/RDMDepositForm/RDMDepositForm.js
@@ -248,17 +248,6 @@ export class RDMDepositForm extends Component {
       },
     };
     this.apiErrorHandler = new APIErrorHandler(this.vocabularies);
-    if (!this.props.record.metadata) {
-      this.props.record.metadata = {};
-      this.props.record.metadata["licenses"] = [
-        {
-          id: "MIT",
-          title: "MIT",
-          description:
-            "This license requires that reuses give credit to the creator. It allows reusers to distribute, remix, adapt, and build upon the material in any medium or format, even for commercial purposes.",
-        },
-      ];
-    }
   }
 
   render() {


### PR DESCRIPTION
* Removes the initial license from invenio-app-rdm
* Moves it to the default serializer in react-invenio-deposit