### PR TITLE
dependencies: add invenio-logging with sentry sdk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ install_requires = [
     'CairoSVG>=2.5.2,<3.0.0',
     f'invenio[base,auth,metadata,files]{invenio_version}',
     'invenio-communities>=2.5.0.dev2,<2.6.0',
+    'invenio-logging[sentry-sdk]>=1.3.0,<1.4.0',
     'invenio-rdm-records>=0.32.4,<0.33.0',
 ]
 


### PR DESCRIPTION
Adds logging with sentry-sdk extra. It is not configured by default.

Tested with a new instance (v6.0) from scratch and no errors were shown. 

**Open questions**

- Do we want to add sentry to the docker-compose file? It would **not** be a zero-config thing, because the teams/users/project/dsn would still need to be created by the user
- Should docs be added somewhere in InvenioRDM or the Invenio ones are enough (those are the ones I followed).