### PR TITLE
assets: fix creator name requirement on deposit search

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposits/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposits/search/components.js
@@ -88,7 +88,7 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
     "open"
   );
   const access_right_icon = _get(result, "ui.access_right.icon", "open");
-  const creator = result.ui.creators.creators[0];
+  const creator_name = _get(result, "ui.creators.creators[0].name", "No creator found");
   const title = _get(result, "metadata.title", "No title");
   const author = _get(result, "metadata._internal_notes[0].user", "anonymous");
   const id = _get(result, "id");
@@ -142,7 +142,7 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
               </Item.Header>
               <Item.Extra>
                 <div>
-                  Created on <span>{createdDate}</span> by {creator.name}
+                  Created on <span>{createdDate}</span> by {creator_name}
                   <div className="ui right floated stats">
                     <span>
                       <Icon name="eye" />

--- a/invenio_app_rdm/version.py
+++ b/invenio_app_rdm/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_app_rdm.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.18.6'
+__version__ = '0.18.7'


### PR DESCRIPTION
Can see several not complete deposit, the last one is actually fully empty!

<img width="1171" alt="Screenshot 2021-01-08 at 12 33 43" src="https://user-images.githubusercontent.com/6756943/104011189-02ea4900-51ae-11eb-9d63-23c67bc255e7.png">
