### PR TITLE
Fix header break with long email

### DIFF
--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header_login.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header_login.html
@@ -25,7 +25,7 @@
     {# Quick-create ("plus") menu #}
     {%- set plus_menu_items = current_menu.submenu('plus').children %}
     {%- if plus_menu_items %}
-      <div class="rdm-plus-menu ui dropdown floating">
+      <div class="rdm-plus-menu ui dropdown floating" style="position: absolute;margin-top: 5px;">
         <i class="fitted plus icon inverted"></i>
         <i class="fitted dropdown icon inverted"></i>
         <div class="menu">
@@ -40,7 +40,7 @@
     {% endif %}
 
     {%- if config.USERPROFILES %}
-      <div class="ui buttons">
+      <div class="ui buttons"style= "margin-left: 40px;">
         <a class="ui button"
            href="{{ url_for('invenio_userprofiles.profile') }}">
           <i class="user icon"></i> {{ current_user.email|truncate(31,true) }}


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/834
Changed the position of the plus button when the window is resized so it wouldn't stay on top of the user email and make it go below the header. Added some spacing between the plus button and the user email so they wouldn't overlap

![header1](https://user-images.githubusercontent.com/30771373/117361397-46359980-aeba-11eb-962c-8c5a3ffb4f7d.png)
![header2](https://user-images.githubusercontent.com/30771373/117361412-49308a00-aeba-11eb-9d2e-1fd3b26f3165.png)
