### PR TITLE
run-tests: forward supplied options and arguments to pytest

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,9 +3,20 @@
 #
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2021 TU Wien.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
+
+# Usage:
+#   ./run-tests.sh [pytest options and args...]
+#
+# Note: the DB, SEARCH and CACHE services to use are determined by corresponding environment
+#       variables if they are set -- otherwise, the following defaults are used:
+#       DB=postgresql, SEARCH=elasticsearch and CACHE=redis
+#
+# Example for using mysql instead of postgresql:
+#    DB=mysql ./run-tests.sh
 
 # Quit on errors
 set -o errexit
@@ -19,11 +30,10 @@ function cleanup() {
 }
 trap cleanup EXIT
 
-
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --cache ${CACHE:-redis} --env)"
-python -m pytest
+python -m pytest $@
 tests_exit_code=$?
 python -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest
 exit "$tests_exit_code"


### PR DESCRIPTION
closes #675 
since the main goal of `run-tests.sh` is to call `pytest`, i think it makes sense to just forward the given CLI options/arguments to the `pytest` call

this enables running the tests in specific files (e.g. `./run-tests.sh tests/test_version.py`), as well as selecting tests on a pattern-matching basis (e.g. `./run-tests -k test_set_default_value__value`), etc.