### PR TITLE
frontend: enable sentry logging for react apps

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -27,6 +27,10 @@
   {%- if permissions %}
   <input id="deposits-record-permissions" type="hidden" name="deposits-record-permissions" value='{{permissions | tojson }}'></input>
   {%- endif %}
+  {%- if sentry_config %}
+  <input id="sentry-config" type="hidden" name="sentry-config" value='{{sentry_config}}'></input>
+  {%- endif %}
+
   <div id="deposit-form"></div>
 {%- endblock page_body %}
 

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -17,6 +17,11 @@
 {%- set metadata = record.metadata %}
 
 {%- block page_body %}
+
+{%- if sentry_config %}
+<input id="sentry-config" type="hidden" name="sentry-config" value='{{sentry_config | tojson}}'></input>
+{%- endif %}
+
 <div class="banners">
   {% if is_preview %}
   <div class="ui info flashed top-attached manage message">

--- a/invenio_app_rdm/records_ui/utils.py
+++ b/invenio_app_rdm/records_ui/utils.py
@@ -9,6 +9,7 @@
 
 """Utility functions."""
 
+from flask import current_app
 from invenio_records.dictutils import dict_set
 from invenio_records.errors import MissingModelError
 from invenio_records_files.api import FileObject
@@ -55,3 +56,16 @@ def set_default_value(record_dict, value, path, default_prefix="metadata"):
         path = "{}.{}".format(default_prefix, path)
 
     dict_set(record_dict, path, value)
+
+
+def get_sentry_config():
+    """Gets the sentry config for UI (React)."""
+    dsn = current_app.config.get("SENTRY_DSN", None)
+
+    if not dsn:
+        return None
+
+    return {
+        "dsn": dsn,
+        "environment": current_app.config.get("SENTRY_ENVIRONMENT", "dev"),
+    }

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -23,7 +23,7 @@ from invenio_vocabularies.records.models import VocabularyScheme
 from marshmallow_utils.fields.babel import gettext_from_dict
 from sqlalchemy.orm import load_only
 
-from ..utils import set_default_value
+from ..utils import get_sentry_config, set_default_value
 from .decorators import pass_draft, pass_draft_files
 from .filters import get_scheme_label
 
