### PR TITLE
global: access status label on search and landing pages

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -87,9 +87,10 @@
             </div>
             <div class="right floated right aligned column">
               <span class="ui label small grey">{{ record.ui.resource_type }}</span>
-              <!--TODO: Re-enable in next releases-->
-              <!-- <span class="ui label small access-right {{ 'unlock' }}">
-                <i class="icon {{ 'unlock' }}"></i>{{ _("Open Access") }}</span> -->
+              <span class="ui label small access-status {{ record.ui.access_status.id }}" data-tooltip="{{ record.ui.access_status.description_l10n }}" data-inverted="">
+                {% if record.ui.access_status.icon %}<i class="icon {{ record.ui.access_status.icon }}"></i>{% endif %}
+                {{ record.ui.access_status.title_l10n }}
+              </span>
             </div>
           </div>
         </div>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/search.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/search.html
@@ -18,7 +18,7 @@
   "aggs": [
     {
       "aggName": "access_status",
-      "field": "access_status",
+      "field": "access.status",
       "title": "Access status"
     },
     {

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/search.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/search.html
@@ -17,6 +17,11 @@
 <div data-invenio-search-config='{
   "aggs": [
     {
+      "aggName": "access_status",
+      "field": "access_status",
+      "title": "Access status"
+    },
+    {
       "aggName": "resource_type",
       "field": "resource_type.type",
       "title": "Resource Type",

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -26,14 +26,9 @@ import Overridable from "react-overridable";
 import { SearchBar } from "@js/invenio_search_ui/components";
 
 export const RDMRecordResultsListItem = ({ result, index }) => {
-  // TODO: Enable Access_Right badge
-  // const access = _get(result, "ui.access_right.title", "Open Access");
-  // const access_right_category = _get(
-  //   result,
-  //   "ui.access_right.category",
-  //   "open"
-  // );
-  // const access_right_icon = _get(result, "ui.access_right.icon", "open");
+  const access_status_id = _get(result, "ui.access_status.id", "open");
+  const access_status = _get(result, "ui.access_status.title_l10n", "Open");
+  const access_status_icon = _get(result, "ui.access_status.icon", "unlock");
   const createdDate = _get(
     result,
     "ui.created_date_l10n_long",
@@ -70,15 +65,12 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
           <Label size="tiny" color="grey">
             {resource_type}
           </Label>
-          {/* temporary: February release removal
-                TODO: Re-enable in next releases*/}
-          {/* <Label
-              size="tiny"
-              className={`access-right ${access_right_category}`}
-            >
-              <i className={`icon tiny ${access_right_icon}`}></i>
-              {access}
-            </Label> */}
+          <Label size="tiny" className={`access-status ${access_status_id}`}>
+            {access_status_icon && (
+              <i className={`icon ${access_status_icon}`}></i>
+            )}
+            {access_status}
+          </Label>
           <Button compact size="small" floated="right">
             <Icon name="eye" />
             View

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_records_search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_records_search/components.js
@@ -147,14 +147,9 @@ export const RDMDepositResults = ({
 };
 
 export const RDMRecordResultsListItem = ({ result, index }) => {
-  // TODO: Enable Access Right badge
-  // const access = _get(result, "ui.access_right.title", "Open Access");
-  // const access_right_category = _get(
-  //   result,
-  //   "ui.access_right.category",
-  //   "open"
-  // );
-  // const access_right_icon = _get(result, "ui.access_right.icon", "open");
+  const access_status_id = _get(result, "ui.access_status.id", "open");
+  const access_status = _get(result, "ui.access_status.title_l10n", "Open");
+  const access_status_icon = _get(result, "ui.access_status.icon", "unlock");
   const createdDate = _get(
     result,
     "ui.created_date_l10n_long",
@@ -215,15 +210,12 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
           <Label size="tiny" color="grey">
             {resource_type}
           </Label>
-          {/* temporary: February release removal
-                TODO: Re-enable in next releases*/}
-          {/* <Label
-              size="tiny"
-              className={`access-right ${access_right_category}`}
-            >
-              <i className={`icon tiny ${access_right_icon}`}></i>
-              {access}
-            </Label> */}
+          <Label size="tiny" className={`access-status ${access_status_id}`}>
+            {access_status_icon && (
+              <i className={`icon ${access_status_icon}`}></i>
+            )}
+            {access_status}
+          </Label>
           <Button
             compact
             size="small"

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
@@ -299,11 +299,11 @@ body {
   margin-bottom: 0.75em;
 }
 
-.ui.label.access-right {
+.ui.label.access-status {
   color: #FFFFFF;
 
   &.open {
-      background-color: @accessRightOpen;
+    background-color: @accessRightOpen;
   }
   &.restricted {
     background-color: @accessRightRestricted;
@@ -311,8 +311,8 @@ body {
   &.embargoed {
     background-color: @accessRightEmbargoed;
   }
-  &.closed {
-    background-color: @accessRightClosed;
+  &.metadata-only {
+    background-color: @accessRightMetadataOnly;
   }
 }
 

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
@@ -17,9 +17,9 @@
 @coverPageDefaultMargin: 0;
 
 @accessRightOpen: @green;
-@accessRightRestricted: @yellow;
-@accessRightEmbargoed: @red;
-@accessRightClosed: @red;
+@accessRightRestricted: @red;
+@accessRightEmbargoed: @yellow;
+@accessRightMetadataOnly: @red;
 
 @footerLightColor: #0377cd;
 @footerDarkColor: #0047a8;


### PR DESCRIPTION
* Includes search results, user search results, and record landing pages.

Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/667.


Depends on:
- https://github.com/inveniosoftware/invenio-rdm-records/pull/499 (backend implementation)
- https://github.com/inveniosoftware/invenio-records/pull/252 (adds needed hooks to record base api)
- https://github.com/inveniosoftware/invenio-records-resources/pull/233 (adds access status to service schema dump so it is accessible in the UI serialisers)

**Status**
Mostly done see screen recordings.


https://user-images.githubusercontent.com/9035606/114845595-30154b80-9ddc-11eb-9459-02e62861510b.mov


https://user-images.githubusercontent.com/9035606/114845605-33103c00-9ddc-11eb-8d9b-1d5db57e09bd.mov



**Missing**

- Move `AccessStatusEnum` to a more suitable location
    - moving it to `records/api.py` made more sense so we expose it in the record module's external api, however, this doesn't work because there is a circular import (fields are imported in `api.py`).