### PR TITLE
user-reords-search: fix styling on empty results

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_records_search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_records_search/components.js
@@ -23,6 +23,7 @@ import _get from "lodash/get";
 import _truncate from "lodash/truncate";
 import {
   Count,
+  EmptyResults,
   Pagination,
   ResultsList,
   Sort,
@@ -250,7 +251,9 @@ export const RDMRecordResultsGridItem = ({ result, index }) => {
 };
 
 export const RDMEmptyResults = (props) => {
-  return (
+  const queryString = props.queryString;
+  return queryString === "" ? (
+    <Segment.Group>
       <Segment placeholder textAlign="center" padded="very">
         <Header as="h1" align="center">
           <Header.Content>
@@ -270,6 +273,19 @@ export const RDMEmptyResults = (props) => {
           content="New upload"
         />
       </Segment>
+    </Segment.Group>
+  ) : (
+    <Segment placeholder textAlign="center">
+      <Header icon>
+        <Icon name="search" />
+        No results found!
+      </Header>
+      {queryString && <em>Current search "{queryString}"</em>}
+      <br />
+      <Button primary onClick={() => props.resetQuery()}>
+        Clear query
+      </Button>
+    </Segment>
   );
 };
 


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/625

<img width="1677" alt="Screenshot 2021-02-25 at 15 58 01" src="https://user-images.githubusercontent.com/22594783/109171832-6cd0a900-7782-11eb-980e-2c55e6b2b4e4.png">
<img width="843" alt="Screenshot 2021-02-25 at 15 58 11" src="https://user-images.githubusercontent.com/22594783/109171849-73f7b700-7782-11eb-8c0c-715209e63c6b.png">