@@ -298,6 +298,7 @@ def deposit_create():
     """Create a new deposit."""
     return render_template(
         "invenio_app_rdm/records/deposit.html",
+        sentry_config=get_sentry_config(),
         forms_config=get_form_config(createUrl=("/api/records")),
         searchbar_config=dict(searchUrl=get_search_url()),
         record=new_record(),
@@ -317,6 +318,7 @@ def deposit_edit(draft=None, draft_files=None, pid_value=None):
 
     return render_template(
         "invenio_app_rdm/records/deposit.html",
+        sentry_config=get_sentry_config(),
         forms_config=get_form_config(apiUrl=f"/api/records/{pid_value}/draft"),
         record=record,
         files=draft_files.to_dict(),

--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -21,6 +21,7 @@ from invenio_rdm_records.proxies import current_rdm_records
 from invenio_rdm_records.resources.serializers import UIJSONSerializer
 from marshmallow import ValidationError
 
+from ..utils import get_sentry_config
 from .decorators import pass_file_item, pass_file_metadata, pass_is_preview, \
     pass_record_files, pass_record_from_pid, pass_record_latest, \
     pass_record_or_draft
@@ -83,6 +84,7 @@ def record_detail(record=None, files=None, pid_value=None, is_preview=False):
             abort(404)
     return render_template(
         "invenio_app_rdm/records/detail.html",
+        sentry_config=get_sentry_config(),
         record=record_ui,
         pid=pid_value,
         files=files_dict,

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/index.js
@@ -8,9 +8,11 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import "semantic-ui-css/semantic.min.css";
-import { i18next } from "@translations/invenio_app_rdm/i18next";
 import { getInputFromDOM } from "react-invenio-deposit";
 import { RDMDepositForm } from "./RDMDepositForm";
+import { initSentry } from "../utils";
+
+initSentry(getInputFromDOM("sentry-config"));
 
 ReactDOM.render(
   <RDMDepositForm

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
@@ -10,9 +10,13 @@ import $ from "jquery";
 import React from "react";
 import ReactDOM from "react-dom";
 
+import { getInputFromDOM } from "react-invenio-deposit";
 import { RecordManagement } from "./RecordManagement";
 import { RecordVersionsList } from "./RecordVersionsList";
 import { RecordCitationField } from "./RecordCitationField";
+import { initSentry } from "../utils";
+
+initSentry(getInputFromDOM("sentry-config"));
 
 const recordManagementAppDiv = document.getElementById("recordManagement");
 const recordVersionsAppDiv = document.getElementById("recordVersions");
@@ -51,8 +55,8 @@ if (recordCitationAppDiv) {
 
 $(".ui.accordion").accordion({
   selector: {
-    trigger: '.title .dropdown'
-  }
+    trigger: ".title .dropdown",
+  },
 });
 
 $("#record-doi-badge").click(function () {

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
@@ -5,6 +5,8 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import axios from "axios";
+import * as Sentry from "@sentry/react";
+import { Integrations } from "@sentry/tracing";
 
 /**
  * Wrap a promise to be cancellable and avoid potential memory leaks
@@ -37,3 +39,13 @@ const apiConfig = {
 };
 
 export const axiosWithconfig = axios.create(apiConfig);
+
+export const initSentry = (config) => {
+  if (config !== null) {
+    Sentry.init({
+      integrations: [new Integrations.BrowserTracing()],
+      tracesSampleRate: 1.0,
+      ...config,
+    });
+  }
+};

--- a/invenio_app_rdm/theme/webpack.py
+++ b/invenio_app_rdm/theme/webpack.py
@@ -13,49 +13,51 @@ from invenio_assets.webpack import WebpackThemeBundle
 
 theme = WebpackThemeBundle(
     __name__,
-    'assets',
-    default='semantic-ui',
+    "assets",
+    default="semantic-ui",
     themes={
-        'semantic-ui': dict(
+        "semantic-ui": dict(
             entry={
-                'invenio-app-rdm-landing-page':
-                    './js/invenio_app_rdm/landing_page/index.js',
-                'invenio-app-rdm-deposit':
-                    './js/invenio_app_rdm/deposit/index.js',
-                'invenio-app-rdm-search':
-                    './js/invenio_app_rdm/search/index.js',
-                'invenio-app-rdm-user-records-search':
-                    './js/invenio_app_rdm/user_records_search/index.js',
+                "invenio-app-rdm-landing-page":
+                    "./js/invenio_app_rdm/landing_page/index.js",
+                "invenio-app-rdm-deposit":
+                    "./js/invenio_app_rdm/deposit/index.js",
+                "invenio-app-rdm-search":
+                    "./js/invenio_app_rdm/search/index.js",
+                "invenio-app-rdm-user-records-search":
+                    "./js/invenio_app_rdm/user_records_search/index.js",
             },
             dependencies={
                 # add any additional npm dependencies here...
                 "@babel/runtime": "^7.9.0",
-                'formik': '^2.1.4',
-                'luxon': '^1.23.0',
-                'path': '^0.12.7',
-                'prop-types': '^15.7.2',
-                'react-dnd': '^11.1.3',
-                'react-dnd-html5-backend': '^11.1.3',
-                'react-invenio-deposit': '^0.16.1',
-                'react-invenio-forms': '^0.8.7',
-                'react-dropzone': "^11.0.3",
-                'yup': '^0.32.9',
-                '@ckeditor/ckeditor5-build-classic': '^16.0.0',
-                '@ckeditor/ckeditor5-react': '^2.1.0',
+                "@ckeditor/ckeditor5-build-classic": "^16.0.0",
+                "@ckeditor/ckeditor5-react": "^2.1.0",
+                "formik": "^2.1.4",
                 "i18next": "^20.3.1",
-                "react-i18next": "^11.11.3",
                 "i18next-browser-languagedetector": "^6.1.1",
-                'react-copy-to-clipboard': '^5.0.3'
+                "luxon": "^1.23.0",
+                "path": "^0.12.7",
+                "prop-types": "^15.7.2",
+                "react-copy-to-clipboard": "^5.0.3",
+                "react-dnd": "^11.1.3",
+                "react-dnd-html5-backend": "^11.1.3",
+                "react-dropzone": "^11.0.3",
+                "react-i18next": "^11.11.3",
+                "react-invenio-deposit": "^0.16.1",
+                "react-invenio-forms": "^0.8.7",
+                "@sentry/react": "^6.11.0",
+                "@sentry/tracing": "^6.11.0",
+                "yup": "^0.32.9",
             },
             aliases={
                 # Define Semantic-UI theme configuration needed by
                 # Invenio-Theme in order to build Semantic UI (in theme.js
                 # entry point). theme.config itself is provided by
                 # cookiecutter-invenio-rdm.
-                '../../theme.config$': 'less/theme.config',
-                'themes/rdm': 'less/invenio_app_rdm/theme',
-                '@less/invenio_app_rdm': 'less/invenio_app_rdm',
-                '@translations/invenio_app_rdm': 'translations/invenio_app_rdm'
+                "../../theme.config$": "less/theme.config",
+                "themes/rdm": "less/invenio_app_rdm/theme",
+                "@less/invenio_app_rdm": "less/invenio_app_rdm",
+                "@translations/invenio_app_rdm": "translations/invenio_app_rdm"
             }
         ),
     }

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ install_requires = [
     'CairoSVG>=2.5.2,<3.0.0',
     f'invenio[base,auth,metadata,files]{invenio_version}',
     'invenio-communities>=2.5.0.dev2,<2.6.0',
+    'invenio-logging[sentry-sdk]>=1.3.0,<1.4.0',
     'invenio-rdm-records>=0.32.4,<0.33.0',
 ]
 


### PR DESCRIPTION
- requires https://github.com/inveniosoftware/invenio-app-rdm/pull/1086

**issues**
- [security] the way we inject configuration means that the DSN would be exposed. This can be tamed at sentry project level (i.e. restrict origins).
- CSP/CORS gives some errors from the response of sentry that I haven't been able to fix.
- Still need to implement it for the search apps, but as a PoC is enough. The main issue with search apps is that the view is defined in `invenio-search-ui` and we cannot easily modify it to send the config along when rendering. Since the plan is to move out of `invenio-search-ui` this can be tackled then.