### PR TITLE
bugfix: licenses dialog description new line

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/deposit.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/deposit.less
@@ -109,6 +109,6 @@
 }
 
 /*Description*/
-.item .description {
+.item div.description:not(.license-item-description) {
   display: initial !important;
 }


### PR DESCRIPTION
fixed - ```Deposit form: License dialog shows description on same line as title (should be next line) - note this was likely due to the fix done for putting "read more" link on same line as description.```

![1of2](https://user-images.githubusercontent.com/44528277/109168320-fbdbc200-777e-11eb-96df-4b8b02a403cc.png)
![2of2](https://user-images.githubusercontent.com/44528277/109168328-fd0cef00-777e-11eb-9977-a4da707901f3.png)
