### PR TITLE
landing-page: share record access link modal

### DIFF
--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -67,7 +67,8 @@ def record_detail(record=None, files=None, pid_value=None):
         record=UIJSONSerializer().serialize_object_to_dict(record.to_dict()),
         pid=pid_value,
         files=files_dict,
-        permissions=record.has_permissions_to(['edit', 'new_version']),
+        permissions=record.has_permissions_to(['edit', 'new_version', 'manage',
+                                               'update_draft']),
     )
 
 

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
@@ -10,6 +10,7 @@ import React, { useState } from "react";
 import { Grid, Icon } from "semantic-ui-react";
 
 import { EditButton } from "./EditButton";
+import { ShareButton } from "./ShareButton";
 import { NewVersionButton } from "react-invenio-deposit";
 
 export const RecordManagement = (props) => {
@@ -23,7 +24,7 @@ export const RecordManagement = (props) => {
   };
 
   return (
-    <Grid relaxed>
+    <Grid relaxed columns={2}>
       <Grid.Column>
         <Grid.Row>
           <Icon name="cogs" />
@@ -43,6 +44,11 @@ export const RecordManagement = (props) => {
           </Grid.Row>
         )}
       </Grid.Column>
+      {permissions.can_manage && (
+        <Grid.Column floated="right" width={2}>
+          <ShareButton disabled={!permissions.can_update_draft} />
+        </Grid.Column>
+      )}
     </Grid>
   );
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
@@ -46,7 +46,7 @@ export const RecordManagement = (props) => {
       </Grid.Column>
       {permissions.can_manage && (
         <Grid.Column floated="right" width={2}>
-          <ShareButton disabled={!permissions.can_update_draft} />
+          <ShareButton disabled={!permissions.can_update_draft} recid={recid} />
         </Grid.Column>
       )}
     </Grid>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareButton.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareButton.js
@@ -1,0 +1,25 @@
+// This file is part of InvenioRDM
+// Copyright (C) 2021 Northwestern University.
+//
+// Invenio RDM Records is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React from "react";
+import { Icon, Button, Popup } from "semantic-ui-react";
+
+export const ShareButton = (props) => {
+  return (
+    <Popup
+      content="You don't have permissions to share this record."
+      disabled={!props.disabled}
+      trigger={
+        <div>
+          <Button disabled={props.disabled} primary size="mini">
+            <Icon name="share square" />
+            Share
+          </Button>
+        </div>
+      }
+    />
+  );
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareButton.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareButton.js
@@ -4,22 +4,35 @@
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import React from "react";
+import React, { useState } from "react";
 import { Icon, Button, Popup } from "semantic-ui-react";
+import { ShareModal } from "./ShareModal";
 
 export const ShareButton = (props) => {
+  const [modalOpen, setModalOpen] = useState(false);
+  const handleOpen = () => setModalOpen(true);
+  const handleClose = () => setModalOpen(false);
+
   return (
-    <Popup
-      content="You don't have permissions to share this record."
-      disabled={!props.disabled}
-      trigger={
-        <div>
-          <Button disabled={props.disabled} primary size="mini">
-            <Icon name="share square" />
-            Share
-          </Button>
-        </div>
-      }
-    />
+    <>
+      <Popup
+        content="You don't have permissions to share this record."
+        disabled={!props.disabled}
+        trigger={
+          <div>
+            <Button
+              onClick={handleOpen}
+              disabled={props.disabled}
+              primary
+              size="mini"
+            >
+              <Icon name="share square" />
+              Share
+            </Button>
+          </div>
+        }
+      />
+      <ShareModal open={modalOpen} handleClose={handleClose} />
+    </>
   );
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareButton.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareButton.js
@@ -1,4 +1,5 @@
 // This file is part of InvenioRDM
+// Copyright (C) 2021 CERN.
 // Copyright (C) 2021 Northwestern University.
 //
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
@@ -32,7 +33,11 @@ export const ShareButton = (props) => {
           </div>
         }
       />
-      <ShareModal open={modalOpen} handleClose={handleClose} />
+      <ShareModal
+        open={modalOpen}
+        handleClose={handleClose}
+        recid={props.recid}
+      />
     </>
   );
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareModal.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareModal.js
@@ -4,21 +4,21 @@
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Dropdown, Icon, Input, Button, Modal } from "semantic-ui-react";
+import axios from "axios";
 
 export const ShareModal = (props) => {
-  const [link, setLink] = useState("");
-  const [shareMode, setShareMode] = useState("view");
+  const [accessLinkObj, setAccessLinkObj] = useState();
+  const [shareMode, setShareMode] = useState("read");
 
-  const handleChangeMode = (e, { value }) => setShareMode(value);
-  const options = [
-    { key: "view", text: "Can view", value: "view" },
+  const dropdownOptions = [
+    { key: "read", text: "Can view", value: "read" },
     { key: "edit", text: "Can edit", value: "edit" },
   ];
 
   const message = {
-    view: (
+    read: (
       <span>
         Anyone on the Internet with this link{" "}
         <strong>can view all versions</strong> of this record & files.
@@ -32,6 +32,92 @@ export const ShareModal = (props) => {
     ),
   };
 
+  const getAccessLink = (linkObj) =>
+    linkObj ? `${window.location}?token=${linkObj.token}` : "";
+
+  const updateAccessLink = async () => {
+    await axios.patch(
+      `/api/records/${props.recid}/access/links/${accessLinkObj.id}`,
+      {
+        permission: shareMode,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        withCredentials: true,
+      }
+    );
+  };
+
+  const createAccessLink = async () => {
+    await axios
+      .post(
+        `/api/records/${props.recid}/access/links`,
+        { permission: shareMode },
+        {
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          withCredentials: true,
+        }
+      )
+      .then((resp) => {
+        setAccessLinkObj(resp.data);
+      });
+  };
+
+  const copyAccessLink = () => {
+    const copyText = document.querySelector("#input");
+    copyText.select();
+    document.execCommand("copy");
+  };
+
+  const handleChangeMode = (e, { value }) => setShareMode(value);
+
+  const handleDelete = async () => {
+    await axios
+      .delete(`/api/records/${props.recid}/access/links/${accessLinkObj.id}`, {
+        headers: {
+          Accept: "application/json",
+        },
+        withCredentials: true,
+      })
+      .then(() => {
+        setAccessLinkObj();
+      });
+  };
+
+  useEffect(() => {
+    if (!!accessLinkObj) {
+      updateAccessLink();
+    }
+  }, [shareMode]);
+
+  useEffect(() => {
+    if (!!accessLinkObj) {
+      setShareMode(accessLinkObj.permission);
+    }
+  }, [accessLinkObj]);
+
+  useEffect(() => {
+    async function fetchAccessLink() {
+      const result = await axios(`/api/records/${props.recid}/access/links`, {
+        headers: {
+          Accept: "application/json",
+        },
+        withCredentials: true,
+      });
+      const { hits, total } = result.data.hits;
+      if (total > 0) {
+        // Only accessing first access link for MVP.
+        setAccessLinkObj(hits[0]);
+      }
+    }
+    fetchAccessLink();
+  }, []);
+
   return (
     <Modal
       open={props.open}
@@ -44,32 +130,42 @@ export const ShareModal = (props) => {
       </Modal.Header>
       <Modal.Content>
         <div className="share-content">
-          <Input value={link} disabled />
+          <Input id="input" value={getAccessLink(accessLinkObj)} readOnly />
           <Dropdown
             className="ui small"
             size="small"
             button
-            options={options}
+            options={dropdownOptions}
             defaultValue={shareMode}
             onChange={handleChangeMode}
           />
-          <Button size="small" icon>
+          <Button
+            size="small"
+            onClick={accessLinkObj ? copyAccessLink : createAccessLink}
+            icon
+          >
             <Icon name="copy outline" />
-            {link ? "Copy link" : "Get a link"}
+            {accessLinkObj ? "Copy link" : "Get a link"}
           </Button>
         </div>
         <Modal.Description>
-          <p>
+          <p className="share-description">
             <Icon name="warning circle" />
-            {!!!link
+            {!!!accessLinkObj
               ? 'No link has been created. Click on "Get a Link" to make a new link'
               : message[shareMode]}
           </p>
         </Modal.Description>
       </Modal.Content>
       <Modal.Actions>
-        {!!link && (
-          <Button size="small" color="red" floated="left" icon>
+        {!!accessLinkObj && (
+          <Button
+            size="small"
+            color="red"
+            floated="left"
+            onClick={handleDelete}
+            icon
+          >
             <Icon name="trash alternate outline" />
             Delete link
           </Button>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareModal.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareModal.js
@@ -1,0 +1,83 @@
+// This file is part of InvenioRDM
+// Copyright (C) 2021 Northwestern University.
+//
+// Invenio RDM Records is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React, { useState } from "react";
+import { Dropdown, Icon, Input, Button, Modal } from "semantic-ui-react";
+
+export const ShareModal = (props) => {
+  const [link, setLink] = useState("");
+  const [shareMode, setShareMode] = useState("view");
+
+  const handleChangeMode = (e, { value }) => setShareMode(value);
+  const options = [
+    { key: "view", text: "Can view", value: "view" },
+    { key: "edit", text: "Can edit", value: "edit" },
+  ];
+
+  const message = {
+    view: (
+      <span>
+        Anyone on the Internet with this link{" "}
+        <strong>can view all versions</strong> of this record & files.
+      </span>
+    ),
+    edit: (
+      <span>
+        Anyone with an account and this link{" "}
+        <strong>can edit all versions</strong> of this record & files.
+      </span>
+    ),
+  };
+
+  return (
+    <Modal
+      open={props.open}
+      onClose={props.handleClose}
+      className="share-modal"
+    >
+      <Modal.Header>
+        <Icon name="share alternate" />
+        Get a link
+      </Modal.Header>
+      <Modal.Content>
+        <div className="share-content">
+          <Input value={link} disabled />
+          <Dropdown
+            className="ui small"
+            size="small"
+            button
+            options={options}
+            defaultValue={shareMode}
+            onChange={handleChangeMode}
+          />
+          <Button size="small" icon>
+            <Icon name="copy outline" />
+            {link ? "Copy link" : "Get a link"}
+          </Button>
+        </div>
+        <Modal.Description>
+          <p>
+            <Icon name="warning circle" />
+            {!!!link
+              ? 'No link has been created. Click on "Get a Link" to make a new link'
+              : message[shareMode]}
+          </p>
+        </Modal.Description>
+      </Modal.Content>
+      <Modal.Actions>
+        {!!link && (
+          <Button size="small" color="red" floated="left" icon>
+            <Icon name="trash alternate outline" />
+            Delete link
+          </Button>
+        )}
+        <Button size="small" onClick={props.handleClose}>
+          Done
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -163,4 +163,8 @@
             padding-right: 0.5em;
         }
     }
+
+    .share-description {
+        margin: 1em auto;
+    }
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -153,3 +153,14 @@
          padding-top: 0px !important;
      }
  }
+
+.share-modal {
+    .share-content {
+        display: flex;
+
+        .input {
+            flex-grow: 1;
+            padding-right: 0.5em;
+        }
+    }
+}


### PR DESCRIPTION
closes #703

![image](https://user-images.githubusercontent.com/8863238/113273870-5bc50b80-92dd-11eb-9b26-6937aeecdc50.png)

#### To test

- Create a record
- As creator, you should be able to see the Share button
- Create an access link
- Visit `https://127.0.0.1:5000/api/records/<recid>/access/links` (API) to check if the access link has been created properly with the right permission
- Edit share mode (permission) and verify in the API.
- Delete link and verify in the API.

#### TBD

- One record can have multiple links (1:n), how should the UI reflect this? So far only accessing the element 0 of the list (emulating a 1:1 relationship).
  - > Only one link initially......later we may have more.....
- The generated access links are the same for all the users? No reference to users when creating access links.