### PR TITLE
records_ui: fix detail template to not require any value

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -101,7 +101,9 @@
               <span class="label text-muted"> | Version {{ record.ui.version }}</span>
             </div>
             <div class="right floated right aligned column">
+              {% if record.ui.resource_type %}
               <span class="ui label small grey">{{ record.ui.resource_type.title_l10n }}</span>
+              {% endif %}
               <span class="ui label small access-status {{ record.ui.access_status.id }}" data-tooltip="{{ record.ui.access_status.description_l10n }}" data-inverted="">
                 {% if record.ui.access_status.icon %}<i class="icon {{ record.ui.access_status.icon }}"></i>{% endif %}
                 {{ record.ui.access_status.title_l10n }}
@@ -112,7 +114,9 @@
         {%- endblock record_header -%}
         {%- block record_title -%}
         <h1>{{ metadata.title }}</h1>
+        {% if record.ui.creators %}
         <p>{%- include "invenio_app_rdm/records/details/creators.html" %}</p>
+        {% endif %}
         {%- endblock record_title -%}
         {%- block record_content -%}
         <p>{%- include "invenio_app_rdm/records/details/contributors.html" %}</p>


### PR DESCRIPTION
- requires https://github.com/inveniosoftware/react-invenio-deposit/pull/332
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/944

Issues:
- The error messages on the form are temporarily shown.
- When `back to edit` those error messages disappear, the user would need to `save` again to see them.
- The citation box is broken (there is another issue to tackle that)

https://user-images.githubusercontent.com/6756943/125286410-0f498d00-e31c-11eb-867e-b0ede19eb559.mov


Note the `if`s added to the Jinja template are not ideal. But this will need to be changed in any case when creating the new content types that will allow us to version before the LTS.