### PR TITLE
Move sidebar components into separate templates and make extensible

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -545,3 +545,10 @@ RDM_CITATION_STYLES = [
 
 RDM_CITATION_STYLES_DEFAULT = 'apa'
 """Default citation style"""
+
+APP_RDM_DETAIL_SIDE_BAR_TEMPLATES = [
+    "invenio_app_rdm/records/details/side_bar/metrics.html",
+    "invenio_app_rdm/records/details/side_bar/versions.html",
+    "invenio_app_rdm/records/details/side_bar/export.html",
+]
+"""Template names for detail view sidebar components"""

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar.html
@@ -2,55 +2,12 @@
   Copyright (C) 2020 CERN.
   Copyright (C) 2020 Northwestern University.
   Copyright (C) 2021 TU Wien.
+  Copyright (C) 2021 Cottage Labs.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.
 #}
 
-{%- from "invenio_app_rdm/records/macros/version.html" import show_version %}
-
-
-{#
-<!-- TODO add again once the metrics are working -->
-<div class="ui segment rdm-sidebar">
-  <dt><b>{{ _('Metrics')}}</b></dt>
-  <hr class="thin-line">
-  </hr>
-  <dd>
-    <!-- Stats -->
-    {%- include "invenio_app_rdm/landing_page/details/stats.html" %}
-  </dd>
-</div>
-#}
-
-<div class="ui segment rdm-sidebar">
-  <dt><b>{{ _('Versions')}}</b></dt>
-  <hr class="thin-line">
-  </hr>
-  <dd class="versions">
-    <div id="recordVersions" data-record='{{ record | tojson }}' data-preview='{{ is_preview | tojson }}'></div>
-  </dd>
-</div>
-
-{%- if config.get("APP_RDM_RECORD_EXPORTERS") -%}
-{# if no export formats are specified, don't bother showing the box #}
-<div class="ui segment rdm-sidebar exports">
-  <dt><b>{{ _('Export')}}</b></dt>
-  <hr class="thin-line">
-  </hr>
-  <dd class="top-bottom-padded">
-    <div class="ui celled horizontal list separated-list">
-      {# dynamically create the list of export formats #}
-      {%- for fmt, val in config.get("APP_RDM_RECORD_EXPORTERS", {}).items() -%}
-        {%- set name = val.get("name", fmt) -%}
-        {% if is_preview %}
-          {%- set export_url = url_for('invenio_app_rdm_records.record_export', pid_value=record.id, export_format=fmt, preview=1) -%}
-        {% else %}
-          {%- set export_url = url_for('invenio_app_rdm_records.record_export', pid_value=record.id, export_format=fmt) -%}
-        {% endif %}
-         <div class="item"><a href="{{ export_url }}">{{ name }}</a></div>
-      {%- endfor -%}
-    </div>
-  </dd>
-</div>
-{%- endif -%}
+{%- for template_name in config.get("APP_RDM_DETAIL_SIDE_BAR_TEMPLATES", []) -%}
+  {% include template_name %}
+{%- endfor -%}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/export.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/export.html
@@ -1,0 +1,31 @@
+{#
+  Copyright (C) 2020 CERN.
+  Copyright (C) 2020 Northwestern University.
+  Copyright (C) 2021 TU Wien.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- if config.get("APP_RDM_RECORD_EXPORTERS") -%}
+{# if no export formats are specified, don't bother showing the box #}
+<div class="ui segment rdm-sidebar exports">
+  <dt><b>{{ _('Export')}}</b></dt>
+  <hr class="thin-line">
+  </hr>
+  <dd class="top-bottom-padded">
+    <div class="ui celled horizontal list separated-list">
+      {# dynamically create the list of export formats #}
+      {%- for fmt, val in config.get("APP_RDM_RECORD_EXPORTERS", {}).items() -%}
+        {%- set name = val.get("name", fmt) -%}
+        {% if is_preview %}
+          {%- set export_url = url_for('invenio_app_rdm_records.record_export', pid_value=record.id, export_format=fmt, preview=1) -%}
+        {% else %}
+          {%- set export_url = url_for('invenio_app_rdm_records.record_export', pid_value=record.id, export_format=fmt) -%}
+        {% endif %}
+         <div class="item"><a href="{{ export_url }}">{{ name }}</a></div>
+      {%- endfor -%}
+    </div>
+  </dd>
+</div>
+{%- endif -%}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/metrics.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/metrics.html
@@ -1,0 +1,21 @@
+{#
+  Copyright (C) 2020 CERN.
+  Copyright (C) 2020 Northwestern University.
+  Copyright (C) 2021 TU Wien.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{#
+<!-- TODO add again once the metrics are working -->
+<div class="ui segment rdm-sidebar">
+  <dt><b>{{ _('Metrics')}}</b></dt>
+  <hr class="thin-line">
+  </hr>
+  <dd>
+    <!-- Stats -->
+    {%- include "invenio_app_rdm/landing_page/details/stats.html" %}
+  </dd>
+</div>
+#}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/versions.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/versions.html
@@ -1,0 +1,17 @@
+{#
+  Copyright (C) 2020 CERN.
+  Copyright (C) 2020 Northwestern University.
+  Copyright (C) 2021 TU Wien.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+-#}
+
+<div class="ui segment rdm-sidebar">
+  <dt><b>{{ _('Versions')}}</b></dt>
+  <hr class="thin-line">
+  </hr>
+  <dd class="versions">
+    <div id="recordVersions" data-record='{{ record | tojson }}' data-preview='{{ is_preview | tojson }}'></div>
+  </dd>
+</div>


### PR DESCRIPTION
Each sidebar component is now individually overridable, and components can be added or removed via the `APP_RDM_DETAIL_SIDE_BAR_TEMPLATES` config variable.