### PR TITLE
deposit: add support for default values in the deposit form

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -28,7 +28,7 @@ WARNING: An instance should NOT install multiple flavour extensions since
          there would be no guarantee of priority anymore.
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from .theme.utils import previewer_record_file_factory
 
@@ -362,3 +362,26 @@ APP_RDM_RECORD_EXPORTERS = {
 }
 
 APP_RDM_RECORDS_EXPORT_URL = "/records/<pid_value>/export/<export_format>"
+
+APP_RDM_DEPOSIT_FORM_DEFAULTS = {
+    "publication_date": lambda: datetime.now().strftime("%Y-%m-%d"),
+    "rights": [
+        {
+            "id": "cc-by-4.0",
+            "title": "Creative Commons Attribution 4.0 International",
+            "description": ("The Creative Commons Attribution license allows "
+                            "re-distribution and re-use of a licensed work "
+                            "on the condition that the creator is "
+                            "appropriately credited."),
+            "link": "https://creativecommons.org/licenses/by/4.0/legalcode",
+        }
+    ],
+    "publisher": "CERN",
+}
+"""Default values for new records in the deposit UI.
+
+The keys denote the dot-separated path, where in the record's metadata
+the values should be set (see invenio-records.dictutils).
+If the value is callable, its return value will be used for the field
+(e.g. lambda/function for dynamic calculation of values).
+"""

--- a/invenio_app_rdm/theme/utils.py
+++ b/invenio_app_rdm/theme/utils.py
@@ -9,6 +9,7 @@
 
 """Utility functions."""
 
+from invenio_records.dictutils import dict_set
 from invenio_records.errors import MissingModelError
 from invenio_records_files.api import FileObject
 from werkzeug.utils import import_string
@@ -48,3 +49,24 @@ def obj_or_import_string(value, default=None):
     elif value:
         return value
     return default
+
+
+def set_default_value(record_dict, value, path, default_prefix="metadata"):
+    """Set the value with the specified dot-separated path in the record.
+
+    :param record_dict: The dict in which to set the value.
+    :param value: The value to set (can be callable).
+    :param path: The dot-separated path to the value.
+    :param default_prefix: The default path prefix to assume.
+    """
+    if callable(value):
+        value = value()
+
+    # if the path explicitly starts with a dot, we know that we shouldn't
+    # prepend the default_prefix to the path
+    if path.startswith("."):
+        path = path[1:]
+    else:
+        path = "{}.{}".format(default_prefix, path)
+
+    dict_set(record_dict, path, value)

--- a/invenio_app_rdm/theme/views/deposits.py
+++ b/invenio_app_rdm/theme/views/deposits.py
@@ -19,6 +19,8 @@ from invenio_rdm_records.services.schemas import RDMRecordSchema
 from invenio_rdm_records.services.schemas.utils import dump_empty
 from invenio_rdm_records.vocabularies import Vocabularies
 
+from ..utils import set_default_value
+
 
 def register_deposits_ui_routes(app, blueprint):
     """Dynamically registers routes (allows us to rely on config)."""
@@ -43,10 +45,17 @@ def register_deposits_ui_routes(app, blueprint):
             vocabularies=Vocabularies.dump(),
             current_locale=str(current_i18n.locale),
         )
+
+        new_record = dump_empty(RDMRecordSchema)
+        defaults = app.config.get("APP_RDM_DEPOSIT_FORM_DEFAULTS") or {}
+        for key in defaults:
+            value = defaults[key]
+            set_default_value(new_record, value, key)
+
         return render_template(
             current_app.config["DEPOSITS_FORMS_BASE_TEMPLATE"],
             forms_config=forms_config,
-            record=dump_empty(RDMRecordSchema),
+            record=new_record,
             files=dict(
                 default_preview=None, enabled=True, entries=[], links={}
             ),

--- a/invenio_app_rdm/theme/views/deposits.py
+++ b/invenio_app_rdm/theme/views/deposits.py
@@ -48,8 +48,7 @@ def register_deposits_ui_routes(app, blueprint):
 
         new_record = dump_empty(RDMRecordSchema)
         defaults = app.config.get("APP_RDM_DEPOSIT_FORM_DEFAULTS") or {}
-        for key in defaults:
-            value = defaults[key]
+        for key, value in defaults.items():
             set_default_value(new_record, value, key)
 
         return render_template(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for utility functions."""
+
+from datetime import datetime
+
+from invenio_app_rdm.theme.utils import obj_or_import_string, set_default_value
+
+
+def test_obj_or_import_string():
+    """Test retrieval of objects via obj_or_import_string."""
+    string = "invenio_app_rdm.theme.utils:obj_or_import_string"
+    obj = obj_or_import_string
+
+    assert obj_or_import_string(obj) == obj
+    assert obj_or_import_string(string) == obj
+
+
+def test_set_default_value__value():
+    """Test setting a value."""
+    dict_ = {"metadata": {"publication_date": None}}
+    value = "1939-01-01"
+    path = "publication_date"
+
+    set_default_value(dict_, value, path)
+
+    assert dict_["metadata"]["publication_date"] == value
+
+
+def test_set_default_value__callable():
+    """Test setting a value via a callable."""
+    dict_ = {"metadata": {"publication_date": None}}
+
+    def func():
+        return datetime.now().strftime("%Y-%m-%d")
+
+    path = "publication_date"
+    today = func()
+
+    set_default_value(dict_, func, path)
+
+    assert dict_["metadata"]["publication_date"] == today
+
+
+def test_set_default_value__no_path_prefix():
+    """Test setting a value for an unprefixed path."""
+    dict_ = {"metadata": {"publication_date": None}}
+    value = "1939-01-01"
+    path = ".publication_date"
+
+    set_default_value(dict_, value, path)
+
+    assert dict_["metadata"]["publication_date"] is None
+    assert dict_["publication_date"] == value
+
+
+def test_set_default_value__explicit_and_automatic_prefix():
+    """Compare values set with auto-prefix and explicit prefix."""
+    dict1 = {"metadata": {"publication_date": None}}
+    dict2 = dict1.copy()
+    value = "1939-01-01"
+    path1 = "publication_date"
+    path2 = ".metadata.publication_date"
+
+    set_default_value(dict1, value, path1)
+    set_default_value(dict2, value, path2)
+
+    assert (
+        dict1["metadata"]["publication_date"]
+        == dict2["metadata"]["publication_date"]
+    )
+    assert dict1["metadata"]["publication_date"] == value


### PR DESCRIPTION
closes inveniosoftware/invenio-rdm-records#358

in the screenshot: default values for **rights** (licenses), **publisher**, and **publication_date** (via a callable).
![image](https://user-images.githubusercontent.com/6437519/107498184-ba9abe00-6b93-11eb-8788-9c5d91793ecd.png)
