### PR TITLE
ui: label resource types correctly [+]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ var/
 .venv/
 Pipfile
 Pipfile.lock
+pyproject.toml
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,6 +154,7 @@ def resource_type_item(app, resource_type_type):
         "title": {
             "en": "Photo"
         },
+        "tags": ["depositable", "linkable"],
         "type": "resourcetypes"
     })
 

--- a/tests/ui/test_deposits.py
+++ b/tests/ui/test_deposits.py
@@ -7,31 +7,104 @@
 
 """Test deposit views."""
 
+import pytest
+from elasticsearch_dsl import Q
+from invenio_access.permissions import system_identity
 from invenio_vocabularies.proxies import current_service as vocabulary_service
+from invenio_vocabularies.records.api import Vocabulary
 
-from invenio_app_rdm.records_ui.views.deposits import \
-    _dump_depositable_resource_type_vocabulary, _dump_subjects_vocabulary
+from invenio_app_rdm.records_ui.views.deposits import VocabulariesOptions
 
 
-def test_dump_resource_type_vocabulary(running_app):
-    # Make sure the indexed values are in ES before we start.
-    # Don't know why just this test requires this...
-    vocabulary_service.record_cls.index.refresh()
+@pytest.fixture()
+def additional_resource_types(running_app):
+    """Resource type vocabulary record."""
+    vocabulary_service.create(system_identity, {
+        "id": "publication",
+        "props": {
+            "csl": "report",
+            "datacite_general": "Text",
+            "datacite_type": "",
+            "eurepo": "info:eu-repo/semantics/other",
+            "openaire_resourceType": "17",
+            "openaire_type": "publication",
+            "schema.org": "https://schema.org/CreativeWork",
+            "subtype": "",
+            "subtype_name": "",
+            "type": "publication",
+            "type_icon": "file alternate",
+            "type_name": "Publication",
+        },
+        "title": {
+            "en": "Publication"
+        },
+        "tags": ["depositable", "linkable"],
+        "type": "resourcetypes"
+    })
+    vocabulary_service.create(system_identity, {
+        "id": "publication-annotationcollection",
+        "props": {
+            "csl": "report",
+            "datacite_general": "Collection",
+            "datacite_type": "",
+            "eurepo": "info:eu-repo/semantics/technicalDocumentation",
+            "openaire_resourceType": "9",
+            "openaire_type": "publication",
+            "schema.org": "https://schema.org/Collection",
+            "subtype": "publication-annotationcollection",
+            "subtype_name": "Annotation collection",
+            "type": "publication",
+            "type_icon": "file alternate",
+            "type_name": "Publication",
+        },
+        "title": {
+            "en": "Annotation collection"
+        },
+        "tags": ["depositable", "linkable"],
+        "type": "resourcetypes"
+    })
+
+    Vocabulary.index.refresh()
+
+
+def test_resource_types(additional_resource_types):
+    options = VocabulariesOptions()
     expected = [
+        # If no corresponding parent type entry (e.g. image-photo), type_name
+        # is own title and subtype_name is empty.
         {
             "icon": "chart bar outline",
             "id": "image-photo",
-            "subtype_name": "Photo",
-            "type_name": "Image",
+            "subtype_name": "",
+            "type_name": "Photo",
+        },
+        # If parent type is itself (e.g. Publication), type_name is own title
+        # and subtype_name is empty.
+        {
+            "icon": "file alternate",
+            "id": "publication",
+            "subtype_name": "",
+            "type_name": "Publication",
+        },
+        # If corresponding parent type entry, type_name is parent's title
+        # and subtype_name is own title.
+        {
+            "icon": "file alternate",
+            "id": "publication-annotationcollection",
+            "subtype_name": "Annotation collection",
+            "type_name": "Publication",
         }
     ]
 
-    result = _dump_depositable_resource_type_vocabulary()
+    # the choice of this filter isn't important for the test
+    result = options._resource_types(Q('term', tags="depositable"))
 
-    assert expected == result
+    sorted_result = sorted(result, key=lambda e: e["id"])
+    assert expected == sorted_result
 
 
 def test_dump_subjects_vocabulary(running_app):
+    options = VocabulariesOptions()
     expected = {
         "limit_to": [
             {"text": "All", "value": "all"},
@@ -39,6 +112,6 @@ def test_dump_subjects_vocabulary(running_app):
         ]
     }
 
-    result = _dump_subjects_vocabulary()
+    result = options.subjects()
 
     assert expected == result


### PR DESCRIPTION
'correctly' means:
- with translation
- still relying on cache
- by using parent entry title if need be
  (not relying on `subtype_name` and `type_name` anymore)

also:
- refactors vocabularies dumping for deposit page
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/785
