### PR TITLE
New Version available/button

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -19,6 +19,13 @@
 
 {%- block page_body %}
 <div class="banners">
+  {% if permissions is defined and permissions.can_update_draft %}
+  <div class="ui warning flashed top-attached manage message">
+    <div class="ui container">
+      <div id="recordManagement" data-recid='{{ record["id"] | tojson }}' data-permissions='{{ permissions | tojson }}'></div>
+    </div>
+  </div>
+  {% endif %}
   {% if newer_version_exists %}
   <div class="ui warning flashed top-attached manage message">
     <div class="ui container">
@@ -33,13 +40,6 @@
           </div>
         </div>
       </div>
-    </div>
-  </div>
-  {% endif %}
-  {% if permissions is defined and permissions.can_update_draft %}
-  <div class="ui warning flashed top-attached manage message">
-    <div class="ui container">
-      <div id="recordManagement" data-recid='{{ record["id"] | tojson }}' data-permissions='{{ permissions | tojson }}'></div>
     </div>
   </div>
   {% endif %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -1,6 +1,6 @@
 {#
   Copyright (C) 2020-2021 CERN.
-  Copyright (C) 2020 Northwestern University.
+  Copyright (C) 2020-2021 Northwestern University.
   Copyright (C) 2021 TU Wien.
   Copyright (C) 2021 Graz University of Technology.
 
@@ -15,14 +15,37 @@
 
 {%- set title = record.metadata.title -%}
 {%- set metadata = record.metadata %}
+{%- set newer_version_exists = True %}
 
 {%- block page_body %}
-{% if permissions is defined and permissions.can_update_draft %}
-  <div
-    id="recordManagement"
-    data-recid='{{ record["id"] | tojson }}'>
+<div class="banners">
+  {% if newer_version_exists %}
+  <div class="ui warning flashed top-attached manage message">
+    <div class="ui container">
+      <div class="ui relaxed grid">
+        <div class="column">
+          <div class="row">
+            <p>
+            {% trans link_start=('<a href="/records/' + record.id + '/latest"><b>')|safe, link_end='</b></a>'|safe %}
+            There is a {{ link_start }}newer version{{ link_end }} of the record available.
+            {% endtrans %}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-{% endif %}
+  {% endif %}
+  {% if permissions is defined and permissions.can_update_draft %}
+  <div class="ui warning flashed top-attached manage message">
+    <div class="ui container">
+      <div id="recordManagement" data-recid='{{ record["id"] | tojson }}'></div>
+    </div>
+  </div>
+  {% endif %}
+</div>
+
+
 <div class="ui container">
   <div class="ui relaxed grid">
     <div class="two column row top-padded">

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -39,7 +39,7 @@
   {% if permissions is defined and permissions.can_update_draft %}
   <div class="ui warning flashed top-attached manage message">
     <div class="ui container">
-      <div id="recordManagement" data-recid='{{ record["id"] | tojson }}'></div>
+      <div id="recordManagement" data-recid='{{ record["id"] | tojson }}' data-permissions='{{ permissions | tojson }}'></div>
     </div>
   </div>
   {% endif %}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/EditButton.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/EditButton.js
@@ -1,0 +1,35 @@
+// This file is part of InvenioRDM
+// Copyright (C) 2021 Northwestern University.
+//
+// Invenio RDM Records is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React, { useState } from "react";
+import axios from "axios";
+import { Icon, Button } from "semantic-ui-react";
+
+
+export const EditButton = (props) => {
+  const [loading, setLoading] = useState(false)
+  const recid = props.recid;
+  const handleError = props.onError;
+  const handleClick = () => {
+    setLoading(true);
+    axios
+    .post(`/api/records/${recid}/draft`)
+    .then((response) => {
+      window.location = `/uploads/${recid}`;
+    })
+    .catch((error) => {
+      setLoading(false);
+      handleError(error.response.data.message);
+    });
+  };
+
+  return (
+    <Button color="orange" size="mini" onClick={handleClick} loading={loading}>
+      <Icon name="edit" />
+      Edit
+    </Button>
+  );
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/NewVersionButton.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/NewVersionButton.js
@@ -8,27 +8,26 @@ import React, { useState } from "react";
 import axios from "axios";
 import { Icon, Button } from "semantic-ui-react";
 
-
 export const NewVersionButton = (props) => {
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(false);
   const recid = props.recid;
   const handleError = props.onError;
   const handleClick = () => {
     setLoading(true);
     axios
-    .post(`/api/records/${recid}/versions`)
-    .then((response) => {
-      const new_version_recid = response.data.id;
-      window.location = `/uploads/${new_version_recid}`;
-    })
-    .catch((error) => {
-      setLoading(false);
-      handleError(error.response.data.message);
-    });
+      .post(`/api/records/${recid}/versions`)
+      .then((response) => {
+        const new_version_recid = response.data.id;
+        window.location = `/uploads/${new_version_recid}`;
+      })
+      .catch((error) => {
+        setLoading(false);
+        handleError(error.response.data.message);
+      });
   };
 
   return (
-    <Button color="orange" size="mini" onClick={handleClick} loading={loading}>
+    <Button color="green" size="mini" onClick={handleClick} loading={loading}>
       <Icon name="tag" />
       New Version
     </Button>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/NewVersionButton.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/NewVersionButton.js
@@ -1,0 +1,36 @@
+// This file is part of InvenioRDM
+// Copyright (C) 2021 Northwestern University.
+//
+// Invenio RDM Records is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React, { useState } from "react";
+import axios from "axios";
+import { Icon, Button } from "semantic-ui-react";
+
+
+export const NewVersionButton = (props) => {
+  const [loading, setLoading] = useState(false)
+  const recid = props.recid;
+  const handleError = props.onError;
+  const handleClick = () => {
+    setLoading(true);
+    axios
+    .post(`/api/records/${recid}/versions`)
+    .then((response) => {
+      const new_version_recid = response.data.id;
+      window.location = `/uploads/${new_version_recid}`;
+    })
+    .catch((error) => {
+      setLoading(false);
+      handleError(error.response.data.message);
+    });
+  };
+
+  return (
+    <Button color="orange" size="mini" onClick={handleClick} loading={loading}>
+      <Icon name="tag" />
+      New Version
+    </Button>
+  );
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
@@ -12,36 +12,37 @@ import ReactDOM from "react-dom";
 
 import { RecordManagement } from "./recordManagement";
 
-if (document.getElementById("recordManagement")) {
+
+const reactAppDiv = document.getElementById("recordManagement");
+
+if (reactAppDiv) {
   ReactDOM.render(
-    <RecordManagement />,
-    document.getElementById("recordManagement")
+    <RecordManagement recid={ JSON.parse(reactAppDiv.dataset.recid) } />,
+    reactAppDiv
   );
-
-  $(document).ready(function () {
-    $(".ui.accordion").accordion();
-
-    $("#record-doi-badge").click(function () {
-      $("#doi-modal").modal("show");
-    });
-
-    $(".ui.tooltip-popup").popup();
-  });
-
-  $(".preview-link").on("click", function (event) {
-    $("#preview")
-      .find(".title .filename")
-      .html($(event.target).data("fileKey"));
-    $("#preview").accordion("open", 0);
-    $("#preview-iframe").attr("src", $(event.target).data("url"));
-  });
-
-  $("#jump-btn").on("click", function (event) {
-    document.documentElement.scrollTop = 0;
-  });
-
-  // func to toggle the icon class
-  $(".panel-heading").click(function () {
-    $("i", this).toggleClass("down right");
-  });
 }
+
+$(".ui.accordion").accordion();
+
+$("#record-doi-badge").click(function () {
+  $("#doi-modal").modal("show");
+});
+
+$(".ui.tooltip-popup").popup();
+
+$(".preview-link").on("click", function (event) {
+  $("#preview")
+    .find(".title .filename")
+    .html($(event.target).data("fileKey"));
+  $("#preview").accordion("open", 0);
+  $("#preview-iframe").attr("src", $(event.target).data("url"));
+});
+
+$("#jump-btn").on("click", function (event) {
+  document.documentElement.scrollTop = 0;
+});
+
+// func to toggle the icon class
+$(".panel-heading").click(function () {
+  $("i", this).toggleClass("down right");
+});

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
@@ -17,7 +17,9 @@ const reactAppDiv = document.getElementById("recordManagement");
 
 if (reactAppDiv) {
   ReactDOM.render(
-    <RecordManagement recid={ JSON.parse(reactAppDiv.dataset.recid) } />,
+    <RecordManagement
+      recid={ JSON.parse(reactAppDiv.dataset.recid) }
+      permissions={ JSON.parse(reactAppDiv.dataset.permissions) } />,
     reactAppDiv
   );
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/recordManagement.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/recordManagement.js
@@ -26,23 +26,19 @@ export const RecordManagement = () => {
   };
 
   return (
-    <div className="ui warning flashed top-attached manage message">
-      <div className="ui container">
-        <Grid relaxed>
-          <Grid.Column>
-            <Grid.Row>
-              <Icon name="cogs" />
-              <span>Manage</span>
-            </Grid.Row>
-            <Grid.Row className="record-management-buttons">
-              <Button color="orange" size="mini" onClick={() => editRecord()}>
-                <Icon name="edit" />
-                Edit
-              </Button>
-            </Grid.Row>
-          </Grid.Column>
-        </Grid>
-      </div>
-    </div>
+    <Grid relaxed>
+      <Grid.Column>
+        <Grid.Row>
+          <Icon name="cogs" />
+          <span>Manage</span>
+        </Grid.Row>
+        <Grid.Row className="record-management-buttons">
+          <Button color="orange" size="mini" onClick={() => editRecord()}>
+            <Icon name="edit" />
+            Edit
+          </Button>
+        </Grid.Row>
+      </Grid.Column>
+    </Grid>
   );
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/recordManagement.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/recordManagement.js
@@ -10,11 +10,10 @@ import React from "react";
 import axios from "axios";
 import { Grid, Icon, Button } from "semantic-ui-react";
 
-const domContainer = document.getElementById("recordManagement");
 
-export const RecordManagement = () => {
-  const recid = JSON.parse(domContainer.dataset.recid);
-  var editRecord = () => {
+export const RecordManagement = (props) => {
+  const recid = props.recid;
+  const editRecord = () => {
     axios
       .post(`/api/records/${recid}/draft`)
       .then((response) => {

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/recordManagement.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/recordManagement.js
@@ -7,9 +7,9 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import React, { useState } from "react";
-import axios from "axios";
-import { Grid, Icon, Button } from "semantic-ui-react";
+import { Grid, Icon } from "semantic-ui-react";
 
+import { EditButton } from "./EditButton";
 import { NewVersionButton } from "./NewVersionButton";
 
 
@@ -17,16 +17,6 @@ export const RecordManagement = (props) => {
   const recid = props.recid;
   const permissions = props.permissions;
   const [error, setError] = useState("");
-  const editRecord = () => {
-    axios
-      .post(`/api/records/${recid}/draft`)
-      .then((response) => {
-        window.location = `/uploads/${recid}`;
-      })
-      .catch((error) => {
-        console.log(error.response.data);
-      });
-  };
   const handleError = (errorMessage) => {
     console.log(errorMessage);
     setError(errorMessage);
@@ -39,15 +29,12 @@ export const RecordManagement = (props) => {
           <Icon name="cogs" />
           <span>Manage</span>
         </Grid.Row>
-        <Grid.Row className="record-management-buttons">
-          <Button color="orange" size="mini" onClick={() => editRecord()}>
-            <Icon name="edit" />
-            Edit
-          </Button>
+        <Grid.Row className="record-management-row">
+          { permissions.can_update_draft && <EditButton recid={recid} onError={handleError} /> }
           { permissions.can_manage && <NewVersionButton recid={recid} onError={handleError} /> }
         </Grid.Row>
         { error &&
-        <Grid.Row className="record-management-buttons">
+        <Grid.Row className="record-management-row">
           <p>{error}</p>
         </Grid.Row>
         }

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/recordManagement.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/recordManagement.js
@@ -6,13 +6,17 @@
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import React from "react";
+import React, { useState } from "react";
 import axios from "axios";
 import { Grid, Icon, Button } from "semantic-ui-react";
+
+import { NewVersionButton } from "./NewVersionButton";
 
 
 export const RecordManagement = (props) => {
   const recid = props.recid;
+  const permissions = props.permissions;
+  const [error, setError] = useState("");
   const editRecord = () => {
     axios
       .post(`/api/records/${recid}/draft`)
@@ -23,6 +27,10 @@ export const RecordManagement = (props) => {
         console.log(error.response.data);
       });
   };
+  const handleError = (errorMessage) => {
+    console.log(errorMessage);
+    setError(errorMessage);
+  }
 
   return (
     <Grid relaxed>
@@ -36,7 +44,13 @@ export const RecordManagement = (props) => {
             <Icon name="edit" />
             Edit
           </Button>
+          { permissions.can_manage && <NewVersionButton recid={recid} onError={handleError} /> }
         </Grid.Row>
+        { error &&
+        <Grid.Row className="record-management-buttons">
+          <p>{error}</p>
+        </Grid.Row>
+        }
       </Grid.Column>
     </Grid>
   );

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -116,7 +116,7 @@
    display: none;
  }
 
- .record-management-buttons{
+ .record-management-row{
      margin-top:10px;
 
      button {


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/683
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/684
- reduce DOM calls
- fix jump button bug (and others) by making semantic ui
  javascript independent of presence of recordManagement
  div (which could be absent if viewer is not owner)

Banner with newer version available, New Version button and error response displayed.

![banner_w_error](https://user-images.githubusercontent.com/1932651/110861274-8c3bfb80-8283-11eb-909d-c11151acd42e.png)

NOTE: 
- Because check on `can_manage` permission is done and this permission is not provided, the New Version Button will not show up by default for now.
- On the other hand, the "newer_version_exists" test has been set to True so that the "Newer version available" banner is always shown for now.