### PR TITLE
523 export as json

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -352,3 +352,13 @@ DEPOSITS_FORMS_BASE_TEMPLATE = 'invenio_app_rdm/deposit.html'
 
 DEPOSITS_UPLOADS_TEMPLATE = 'invenio_app_rdm/user_records_search.html'
 """User records' search page's template."""
+
+APP_RDM_RECORD_EXPORTERS = {
+    "json": {
+        "name": "JSON",
+        "serializer": ("invenio_rdm_records.resources.serializers:"
+                       "UIJSONSerializer")
+    }
+}
+
+APP_RDM_RECORDS_EXPORT_URL = "/records/<pid_value>/export/<export_format>"

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/export_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/export_page.less
@@ -5,8 +5,9 @@
  * it under the terms of the MIT License; see LICENSE file for more details.
  */
 
-pre {
+pre.export.result {
     display:block;
+    white-space: pre-wrap;
     padding:9.5px;
     margin:0 0 10px;
     font-size:13px;
@@ -15,5 +16,5 @@ pre {
     word-wrap:break-word;
     background-color:#f5f5f5;
     border:1px solid #ccc;
-    border-radius:4px
+    border-radius:4px;
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/export_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/export_page.less
@@ -1,0 +1,19 @@
+/*
+ *   Copyright (C) 2021 TU Wien.
+ *
+ * Invenio RDM Records is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+pre {
+    display:block;
+    padding:9.5px;
+    margin:0 0 10px;
+    font-size:13px;
+    line-height:1.42857;
+    word-break:break-all;
+    word-wrap:break-word;
+    background-color:#f5f5f5;
+    border:1px solid #ccc;
+    border-radius:4px
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
@@ -13,6 +13,7 @@
 @import "search.less";
 @import "navbar.less";
 @import "landing_page.less";
+@import "export_page.less";
 
 html,
 body {

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/details/side_bar.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/details/side_bar.html
@@ -46,25 +46,18 @@
 </div>
 #}
 
+{%- if config.get("APP_RDM_RECORD_EXPORTERS") -%}
+{# if no export formats are specified, don't bother showing the box #}
 <div class="ui segment rdm-sidebar">
   <dt><b>{{ _('Export')}}</b></dt>
   <hr class="thin-line">
   </hr>
   <dd class="top-bottom-padded">
-    {#
-    <!-- TODO add again once exports are working -->
-    <a class="export-format" href="/coming-soon">BibTeX</a>
-    <a class="export-format" href="/coming-soon">CSL</a>
-    <a class="export-format" href="/coming-soon">DataCite</a>
-    <a class="export-format" href="/coming-soon">Dublin Core</a>
-    <a class="export-format" href="/coming-soon">DCAT</a>
-    #}
-    <a class="export-format" href="/coming-soon">JSON</a>
-    {#
-    <a class="export-format" href="/coming-soon">JSON-LD</a>
-    <a class="export-format" href="/coming-soon">GeoJSON</a>
-    <a class="export-format" href="/coming-soon">MARCXML</a>
-    <a class="export-format" href="/coming-soon">Mendeley</a>
-    #}
+    {# dynamically create the list of export formats #}
+    {%- for fmt, val in config.get("APP_RDM_RECORD_EXPORTERS", {}).items() -%}
+      {%- set name = val.get("name", fmt) -%}
+      <a class="export-format" href="/coming-soon">{{ name }}</a>
+    {%- endfor -%}
   </dd>
 </div>
+{%- endif -%}

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/details/side_bar.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/details/side_bar.html
@@ -56,7 +56,8 @@
     {# dynamically create the list of export formats #}
     {%- for fmt, val in config.get("APP_RDM_RECORD_EXPORTERS", {}).items() -%}
       {%- set name = val.get("name", fmt) -%}
-      <a class="export-format" href="/coming-soon">{{ name }}</a>
+      {%- set export_url = url_for('invenio_app_rdm_records_ui.export_record', pid_value=record.pid.pid_value, export_format=fmt) -%}
+      <a class="export-format" href="{{ export_url }}">{{ name }}</a>
     {%- endfor -%}
   </dd>
 </div>

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/details/side_bar.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/details/side_bar.html
@@ -56,7 +56,7 @@
     {# dynamically create the list of export formats #}
     {%- for fmt, val in config.get("APP_RDM_RECORD_EXPORTERS", {}).items() -%}
       {%- set name = val.get("name", fmt) -%}
-      {%- set export_url = url_for('invenio_app_rdm_records_ui.export_record', pid_value=record.pid.pid_value, export_format=fmt) -%}
+      {%- set export_url = url_for('invenio_app_rdm.export_record', pid_value=record.pid.pid_value, export_format=fmt) -%}
       <a class="export-format" href="{{ export_url }}">{{ name }}</a>
     {%- endfor -%}
   </dd>

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/details/side_bar.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/details/side_bar.html
@@ -56,7 +56,13 @@
     {# dynamically create the list of export formats #}
     {%- for fmt, val in config.get("APP_RDM_RECORD_EXPORTERS", {}).items() -%}
       {%- set name = val.get("name", fmt) -%}
-      {%- set export_url = url_for('invenio_app_rdm.export_record', pid_value=record.pid.pid_value, export_format=fmt) -%}
+      {%- if pid_value is not defined -%}
+        {# in older render_template calls, it may be that no 'pid_value' was specified #}
+        {# and the 'record' was specified as RDMRecord instead of as RecordItem #}
+        {# TODO clean up those calls and this #}
+        {%- set pid_value = record.pid.pid_value -%}
+      {%- endif -%}
+      {%- set export_url = url_for('invenio_app_rdm.export_record', pid_value=pid_value, export_format=fmt) -%}
       <a class="export-format" href="{{ export_url }}">{{ name }}</a>
     {%- endfor -%}
   </dd>

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/export_page.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/export_page.html
@@ -1,0 +1,66 @@
+{#
+  Copyright (C) 2021 TU Wien.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- extends config.BASE_TEMPLATE %}
+
+{%- block css %}
+{{ super() }}
+{%- endblock css %}
+
+{%- from "invenio_app_rdm/landing_page/macros/files.html" import file_list_box, preview_file_box %}
+{%- from "invenio_app_rdm/landing_page/macros/detail.html" import show_detail %}
+
+{%- set record = record|dereference_record|serialize_ui %}
+{%- set metadata = record.metadata %}
+
+{%- block page_body %}
+<div
+  id="recordManagement"
+  data-recid='{{ record["id"] | tojson }}'>
+</div>
+<div class="ui container">
+  <div class="ui padded relaxed grid">
+    <div class="two column row">
+      <div class="eleven wide column">
+        {%- block record_body %}
+        <div class="ui grid middle aligned">
+          <div class="two column row">
+            <div class="left floated left aligned column">
+              <span class="ui" title="Publication date">{{ record.ui.publication_date_l10n_long }}</span>
+              {%- if metadata.version %}
+              <span class="label text-muted"> | Version {{ metadata.version }}</span>
+              {% endif %}
+            </div>
+            <div class="right floated right aligned column">
+              <span class="ui label small grey">{{ record.ui.resource_type }}</span>
+              <span class="ui label small access-right {{ record.ui.access_right.icon }}">
+                <i class="icon {{ record.ui.access_right.icon }}"></i>{{ record.ui.access_right.title }}</span>
+            </div>
+          </div>
+        </div>
+        <h1>{{ metadata.title }}</h1>
+        <p>{%- include "invenio_app_rdm/landing_page/details/creators.html" %}</p>
+
+        <h3>{{ export_format }} Export</h3>
+        <div class="top-padded">
+          <pre style="white-space: pre-wrap;">
+          {{- exported_record -}}
+          </pre>
+        </div>
+
+        {%- endblock record_body %}
+      </div>
+      <div class="five wide column">
+        {% block sidebar %}
+        {%- include "invenio_app_rdm/landing_page/details/side_bar.html" %}
+        {% endblock sidebar %}
+      </div>
+    </div>
+  </div>
+</div>
+
+{%- endblock page_body %}

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/export_page.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/landing_page/export_page.html
@@ -14,14 +14,10 @@
 {%- from "invenio_app_rdm/landing_page/macros/files.html" import file_list_box, preview_file_box %}
 {%- from "invenio_app_rdm/landing_page/macros/detail.html" import show_detail %}
 
-{%- set record = record|dereference_record|serialize_ui %}
+{%- set record = record.data|serialize_ui %}
 {%- set metadata = record.metadata %}
 
 {%- block page_body %}
-<div
-  id="recordManagement"
-  data-recid='{{ record["id"] | tojson }}'>
-</div>
 <div class="ui container">
   <div class="ui padded relaxed grid">
     <div class="two column row">
@@ -37,8 +33,11 @@
             </div>
             <div class="right floated right aligned column">
               <span class="ui label small grey">{{ record.ui.resource_type }}</span>
+              {# note: keeping this results in an error, because record.ui has no access_right property here #}
+              {#
               <span class="ui label small access-right {{ record.ui.access_right.icon }}">
                 <i class="icon {{ record.ui.access_right.icon }}"></i>{{ record.ui.access_right.title }}</span>
+              #}
             </div>
           </div>
         </div>
@@ -47,7 +46,7 @@
 
         <h3>{{ export_format }} Export</h3>
         <div class="top-padded">
-          <pre style="white-space: pre-wrap;">
+          <pre class="export result">
           {{- exported_record -}}
           </pre>
         </div>

--- a/invenio_app_rdm/theme/utils.py
+++ b/invenio_app_rdm/theme/utils.py
@@ -10,6 +10,7 @@
 
 from invenio_records.errors import MissingModelError
 from invenio_records_files.api import FileObject
+from werkzeug.utils import import_string
 
 
 def previewer_record_file_factory(pid, record, filename):
@@ -32,3 +33,17 @@ def previewer_record_file_factory(pid, record, filename):
             return FileObject(obj=rf.file, data=rf.metadata or {})
     except KeyError:
         return None
+
+
+def obj_or_import_string(value, default=None):
+    """Import string or return object.
+
+    :params value: Import path or class object to instantiate.
+    :params default: Default object to return if the import fails.
+    :returns: The imported object.
+    """
+    if isinstance(value, str):
+        return import_string(value)
+    elif value:
+        return value
+    return default

--- a/invenio_app_rdm/theme/utils.py
+++ b/invenio_app_rdm/theme/utils.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2021 TU Wien.
 #
 # Invenio-App-RDM is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/theme/views/__init__.py
+++ b/invenio_app_rdm/theme/views/__init__.py
@@ -7,7 +7,36 @@
 
 """Blueprints and views for Invenio-App-RDM."""
 
-from .general import ui_blueprint
-from .records_ui import file_download_ui, records_ui_blueprint
+from flask import Blueprint
+from flask_menu import current_menu
 
-__all__ = ("file_download_ui", "ui_blueprint", "records_ui_blueprint")
+from .filters import register_filters
+from .general import register_general_ui_routes
+from .records import file_download_ui, register_records_ui_routes
+
+
+def ui_blueprint(app):
+    """Blueprint for the routes and resources provided by Invenio-App-RDM."""
+    blueprint = Blueprint(
+        "invenio_app_rdm",
+        __name__,
+        template_folder="../templates",
+        static_folder="../static",
+    )
+
+    register_filters(blueprint)
+    register_general_ui_routes(app, blueprint)
+    register_records_ui_routes(app, blueprint)
+
+    @blueprint.before_app_first_request
+    def init_menu():
+        """Initialize menu before first request."""
+        item = current_menu.submenu("main.deposit")
+        item.register(
+            "invenio_app_rdm.deposits_user", "Uploads", order=1
+        )
+
+    return blueprint
+
+
+__all__ = ("file_download_ui", "ui_blueprint")

--- a/invenio_app_rdm/theme/views/__init__.py
+++ b/invenio_app_rdm/theme/views/__init__.py
@@ -10,6 +10,7 @@
 from flask import Blueprint
 from flask_menu import current_menu
 
+from .deposits import register_deposits_ui_routes
 from .filters import register_filters
 from .general import register_general_ui_routes
 from .records import file_download_ui, register_records_ui_routes
@@ -27,14 +28,13 @@ def ui_blueprint(app):
     register_filters(blueprint)
     register_general_ui_routes(app, blueprint)
     register_records_ui_routes(app, blueprint)
+    register_deposits_ui_routes(app, blueprint)
 
     @blueprint.before_app_first_request
     def init_menu():
         """Initialize menu before first request."""
         item = current_menu.submenu("main.deposit")
-        item.register(
-            "invenio_app_rdm.deposits_user", "Uploads", order=1
-        )
+        item.register("invenio_app_rdm.deposits_user", "Uploads", order=1)
 
     return blueprint
 

--- a/invenio_app_rdm/theme/views/__init__.py
+++ b/invenio_app_rdm/theme/views/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Blueprints and views for Invenio-App-RDM."""
+
+from .general import ui_blueprint
+from .records_ui import file_download_ui, records_ui_blueprint
+
+__all__ = ("file_download_ui", "ui_blueprint", "records_ui_blueprint")

--- a/invenio_app_rdm/theme/views/deposits.py
+++ b/invenio_app_rdm/theme/views/deposits.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019-2020 CERN.
+# Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C)      2021 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Routes for record-related pages provided by Invenio-App-RDM."""
+
+from flask import current_app, g, render_template
+from invenio_i18n.ext import current_i18n
+from invenio_rdm_records.resources.config import RDMDraftFilesResourceConfig, \
+    RDMDraftResourceConfig
+from invenio_rdm_records.resources.serializers import UIJSONSerializer
+from invenio_rdm_records.services import RDMDraftFilesService
+from invenio_rdm_records.services.schemas import RDMRecordSchema
+from invenio_rdm_records.services.schemas.utils import dump_empty
+from invenio_rdm_records.vocabularies import Vocabularies
+
+
+def register_deposits_ui_routes(app, blueprint):
+    """Dynamically registers routes (allows us to rely on config)."""
+    service = app.extensions["invenio-rdm-records"].records_service
+    search_url = app.config.get("RDM_RECORDS_UI_SEARCH_URL", "/search")
+
+    @blueprint.route(
+        app.config.get("RDM_RECORDS_UI_SEARCH_USER_URL", "/uploads")
+    )
+    def deposits_user():
+        """List of user deposits page."""
+        return render_template(
+            current_app.config["DEPOSITS_UPLOADS_TEMPLATE"],
+            searchbar_config=dict(searchUrl=search_url),
+        )
+
+    @blueprint.route(app.config.get("RDM_RECORDS_UI_NEW_URL", "/uploads/new"))
+    def deposits_create():
+        """Record creation page."""
+        forms_config = dict(
+            createUrl=("/api/records"),
+            vocabularies=Vocabularies.dump(),
+            current_locale=str(current_i18n.locale),
+        )
+        return render_template(
+            current_app.config["DEPOSITS_FORMS_BASE_TEMPLATE"],
+            forms_config=forms_config,
+            record=dump_empty(RDMRecordSchema),
+            files=dict(
+                default_preview=None, enabled=True, entries=[], links={}
+            ),
+            searchbar_config=dict(searchUrl=search_url),
+        )
+
+    @blueprint.route(
+        app.config.get("RDM_RECORDS_UI_EDIT_URL", "/uploads/<pid_value>")
+    )
+    def deposits_edit(pid_value):
+        """Deposit edit page."""
+        links_config = RDMDraftResourceConfig.links_config
+        draft = service.read_draft(
+            id_=pid_value, identity=g.identity, links_config=links_config
+        )
+
+        files_service = RDMDraftFilesService()
+        files_list = files_service.list_files(
+            id_=pid_value,
+            identity=g.identity,
+            links_config=RDMDraftFilesResourceConfig.links_config,
+        )
+
+        forms_config = dict(
+            apiUrl=f"/api/records/{pid_value}/draft",
+            vocabularies=Vocabularies.dump(),
+            current_locale=str(current_i18n.locale),
+        )
+
+        # Dereference relations (languages, licenses, etc.)
+        draft._record.relations.dereference()
+        serializer = UIJSONSerializer()
+        record = serializer.serialize_object_to_dict(draft.to_dict())
+
+        # TODO: get the `is_published` field when reading the draft
+        from invenio_pidstore.errors import PIDUnregistered
+
+        try:
+            service.draft_cls.pid.resolve(pid_value, registered_only=True)
+            record["is_published"] = True
+        except PIDUnregistered:
+            record["is_published"] = False
+
+        return render_template(
+            current_app.config["DEPOSITS_FORMS_BASE_TEMPLATE"],
+            forms_config=forms_config,
+            record=record,
+            files=files_list.to_dict(),
+            searchbar_config=dict(searchUrl=search_url),
+        )
+
+    return blueprint

--- a/invenio_app_rdm/theme/views/filters.py
+++ b/invenio_app_rdm/theme/views/filters.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019-2020 CERN.
+# Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C)      2021 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Filters to be used in the Jinja templates."""
+
+from operator import itemgetter
+from os.path import splitext
+
+import idutils
+from flask import current_app
+from invenio_previewer.views import is_previewable
+from invenio_rdm_records.resources.serializers import UIJSONSerializer
+from invenio_rdm_records.vocabularies import Vocabularies
+from invenio_records_files.api import FileObject
+from invenio_records_permissions.policies import get_record_permission_policy
+
+
+def register_filters(blueprint):
+    """Register filters to be used in the Jinja templates."""
+
+    @blueprint.app_template_filter()
+    def make_files_preview_compatible(files):
+        """Processes a list of RecordFiles to a list of FileObjects.
+
+        This is needed to make the objects compatible with invenio-previewer.
+        """
+        file_objects = []
+        for file in files:
+            file_objects.append(
+                FileObject(obj=files[file].object_version, data={}).dumps()
+            )
+        return file_objects
+
+    @blueprint.app_template_filter()
+    def select_preview_file(files, default_preview=None):
+        """Get list of files and select one for preview."""
+        selected = None
+
+        try:
+            for f in sorted(files or [], key=itemgetter("key")):
+                file_type = splitext(f["key"])[1][1:].lower()
+                if is_previewable(file_type):
+                    if selected is None:
+                        selected = f
+                    elif f["key"] == default_preview:
+                        selected = f
+        except KeyError:
+            pass
+        return selected
+
+    @blueprint.app_template_filter()
+    def to_previewer_files(record):
+        """Get previewer-compatible files list."""
+        return [
+            FileObject(obj=f.object_version, data=f.metadata or {})
+            for f in record.files.values()
+        ]
+
+    @blueprint.app_template_filter("can_list_files")
+    def can_list_files(record):
+        """Permission check if current user can list files of record.
+
+        The current_user is used under the hood by flask-principal.
+
+        Once we move to Single-Page-App approach, we likely want to enforce
+        permissions at the final serialization level (only).
+        """
+        PermissionPolicy = get_record_permission_policy()
+        return PermissionPolicy(action="read_files", record=record).can()
+
+    @blueprint.app_template_filter("pid_url")
+    def pid_url(identifier, scheme=None, url_scheme="https"):
+        """Convert persistent identifier into a link."""
+        if scheme is None:
+            try:
+                scheme = idutils.detect_identifier_schemes(identifier)[0]
+            except IndexError:
+                scheme = None
+        try:
+            if scheme and identifier:
+                return idutils.to_url(
+                    identifier, scheme, url_scheme=url_scheme
+                )
+        except Exception:
+            current_app.logger.warning(
+                f"URL generation for identifier {identifier} failed.",
+                exc_info=True,
+            )
+        return ""
+
+    @blueprint.app_template_filter("doi_identifier")
+    def doi_identifier(identifiers):
+        """Extract DOI from sequence of identifiers."""
+        for identifier in identifiers:
+            # TODO: extract this "DOI" constant to a registry?
+            if identifier == "doi":
+                return identifiers[identifier]
+
+    @blueprint.app_template_filter("vocabulary_title")
+    def vocabulary_title(dict_key, vocabulary_key, alt_key=None):
+        """Returns formatted vocabulary-corresponding human-readable string.
+
+        In some cases the dict needs to be reconstructed. `alt_key` will be the
+        key while `dict_key` will become the value.
+        """
+        if alt_key:
+            dict_key = {alt_key: dict_key}
+        vocabulary = Vocabularies.get_vocabulary(vocabulary_key)
+        return vocabulary.get_title_by_dict(dict_key) if vocabulary else ""
+
+    @blueprint.app_template_filter("dereference_record")
+    def dereference_record(record):
+        """Returns the UI serialization of a record."""
+        record.relations.dereference()
+
+        return record
+
+    @blueprint.app_template_filter("serialize_ui")
+    def serialize_ui(record):
+        """Returns the UI serialization of a record."""
+        serializer = UIJSONSerializer()
+        # We need a dict not a string
+        return serializer.serialize_object_to_dict(record)

--- a/invenio_app_rdm/theme/views/general.py
+++ b/invenio_app_rdm/theme/views/general.py
@@ -7,19 +7,13 @@
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-"""Blueprint for general pages provided by Invenio-App-RDM."""
+"""Routes for general pages provided by Invenio-App-RDM."""
 
-from flask import Blueprint, current_app, render_template
+from flask import current_app, render_template
 
 
-def ui_blueprint(app):
-    """Dynamically registers routes (allows us to rely on config)."""
-    blueprint = Blueprint(
-        "invenio_app_rdm_theme",
-        __name__,
-        template_folder="../templates",
-        static_folder="../static",
-    )
+def register_general_ui_routes(app, blueprint):
+    """Register routes for general pages provided by Invenio-App-RDM."""
 
     @blueprint.route(app.config.get("RDM_RECORDS_UI_SEARCH_URL", "/search"))
     def search():

--- a/invenio_app_rdm/theme/views/general.py
+++ b/invenio_app_rdm/theme/views/general.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019-2020 CERN.
+# Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C)      2021 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Blueprint for general pages provided by Invenio-App-RDM."""
+
+from flask import Blueprint, current_app, render_template
+
+
+def ui_blueprint(app):
+    """Dynamically registers routes (allows us to rely on config)."""
+    blueprint = Blueprint(
+        "invenio_app_rdm_theme",
+        __name__,
+        template_folder="../templates",
+        static_folder="../static",
+    )
+
+    @blueprint.route(app.config.get("RDM_RECORDS_UI_SEARCH_URL", "/search"))
+    def search():
+        """Search page."""
+        return render_template(current_app.config["SEARCH_BASE_TEMPLATE"])
+
+    @blueprint.route("/coming-soon")
+    def coming_soon():
+        """Route to display on soon-to-come features."""
+        return render_template("invenio_app_rdm/coming_soon_page.html")
+
+    @blueprint.route("/help/search")
+    def help_search():
+        """Search help guide."""
+        return render_template("invenio_app_rdm/help/search.html")
+
+    return blueprint

--- a/invenio_app_rdm/theme/views/records.py
+++ b/invenio_app_rdm/theme/views/records.py
@@ -9,98 +9,15 @@
 
 """Routes for record-related pages provided by Invenio-App-RDM."""
 
-from flask import abort, current_app, g, render_template, request
+from flask import abort, g, render_template, request
 from invenio_files_rest.views import ObjectResource
-from invenio_i18n.ext import current_i18n
 from invenio_rdm_records.proxies import current_rdm_records
-from invenio_rdm_records.resources.config import RDMDraftFilesResourceConfig, \
-    RDMDraftResourceConfig
-from invenio_rdm_records.resources.serializers import UIJSONSerializer
-from invenio_rdm_records.services import RDMDraftFilesService
-from invenio_rdm_records.services.schemas import RDMRecordSchema
-from invenio_rdm_records.services.schemas.utils import dump_empty
-from invenio_rdm_records.vocabularies import Vocabularies
 
 from ..utils import obj_or_import_string, previewer_record_file_factory
 
 
 def register_records_ui_routes(app, blueprint):
     """Dynamically registers routes (allows us to rely on config)."""
-    service = app.extensions["invenio-rdm-records"].records_service
-    search_url = app.config.get("RDM_RECORDS_UI_SEARCH_URL", "/search")
-
-    @blueprint.route(app.config.get("RDM_RECORDS_UI_NEW_URL", "/uploads/new"))
-    def deposits_create():
-        """Record creation page."""
-        forms_config = dict(
-            createUrl=("/api/records"),
-            vocabularies=Vocabularies.dump(),
-            current_locale=str(current_i18n.locale),
-        )
-        return render_template(
-            current_app.config["DEPOSITS_FORMS_BASE_TEMPLATE"],
-            forms_config=forms_config,
-            record=dump_empty(RDMRecordSchema),
-            files=dict(
-                default_preview=None, enabled=True, entries=[], links={}
-            ),
-            searchbar_config=dict(searchUrl=search_url),
-        )
-
-    @blueprint.route(
-        app.config.get("RDM_RECORDS_UI_EDIT_URL", "/uploads/<pid_value>")
-    )
-    def deposits_edit(pid_value):
-        """Deposit edit page."""
-        links_config = RDMDraftResourceConfig.links_config
-        draft = service.read_draft(
-            id_=pid_value, identity=g.identity, links_config=links_config
-        )
-
-        files_service = RDMDraftFilesService()
-        files_list = files_service.list_files(
-            id_=pid_value,
-            identity=g.identity,
-            links_config=RDMDraftFilesResourceConfig.links_config,
-        )
-
-        forms_config = dict(
-            apiUrl=f"/api/records/{pid_value}/draft",
-            vocabularies=Vocabularies.dump(),
-            current_locale=str(current_i18n.locale),
-        )
-
-        # Dereference relations (languages, licenses, etc.)
-        draft._record.relations.dereference()
-        serializer = UIJSONSerializer()
-        record = serializer.serialize_object_to_dict(draft.to_dict())
-
-        # TODO: get the `is_published` field when reading the draft
-        from invenio_pidstore.errors import PIDUnregistered
-
-        try:
-            service.draft_cls.pid.resolve(pid_value, registered_only=True)
-            record["is_published"] = True
-        except PIDUnregistered:
-            record["is_published"] = False
-
-        return render_template(
-            current_app.config["DEPOSITS_FORMS_BASE_TEMPLATE"],
-            forms_config=forms_config,
-            record=record,
-            files=files_list.to_dict(),
-            searchbar_config=dict(searchUrl=search_url),
-        )
-
-    @blueprint.route(
-        app.config.get("RDM_RECORDS_UI_SEARCH_USER_URL", "/uploads")
-    )
-    def deposits_user():
-        """List of user deposits page."""
-        return render_template(
-            current_app.config["DEPOSITS_UPLOADS_TEMPLATE"],
-            searchbar_config=dict(searchUrl=search_url),
-        )
 
     @blueprint.route(
         app.config.get(

--- a/invenio_app_rdm/theme/views/records.py
+++ b/invenio_app_rdm/theme/views/records.py
@@ -37,28 +37,29 @@ def register_records_ui_routes(app, blueprint):
 
         record = service.read(
             id_=pid_value, identity=g.identity, links_config=links_config
-        )._record
+        )
 
         # get the configured serializer
-        temp = app.config.get("APP_RDM_RECORD_EXPORTERS", {}).get(
+        exporter = app.config.get("APP_RDM_RECORD_EXPORTERS", {}).get(
             export_format
         )
-        if temp is None:
+        if exporter is None:
             raise Exception(
                 "no exporter for the specified format registered: {}".format(
                     export_format
                 )
             )
 
-        format_name = temp.get("name", export_format)
-        serializer = obj_or_import_string(temp["serializer"])()
-        exported_record = serializer.serialize_object(record)
+        format_name = exporter.get("name", export_format)
+        serializer = obj_or_import_string(exporter["serializer"])()
+        exported_record = serializer.serialize_object(record.to_dict())
 
         return render_template(
             template,
             export_format=format_name,
             exported_record=exported_record,
             record=record,
+            pid_value=record.id,
         )
 
     return blueprint

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2019-2020 CERN.
 # Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C)      2021 TU Wien.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -95,7 +96,10 @@ setup(
             'invenio-app-rdm = invenio_app.cli:cli',
         ],
         'invenio_base.blueprints': [
-            'invenio_app_rdm = invenio_app_rdm.theme.views:ui_blueprint',
+            ("invenio_app_rdm = invenio_app_rdm.theme.views:"
+             "ui_blueprint"),
+            ("invenio_app_rdm_records = invenio_app_rdm.theme.views:"
+             "records_ui_blueprint"),
         ],
         'invenio_assets.webpack': [
             'invenio_app_rdm_theme = invenio_app_rdm.theme.webpack:theme',

--- a/setup.py
+++ b/setup.py
@@ -96,10 +96,7 @@ setup(
             'invenio-app-rdm = invenio_app.cli:cli',
         ],
         'invenio_base.blueprints': [
-            ("invenio_app_rdm = invenio_app_rdm.theme.views:"
-             "ui_blueprint"),
-            ("invenio_app_rdm_records = invenio_app_rdm.theme.views:"
-             "records_ui_blueprint"),
+            "invenio_app_rdm = invenio_app_rdm.theme.views:ui_blueprint",
         ],
         'invenio_assets.webpack': [
             'invenio_app_rdm_theme = invenio_app_rdm.theme.webpack:theme',


### PR DESCRIPTION
closes #523 

Introduced a new configuration item for registering record serializers, e.g.:
```
APP_RDM_RECORD_EXPORTERS = {
    "json": {
        "name": "JSON",
        "serializer": ("invenio_rdm_records.resources.serializers:"
                       "UIJSONSerializer")
    }
}
```
The key is used for the lookup and should be URL-safe, while the `"name"` property is used for display purposes.
The `"serializer"` property is an import string for (or direct reference to) a factory function that can be called without arguments which creates an instance of the serializer (e.g. an argument-less constructor).

*Side note*: This configuration item is also used in the side-bar template, to only display links to export formats of registered serializers.

The URL to the export UI of a record can also be configured via a new configuration item (which needs to include both `<pid_value>` and `<export_format>`):
`APP_RDM_RECORDS_EXPORT_URL = "/records/<pid_value>/export/<export_format>"`

*Side note*: This URL is rendered in the jinja template for the side-bar via `url_for(...)`

Also, the `views` have been refactored a bit to split up general and record-related view functions.


**Screenshot of the export page**:
![image](https://user-images.githubusercontent.com/6437519/107201399-36acce80-69f9-11eb-8ec5-8c0fc9e715e4.png)
