### PR TITLE
bugfix: show affiliation btn only if affiliations

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creators.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creators.html
@@ -1,6 +1,7 @@
 {#
     Copyright (C) 2020 CERN.
     Copyright (C) 2020 Northwestern University.
+    Copyright (C) 2021 Graz University of Technology.
 
     Invenio RDM Records is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.
@@ -11,10 +12,12 @@
 <div class="ui accordion">
   <div class="title">
     {{ show_creatibutors(record.ui.creators.creators, show_affiliations=True) }}
+    {% if record.ui.creators.affiliations %}
     <a style="cursor: pointer;" class="dropdown">
       <span class="up ui label small">show affiliations</span>
       <span class="down ui label small">hide affiliations</span>
     </a>
+    {% endif %}
   </div>
 
   {% if record.ui.creators.affiliations %}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -153,3 +153,8 @@
          padding-top: 0px !important;
      }
  }
+
+ /* accordion cursor */
+ .ui.accordion .title {
+    cursor: auto !important;
+ }


### PR DESCRIPTION
closes #593
inveniosoftware/invenio-rdm-records#304 is still not resolved.

**screenshot**
![no-affi](https://user-images.githubusercontent.com/44528277/109055337-56254600-76df-11eb-8277-fa33f3d78533.png)

![with-aff](https://user-images.githubusercontent.com/44528277/109055334-54f41900-76df-11eb-8589-a3c27224b3e3.png)

