### PR TITLE
templates: render html tags in landing page descriptions

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
@@ -8,5 +8,6 @@
 
 {% set description = metadata.get('description') %}
 {% if description %}
-{{ description | sanitize_html() | safe }}
+{# description data is being sanitized by marshmallow in the backend #}
+{{ description | safe }}
 {% endif %}


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/726

Tests have been added at RDM-Records level.

The ` sanitize_html` Jinja filter is not needed since the service schema already sanitizes it, therefore we avoid the double sanitization which ends in tags removal. [Reference](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/services/schemas/metadata.py#L394)