### PR TITLE
styling: fix txt and img alignment

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
@@ -1,6 +1,7 @@
 {#
     Copyright (C) 2020 CERN.
     Copyright (C) 2020 Northwestern University.
+    Copyright (C) 2021 Graz University of Technology.
 
     Invenio RDM Records is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.
@@ -12,7 +13,7 @@
 {%- if scheme == "orcid" %}
 {% set identifier_found.value = True %}
 <a href="{{ identifier[0]['identifier']|pid_url('orcid') }}">
-  <img class="inline-orcid" src="{{ url_for('static', filename='images/orcid.svg') }}" />
+  <img class="inline-orcid inline-orcid-icon" src="{{ url_for('static', filename='images/orcid.svg') }}" />
 </a>
 {%- elif scheme == "ror" %}
 {% set identifier_found.value = True %}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -62,6 +62,10 @@
      height: @font-size-base;
  }
 
+ .inline-orcid-icon {
+    margin-bottom: 3px;
+  }
+
  .thin-line {
      margin: 0rem 0rem 0.5rem 0rem !important;
  }


### PR DESCRIPTION
did not use the existing class - since it's used other places - just to be sure we are not creating any other bug.

closes #957 

**screenshot**
![inline](https://user-images.githubusercontent.com/44528277/126318573-fb9740b4-b501-409b-a2d6-ad4d90bc1622.png)
