### PR TITLE
permissions: protect files-rest endpoints [+]

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -30,6 +30,9 @@ WARNING: An instance should NOT install multiple flavour extensions since
 
 from datetime import datetime, timedelta
 
+from flask_principal import Denial
+from invenio_access.permissions import any_user
+
 from .records_ui.utils import previewer_record_file_factory
 
 # PIDSTORE_RECID_FIELD
@@ -140,6 +143,19 @@ THEME_LOGO = 'images/invenio-rdm.svg'
 
 THEME_SITENAME = _('InvenioRDM')
 """Site name."""
+
+
+# Invenio-files-rest
+# ==================
+# See https://invenio-files-rest.readthedocs.io/en/latest/configuration.html
+
+def files_rest_permission_factory(obj, action):
+    """Generate a denying permission."""
+    return Denial(any_user)
+
+
+FILES_REST_PERMISSION_FACTORY = files_rest_permission_factory
+"""Set default files permission factory."""
 
 
 # Invenio-IIIF

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -16,3 +16,12 @@ from invenio_app.factory import create_api
 def create_app():
     """Create test app."""
     return create_api
+
+
+@pytest.fixture(scope='module')
+def headers():
+    """Return typical API headers."""
+    return {
+        "content-type": "application/json",
+        "accept": "application/json"
+    }

--- a/tests/api/test_protect_files_rest.py
+++ b/tests/api/test_protect_files_rest.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+# Copyright (C) 2021 Northwestern University.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test files-rest is protected."""
+
+from io import BytesIO
+
+
+def create_draft(client, record, headers):
+    """Create draft and return its id."""
+    response = client.post("/records", json=record, headers=headers)
+    assert response.status_code == 201
+    return response.json['id']
+
+
+def init_file(client, recid, headers):
+    """Init a file for draft with given recid."""
+    return client.post(
+        f'/records/{recid}/draft/files',
+        headers=headers,
+        json=[{'key': 'test.pdf'}]
+    )
+
+
+def upload_file(client, recid, headers):
+    """Create draft and return its id."""
+    return client.put(
+        f"/records/{recid}/draft/files/test.pdf/content",
+        headers={
+            'content-type': 'application/octet-stream',
+            'accept': 'application/json',
+        },
+        data=BytesIO(b'testfile'),
+    )
+
+
+def commit_file(client, recid, headers):
+    """Create draft and return its id."""
+    return client.post(
+        f"/records/{recid}/draft/files/test.pdf/commit",
+        headers=headers
+    )
+
+
+# NOTE: It seems like it was already the case that a logged in user wouldn't be
+#       able to access files-rest. We are just making doubly-clear.
+def test_files_rest_endpoint_is_protected(
+        app, client_with_login, headers, es_clear, location, minimal_record):
+    client = client_with_login
+
+    # Create draft with file
+    recid = create_draft(client, minimal_record, headers)
+    init_file(client, recid, headers)
+    upload_file(client, recid, headers)
+    commit_file(client, recid, headers)
+
+    # Get bucket information
+    url = f"/records/{recid}/draft/files/test.pdf"
+    response = client.get(url, headers=headers)
+    bucket_id = response.json["bucket_id"]
+
+    # Nobody is allowed to use the invenio-files-rest endpoints
+    # (even logged-in user). Just testing for the GET of each is enough
+
+    bucket_url = f"/files/{bucket_id}"
+    response = client.get(bucket_url, headers=headers)
+    assert 404 == response.status_code  # because of files-rest hiding feature
+
+    bucket_key_url = f"/files/{bucket_id}/test.pdf"
+    response = client.get(bucket_key_url, headers=headers)
+    assert 404 == response.status_code


### PR DESCRIPTION
- closes #577 
- Clearly they are protected, but not overriding the permission
factory leads to the same thing, so tests are not really convincing...