### PR TITLE
search: Add defaultSortingOnEmptyQueryString in search config

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/search.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/search.html
@@ -70,6 +70,9 @@
     }
   },
   "sortOrderDisabled": true,
+  "defaultSortingOnEmptyQueryString": {
+    "sortBy": "newest"
+  },
   "sortOptions": [
     {
       "sortBy": "bestmatch",


### PR DESCRIPTION


https://user-images.githubusercontent.com/24358501/112958168-7ca52980-9142-11eb-9ec9-ef1db2d87ae4.mov

closes #658 

- Add `defaultSortingOnEmptyQueryString` in search config
- Change the default sorting to newest in case the query string is left empty