### PR TITLE
form: sub field labels font-weight to normal

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/deposit.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/deposit.less
@@ -21,6 +21,20 @@
     }
   }
 
+  /*Field Label*/
+  .ui.form .field .form-group label{
+    font-size: 13px;
+    font-weight: normal;
+  }
+
+  label.field-level-class {
+    font-size: 15px;
+    &.small {
+      font-size: 13px
+    }
+  }
+  /**/
+
   .save-button {
     margin-bottom: 0.5em;
   }


### PR DESCRIPTION
closes inveniosoftware/react-invenio-deposit#88
not sure about the size of top-level fields - if its too big, see screenshots.
*screenshot*
![font-size](https://user-images.githubusercontent.com/44528277/107024351-3bc70f00-67a8-11eb-8dd8-749388733841.png)
