### PR TITLE
records: change JSONSchema resolution

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -342,12 +342,9 @@ See https://docs.sqlalchemy.org/en/latest/core/engines.html.
 DB_VERSIONING_USER_MODEL = None
 
 
-# Invenio-JSONSchemas
-# ===================
+# Invenio-JSONSchemas/Invenio-Records
+# ===================================
 # See https://invenio-jsonschemas.readthedocs.io/en/latest/configuration.html
-
-JSONSCHEMAS_HOST = 'localhost'
-"""Hostname used in URLs for local JSONSchemas."""
 
 JSONSCHEMAS_REGISTER_ENDPOINTS_API = False
 """Don't' register schema endpoints."""
@@ -355,6 +352,26 @@ JSONSCHEMAS_REGISTER_ENDPOINTS_API = False
 JSONSCHEMAS_REGISTER_ENDPOINTS_UI = False
 """Don't' register schema endpoints."""
 
+JSONSCHEMAS_HOST = 'unused'
+# This variable is set to something different than localhost to avoid a warning
+# being issued. The value is however not used, because of the two variables
+# set below.
+
+RECORDS_REFRESOLVER_CLS = "invenio_records.resolver.InvenioRefResolver"
+"""Custom JSONSchemas ref resolver class.
+
+Note that when using a custom ref resolver class you should also set
+``RECORDS_REFRESOLVER_STORE`` to point to a JSONSchema ref resolver store.
+"""
+
+RECORDS_REFRESOLVER_STORE = (
+    "invenio_jsonschemas.proxies.current_refresolver_store"
+)
+"""JSONSchemas ref resolver store.
+
+Used together with ``RECORDS_REFRESOLVER_CLS`` to provide a specific
+ref resolver store.
+"""
 
 # OAI-PMH
 # =======

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ for name, reqs in extras_require.items():
 install_requires = [
     'CairoSVG>=1.0.20',
     f'invenio[base,auth,metadata,files]{invenio_version}',
-    'invenio-rdm-records>=0.29.2,<0.30.0',
+    'invenio-rdm-records>=0.29.4,<0.30.0',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Changes local reference resolution from `https://localhost/schema`
  to `local://` (closes inveniosoftware/invenio-rdm-records#356).

### Test

1. Checkout locally:
    - https://github.com/inveniosoftware/invenio-rdm-records/pull/492
    - https://github.com/inveniosoftware/invenio-vocabularies/pull/31
2. Create and run a new Invenio RDM instance
    ```
    $ invenio-cli init rdm -c master
    $ cd my-site
    ~/my-site/ $ invenio-cli install
    ~/my-site/ $ invenio-cli packages install ../invenio-rdm-records ../invenio-vocabularies ../invenio-app-rdm
    ~/my-site/ $ invenio-cli services setup
    ~/my-site/ $ invenio-cli run
    ```

    Working locally ✅