### PR TITLE
Remove import of Invenio-Communities JS

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ MIT License
 
 Copyright (C) 2019 CERN.
 Copyright (C) 2019 Northwestern University.
+Copyright (C) 2021 TU Wien.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/record_landing_page.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/record_landing_page.html
@@ -1,6 +1,7 @@
 {#
   Copyright (C) 2020 CERN.
   Copyright (C) 2020 Northwestern University.
+  Copyright (C) 2021 TU Wien.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.
@@ -105,8 +106,8 @@
 {%- block javascript %}
 {{ super() }}
 {{ webpack['invenio-app-rdm-records.js'] }}
-{# Communities management #}
-{{ webpack['invenio-communities-records.js'] }}
+{# Communities management -- TODO include again when communities are ready #}
+{# {{ webpack['invenio-communities-records.js'] }} #}
 {{ webpack['previewer_theme.js'] }}
 {{ webpack['invenio-app-rdm-record-management.js'] }}
 {%- endblock javascript %}

--- a/invenio_app_rdm/theme/webpack.py
+++ b/invenio_app_rdm/theme/webpack.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2019-2020 CERN.
 # Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C)      2021 TU Wien.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -39,6 +40,7 @@ theme = WebpackThemeBundle(
                 'react-invenio-deposit': '^0.10.4',
                 'react-invenio-forms': '^0.5.3',
                 'react-dropzone': "^11.0.3",
+                'yup': '^0.27.0',
                 '@ckeditor/ckeditor5-build-classic': '^16.0.0',
                 '@ckeditor/ckeditor5-react': '^2.1.0',
             },


### PR DESCRIPTION
closes inveniosoftware/invenio-rdm-records#352

remove import of invenio-communities JS code in the record landing page
also, add 'yup' as a webpack dependency because that's required by react-invenio-deposit and was only specified as a dependency in invenio-communities