### PR TITLE
config: fix drafts cleanup task

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -272,8 +272,13 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': timedelta(minutes=60),
     },
     'draft_resources': {
-        'task': 'invenio_draft_resources.tasks.cleanup_drafts',
+        'task': (
+            'invenio_drafts_resources.services.records.tasks.cleanup_drafts'
+        ),
         'schedule': timedelta(minutes=60),
+        "args": [
+            "invenio_rdm_records.proxies:current_rdm_records_service"
+        ],
     },
     'rdm_records': {
         'task': 'invenio_rdm_records.services.tasks.update_expired_embargos',


### PR DESCRIPTION
- requires https://github.com/inveniosoftware/invenio-rdm-records/pull/793
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1044
Example run:
```
[2021-08-04 10:26:15,303: INFO/MainProcess] Received task: invenio_drafts_resources.services.records.tasks.cleanup_drafts[722ee3f8-4694-4b92-a2ad-774f2e2c451c]
[2021-08-04 10:26:15,474: INFO/ForkPoolWorker-9] Task invenio_drafts_resources.services.records.tasks.cleanup_drafts[722ee3f8-4694-4b92-a2ad-774f2e2c451c] succeeded in 0.0647518379999994s: None
/Users/ppanero/.virtualenvs/cleanup_drafts/lib/python3.7/site-packages/marshmallow/fields.py:221: RemovedInMarshmallow4Warning: Passing field metadata as a keyword arg is deprecated. Use the explicit `metadata=...` argument instead.
  RemovedInMarshmallow4Warning,

[2021-08-04 10:26:16,293] DEBUG in entrypoint: Loading config for entry point invenio_app_rdm = invenio_app_rdm.config
[2021-08-04 10:26:17,123] DEBUG in ext: Flask-DebugToolbar extension not installed.
[2021-08-04 10:27:12,658: INFO/Beat] Scheduler: Sending due task draft_resources (invenio_drafts_resources.services.records.tasks.cleanup_drafts)
[2021-08-04 10:27:12,663: INFO/MainProcess] Received task: invenio_drafts_resources.services.records.tasks.cleanup_drafts[98c5eefc-1303-4bcb-a393-c749eb2f0dbd]
[2021-08-04 10:27:12,670: INFO/ForkPoolWorker-9] Task invenio_drafts_resources.services.records.tasks.cleanup_drafts[98c5eefc-1303-4bcb-a393-c749eb2f0dbd] succeeded in 0.006498139999990826s: None
```