### PR TITLE
records ui: add 404 page for permission and lookup errors

### DIFF
--- a/invenio_app_rdm/records_ui/views/__init__.py
+++ b/invenio_app_rdm/records_ui/views/__init__.py
@@ -10,16 +10,16 @@
 """Views related to records and deposits."""
 
 from flask import Blueprint
-from invenio_pidstore.errors import PIDDeletedError
+from invenio_pidstore.errors import PIDDeletedError, PIDDoesNotExistError
 from invenio_records_resources.services.errors import PermissionDeniedError
 
 from .deposits import deposit_create, deposit_edit, deposit_search
 from .filters import can_list_files, dereference_record, doi_identifier, \
     has_previewable_files, make_files_preview_compatible, order_entries, \
     pid_url, select_preview_file, to_previewer_files, vocabulary_title
-from .records import record_detail, record_export, record_file_download, \
-    record_file_preview, record_permission_denied_error, \
-    record_tombstone_error
+from .records import not_found_error, record_detail, record_export, \
+    record_file_download, record_file_preview, \
+    record_permission_denied_error, record_tombstone_error
 
 
 #
@@ -74,6 +74,8 @@ def create_blueprint(app):
 
     # Register error handlers
     blueprint.register_error_handler(PIDDeletedError, record_tombstone_error)
+    blueprint.register_error_handler(PIDDoesNotExistError, not_found_error)
+    blueprint.register_error_handler(KeyError, not_found_error)
     blueprint.register_error_handler(
         PermissionDeniedError, record_permission_denied_error)
 

--- a/invenio_app_rdm/records_ui/views/decorators.py
+++ b/invenio_app_rdm/records_ui/views/decorators.py
@@ -68,21 +68,16 @@ def pass_file_item(f):
     """Decorate a view to pass a file item using the files service."""
     @wraps(f)
     def view(**kwargs):
-        try:
-            pid_value = kwargs.get('pid_value')
-            file_key = kwargs.get('filename')
+        pid_value = kwargs.get('pid_value')
+        file_key = kwargs.get('filename')
 
-            item = files_service().get_file_content(
-                id_=pid_value,
-                file_key=file_key,
-                identity=g.identity,
-                links_config=links_config(),
-            )
-            kwargs['file_item'] = item
-
-        except (KeyError, PermissionDeniedError):
-            kwargs['file_item'] = None
-
+        item = files_service().get_file_content(
+            id_=pid_value,
+            file_key=file_key,
+            identity=g.identity,
+            links_config=links_config(),
+        )
+        kwargs['file_item'] = item
         return f(**kwargs)
     return view
 
@@ -91,20 +86,15 @@ def pass_file_metadata(f):
     """Decorate a view to pass a file's metadata using the files service."""
     @wraps(f)
     def view(**kwargs):
-        try:
-            pid_value = kwargs.get('pid_value')
-            file_key = kwargs.get('filename')
-            files = files_service().read_file_metadata(
-                id_=pid_value,
-                file_key=file_key,
-                identity=g.identity,
-                links_config=links_config(),
-            )
-            kwargs['file_metadata'] = files
-
-        except (KeyError, PermissionDeniedError):
-            kwargs['file_metadata'] = None
-
+        pid_value = kwargs.get('pid_value')
+        file_key = kwargs.get('filename')
+        files = files_service().read_file_metadata(
+            id_=pid_value,
+            file_key=file_key,
+            identity=g.identity,
+            links_config=links_config(),
+        )
+        kwargs['file_metadata'] = files
         return f(**kwargs)
     return view
 
@@ -121,6 +111,9 @@ def pass_record_files(f):
             kwargs['files'] = files
 
         except PermissionDeniedError:
+            # this is handled here because we don't want a 404 on the landing
+            # page when a user is allowed to read the metadata but not the
+            # files
             kwargs['files'] = None
 
         return f(**kwargs)

--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -111,9 +111,6 @@ def record_file_preview(
     **kwargs
 ):
     """Render a preview of the specified file."""
-    if not file_metadata:
-        abort(404)
-
     # Try to see if specific previewer is set
     # TODO: what's the analog of: file_previewer = fileobj.get("previewer") ?
     file_previewer = file_metadata.data.get("previewer")
@@ -136,9 +133,6 @@ def record_file_download(
     **kwargs
 ):
     """Download a file from a record."""
-    if file_item is None:
-        abort(404)
-
     download = bool(request.args.get("download"))
     return file_item.send_file(as_attachment=download)
 
@@ -146,6 +140,11 @@ def record_file_download(
 #
 # Error handlers
 #
+def not_found_error(error):
+    """Handler for 'Not Found' errors."""
+    return render_template(current_app.config['THEME_404_TEMPLATE']), 404
+
+
 def record_tombstone_error(error):
     """Tombstone page."""
     return render_template("invenio_app_rdm/records/tombstone.html"), 410


### PR DESCRIPTION
hide those nasty `PIDDoesNotExistError`s and `PermissionDeniedError`s with their even nastier stack traces behind something more appropriate for users