### PR TITLE
A11y colors and results links

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -71,10 +71,10 @@
 </div>
 
 
-<div class="ui container">
+<main id="main" class="ui container">
   <div class="ui relaxed grid">
-    <div class="two column row top-padded">
-      <div class="eleven wide column">
+    <div class="two column row">
+      <article class="eleven wide column">
         {% if record.access.record == 'restricted' %}
           <div class="ui {{ record.ui.access_status.message_class }} message">
             <strong><i class="{{ record.ui.access_status.icon }} icon"></i>{{ record.ui.access_status.title_l10n }}</strong> {{ record.ui.access_status.description_l10n }}
@@ -115,20 +115,16 @@
         {%- block record_title -%}
         <h1>{{ metadata.title }}</h1>
         {% if record.ui.creators %}
-        <p>{%- include "invenio_app_rdm/records/details/creators.html" %}</p>
+        <section id="creators">{%- include "invenio_app_rdm/records/details/creators.html" %}</section>
         {% endif %}
         {%- endblock record_title -%}
         {%- block record_content -%}
-        <p>{%- include "invenio_app_rdm/records/details/contributors.html" %}</p>
-        <p>{%- include "invenio_app_rdm/records/details/doi.html" %}</p>
-        <p>{%- include "invenio_app_rdm/records/details/citation.html" %}</p>
-        {%- include "invenio_app_rdm/records/details/subjects.html" %}
-        <div class="top-padded">
-        {%- include "invenio_app_rdm/records/details/description.html" %}
-        </div>
-        <div class="top-padded">
-        {%- include "invenio_app_rdm/records/details/licenses.html" %}
-        </div>
+        <section id="record-contributors" class="detail-section">{%- include "invenio_app_rdm/records/details/contributors.html" -%}</section>
+        <section id="record-doi" class="detail-section">{%- include "invenio_app_rdm/records/details/doi.html" -%}</section>
+        <section id="record-citation" class="detail-section">{%- include "invenio_app_rdm/records/details/citation.html" -%}</section>
+        <section id="record-subjects" class="detail-section">{%- include "invenio_app_rdm/records/details/subjects.html" -%}</section>
+        <section id="record-description" class="detail-section">{%- include "invenio_app_rdm/records/details/description.html" -%}</section>
+        <section id="record-licenses" class="detail-section">{%- include "invenio_app_rdm/records/details/licenses.html" -%}</section>
         {%- endblock record_content -%}
 
         {# files #}
@@ -167,9 +163,7 @@
 
         {%- block record_details -%}
         {# More details #}
-        <div class="top-padded">
-        {%- include "invenio_app_rdm/records/details/details.html" %}
-        </div>
+        <section id ="record-details" class="detail-section">{%- include "invenio_app_rdm/records/details/details.html" %}</section>
         {%- endblock record_details -%}
         {%- block record_footer -%}
         <div class="ui grid">
@@ -196,7 +190,7 @@
         </div>
         {%- endblock jump -%}
         {%- endblock record_body %}
-      </div>
+      </article>
       <div class="five wide column">
         {% block record_sidebar %}
         {%- include "invenio_app_rdm/records/details/side_bar.html" %}
@@ -204,7 +198,7 @@
       </div>
     </div>
   </div>
-</div>
+</main>
 
 {%- endblock page_body %}
 

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -3,6 +3,7 @@
   Copyright (C) 2020-2021 Northwestern University.
   Copyright (C) 2021 TU Wien.
   Copyright (C) 2021 Graz University of Technology.
+  Copyright (C) 2021 New York University.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/citation.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/citation.html
@@ -6,9 +6,7 @@
     it under the terms of the MIT License; see LICENSE file for more details.
 #}
 
-<hr class="thin-line"></hr>
   <div id="recordCitation" data-record='{{ record | tojson }}'
     data-styles='{{ config.get("RDM_CITATION_STYLES") | tojson }}'
     data-defaultstyle='{{ config.get("RDM_CITATION_STYLES_DEFAULT") | tojson }}'>
   </div>
-<hr class="thin-line"></hr>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/citation.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/citation.html
@@ -1,6 +1,7 @@
 {#
     Copyright (C) 2020-2021 CERN.
     Copyright (C) 2020 Northwestern University.
+    Copyright (C) 2021 New York University.
 
     Invenio RDM Records is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/contributors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/contributors.html
@@ -11,7 +11,7 @@
   {%- for group in record.ui.contributors.contributors|groupby('role.title')%}
   <div class="ui accordion creatibutors">
     <div class="title">
-      <h4><b>{{group.grouper}}(s)</b></h4>
+      <h2 class="header">{{group.grouper}}(s)</h2>
       {{ show_creatibutors(group.list, show_affiliations=True) }}
       {% if record.ui.contributors.affiliations %}
       <a style="cursor: pointer;" class="dropdown">

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/contributors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/contributors.html
@@ -1,6 +1,7 @@
 {#
     Copyright (C) 2020 CERN.
     Copyright (C) 2020 Northwestern University.
+    Copyright (C) 2021 New York University.
 
     Invenio RDM Records is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
@@ -1,6 +1,7 @@
 {#
   Copyright (C) 2020 CERN.
   Copyright (C) 2020 Northwestern University.
+  Copyright (C) 2021 New York University.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
@@ -9,5 +9,6 @@
 {% set description = metadata.get('description') %}
 {% if description %}
 {# description data is being sanitized by marshmallow in the backend #}
-{{ description | safe }}
+<h2 class="ui header">{{ _('Description')}}</h2>
+<div>{{ description | safe }}</div>
 {% endif %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
@@ -11,9 +11,8 @@
   list_sizes, show_add_descriptions, show_add_titles, show_dates, show_detail, show_funding,
   show_references, show_alternate_identifiers, show_related_identifiers %}
 
-<dt><b>{{ _('Details')}}</b></dt>
-<hr class="thin-line"></hr>
-<dd class="top-bottom-padded">
+<h2 class="ui header">{{ _('Details')}}</h2>
+<div class="top-bottom-padded">
   {{ show_detail(_('Resource type'), record.ui.resource_type.title_l10n) if record.ui.resource_type }}
   {{ show_detail(_('Publication date'), record.ui.publication_date_l10n) if record.ui.publication_date_l10n }}
   {{ show_detail(_('Publisher'), metadata.publisher) if metadata.publisher }}
@@ -27,5 +26,4 @@
   {{ show_detail(_('Alternate identifiers'), show_alternate_identifiers(metadata.identifiers)) if metadata.identifiers }}
   {{ show_detail(_('Related works'), show_related_identifiers(record.ui.related_identifiers)) if record.ui.related_identifiers }}
   {{ show_detail(_('References'), show_references(metadata.references)) if metadata.references }}
-</dd>
-<hr class="thin-line"></hr>
+</div>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
@@ -1,6 +1,7 @@
 {#
   Copyright (C) 2020-2021 CERN.
   Copyright (C) 2020-2021 Northwestern University.
+  Copyright (C) 2021 New York University.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/doi.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/doi.html
@@ -1,6 +1,7 @@
 {#
   Copyright (C) 2020 CERN.
   Copyright (C) 2020 Northwestern University.
+  Copyright (C) 2021 New York University.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/doi.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/doi.html
@@ -6,10 +6,10 @@
   it under the terms of the MIT License; see LICENSE file for more details.
 #}
 
-{%- set id_doi = record.pids.get('doi', {}).get('identifier') %}
-{% if id_doi %}
-<dt><b>{{_('DOI')}}</b></dt>
-<dd class="top-bottom-padded">
+{%- set id_doi = record.pids.get('doi', {}).get('identifier') -%}
+{%- if id_doi %}
+<h2 class="ui header">{{ _('DOI')}}</h2>
+<div class="top-bottom-padded">
   <span class="get-badge" data-toggle="tooltip" data-placement="bottom" style="cursor: pointer;"
     title="{{ _("Get the DOI badge!") }}">
     <img id="record-doi-badge" data-target="[data-modal='{{ id_doi }}']"
@@ -29,5 +29,5 @@
       {{ badges_formats_list(url_for('invenio_formatter_badges.badge', title='DOI', value=id_doi, ext='svg', _external=True, _scheme='https'), id_doi|pid_url(scheme='doi')) }}
     </div>
   </div>
-</dd>
-{% endif %}
+</div>
+{%- endif -%}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/licenses.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/licenses.html
@@ -9,8 +9,8 @@
 
 {% set rights = record.ui.get('rights') %}
 {% if rights %}
-<dt><b>{{ _('Licenses')}}</b></dt>
-<dd>
+<h2 class="ui header">{{ _('Licenses')}}</h2>
+<div>
   {%- for right in rights%}
   <div class="content">
     <div class="header">
@@ -33,7 +33,6 @@
       {% endif %}
     </div>
   </div>
-  <br>
   {% endfor %}
-</dd>
+</div>
 {% endif %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/licenses.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/licenses.html
@@ -2,6 +2,7 @@
   Copyright (C) 2020 CERN.
   Copyright (C) 2020 Northwestern University.
   Copyright (C) 2021 Graz University of Technology.
+  Copyright (C) 2021 New York University.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/licenses.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/licenses.html
@@ -7,8 +7,8 @@
   it under the terms of the MIT License; see LICENSE file for more details.
 #}
 
-{% set rights = record.ui.get('rights') %}
-{% if rights %}
+{%- set rights = record.ui.get('rights') %}
+{%- if rights %}
 <h2 class="ui header">{{ _('Licenses')}}</h2>
 <div>
   {%- for right in rights%}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/subjects.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/subjects.html
@@ -1,6 +1,7 @@
 {#
   Copyright (C) 2020 CERN.
   Copyright (C) 2020 Northwestern University.
+  Copyright (C) 2021 New York University.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/subjects.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/subjects.html
@@ -6,16 +6,15 @@
   it under the terms of the MIT License; see LICENSE file for more details.
 #}
 
-{% set subjects = record.metadata.subjects %}
+{%- set subjects = record.metadata.subjects -%}
 
-{% if subjects %}
-<dd class="top-bottom-padded" id="record-subjects">
+{%- if subjects -%}
   {%- for scheme, subjects in subjects|selectattr("scheme")|groupby('scheme')|sort(attribute='scheme') %}
-  <div class="ui grid">
-    <div class="sixteen wide subject-scheme column">
-      <span class="ui tiny subject header">{{scheme}}</span>
+  <div class="ui">
+    <div class="subject-scheme column">
+      <h2 class="ui subject header">{{scheme}}</h2>
     </div>
-    <div class="sixteen wide subject-label column">
+    <div class="subject-label column">
       {%- for subject in subjects %}
           <span class="subject">{{ subject.subject}}</span>
         {%- endfor %}
@@ -24,16 +23,15 @@
   {%- endfor %}
   {% set keywords = subjects|rejectattr("scheme")|list %}
   {% if keywords %}
-  <div class="ui grid">
-    <div class="sixteen wide subject-scheme column">
-      <span class="ui tiny subject header">{{_('Keywords')}}</span>
+  <div class="ui">
+    <div class="subject-scheme column">
+      <h2 class="ui subject header">{{_('Keywords')}}</h2>
     </div>
-    <div class="sixteen wide subject-label column">
+    <div class="subject-label column">
     {%- for subject in keywords %}
       <span class="subject">{{ subject.subject}}</span>
     {%- endfor %}
     </div>
   </div>
-  {% endif %}
-</dd>
-{% endif %}
+  {%- endif -%}
+{%- endif -%}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -66,7 +66,7 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
   // Derivatives
   const viewLink = `/records/${result.id}`;
   return (
-    <Item key={index} href={viewLink}>
+    <Item key={index}>
       <Item.Content>
         <Item.Extra className="labels-actions">
           <Label size="tiny" color="blue">
@@ -81,13 +81,9 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
             )}
             {access_status}
           </Label>
-          <Button compact size="small" floated="right">
-            <Icon name="eye" />
-            {i18next.t("View")}
-          </Button>
         </Item.Extra>
-        <Item.Header>{title}</Item.Header>
-        <Item.Meta>
+        <Item.Header as='h2'><a href={viewLink}>{title}</a></Item.Header>
+        <Item.Meta className="creatibutors">
           <SearchItemCreators creators={creators} />
         </Item.Meta>
         <Item.Description>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_records_search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_records_search/components.js
@@ -261,8 +261,8 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
             <DeleteDraftButton record={result} />
           )}
         </Item.Extra>
-        <Item.Header href={viewLink}>{title}</Item.Header>
-        <Item.Meta>
+        <Item.Header as='h2'><a href={viewLink}>{title}</a></Item.Header>
+        <Item.Meta className="creatibutors">
           <SearchItemCreators creators={creators} />
         </Item.Meta>
         <Item.Description>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_records_search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_records_search/components.js
@@ -2,6 +2,7 @@
 // Copyright (C) 2020-2021 CERN.
 // Copyright (C) 2020-2021 Northwestern University.
 // Copyright (C) 2021 Graz University of Technology.
+// Copyright (C) 2021 New York University.
 //
 // Invenio App RDM is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
@@ -1,5 +1,6 @@
 // This file is part of InvenioRDM
 // Copyright (C) 2021 CERN.
+// Copyright (C) 2021 New York University.
 //
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
@@ -7,7 +7,7 @@
 import axios from "axios";
 import _get from "lodash/get";
 import React from "react";
-
+import { i18next } from "@translations/invenio_app_rdm/i18next";
 /**
  * Wrap a promise to be cancellable and avoid potential memory leaks
  * https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
@@ -45,15 +45,16 @@ export function SearchItemCreators({creators}) {
 
   function getIcon(creator) {
     let ids = _get(creator, "person_or_org.identifiers", []);
+    let creatorName = _get(creator, "person_or_org.name", "No name");
     let firstId = ids.filter((id) => ["orcid", "ror"].includes(id.scheme))[0];
     firstId = firstId || {scheme: ""};
     let icon = null;
     switch (firstId.scheme) {
       case "orcid":
-        icon = <img className="inline-id-icon" src="/static/images/orcid.svg" />;
+        icon = <a href={"https://orcid.org/" + `${ firstId.identifier}`} aria-label={`${creatorName}: ${i18next.t("ORCID profile")}`} title={`${creatorName}: ${i18next.t("ORCID profile")}`}><img className="inline-id-icon" src="/static/images/orcid.svg" alt="" /></a>;
         break;
       case "ror":
-        icon = <img className="inline-id-icon" src="/static/images/ror-icon.svg" />;
+        icon = <a href={"https://ror.org/" + `${ firstId.identifier}`} aria-label={`${creatorName}: ${i18next.t("ROR profile")}`} title={`${creatorName}: ${i18next.t("ROR profile")}`}><img className="inline-id-icon" src="/static/images/ror-icon.svg" alt="" /></a>;
         break;
       default:
         break;
@@ -61,10 +62,15 @@ export function SearchItemCreators({creators}) {
     return icon;
   }
 
+  function getLink(creator) {
+    let creatorName = _get(creator, "person_or_org.name", "No name");
+    let link = <a href={`/search?q=metadata.creators.person_or_org.name:"${ creatorName }"`} title={ `${creatorName}: ${(i18next.t("Search"))}`}>{creatorName}</a>;
+    return link;
+  }
   return creators.map((creator, index) => (
     <span key={index}>
       {getIcon(creator)}
-      {_get(creator, "person_or_org.name", "No name")}
+      {getLink(creator)}
       {index < creators.length - 1 && ";"}
     </span>
   ));

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/footer.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/footer.less
@@ -1,6 +1,7 @@
 /*
  *   Copyright (C) 2019 CERN.
  *   Copyright (C) 2019 Northwestern University.
+ *   Copyright (C) 2021 New York University.
  *
  * Invenio App RDM is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/footer.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/footer.less
@@ -18,7 +18,6 @@
   }
 
   a {
-    text-decoration: none;
     color: @footerTextLightColor;
 
     &:hover, &:focus {
@@ -27,8 +26,9 @@
   }
 }
 
-.footer-top {
+.ui.grid > .row.footer-top {
   background-color: @footerLightColor;
+  padding: 2rem 0 4rem;
 }
 
 .margin-small {

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/frontpage.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/frontpage.less
@@ -11,7 +11,7 @@
     font-weight: 200;
     font-size: 4em;
     color: white;
-    background-color: #0377cd91;
+    background-color: #4899DB;
     box-sizing: border-box;
     width: 100px;
     height: 100px;
@@ -83,7 +83,7 @@ only screen and (max-width: 993px) {
     line-height: 25px;
     padding: 15px 30px;
     background-color: #0377cd;
-    color: rgb(212, 229, 239) !important;
+    color:  white !important;
     height: 50px;
     font-size: 1em;
     font-weight: 200;
@@ -92,4 +92,5 @@ only screen and (max-width: 993px) {
 .goto-button a:hover,
 .goto-button a:active {
     color: white !important;
+    background-color: #01599c;
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/frontpage.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/frontpage.less
@@ -1,6 +1,7 @@
 /*
  *   Copyright (C) 2020 CERN.
  *   Copyright (C) 2020 Northwestern University.
+ *   Copyright (C) 2021 New York University.
  *
  * Invenio App RDM is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -51,6 +51,9 @@ dd { // Start left aligned
 
 .version-active {
   background-color: @versionActive;
+  .text-muted {
+    color: #686868;
+  }
 }
 
 .ui.rdm-sidebar {
@@ -64,7 +67,7 @@ dd { // Start left aligned
   border-bottom: 1px solid rgba(0,0,0,0.1);
 }
 
- // Files toogles
+ // Files toggles
 
 .hide-on-collapsed {
   display: block;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -7,6 +7,17 @@
  * it under the terms of the MIT License; see LICENSE file for more details.
  */
 
+ .detail-section:not(:empty) {
+   margin: 1rem auto;
+   border-bottom: 1px solid #e5e5e5;
+   padding-bottom: 1.5rem;
+   .ui.header {
+    font-size: 1.3rem;
+   }
+   &#record-citation{
+     padding-bottom: .5rem;
+   }
+ }
 .font-small {
   font-size: @font-size-small
  }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -2,6 +2,7 @@
  *   Copyright (C) 2020 CERN.
  *   Copyright (C) 2020 Northwestern University.
  *   Copyright (C) 2021 Graz University of Technology.
+ *   Copyright (C) 2021 New York University.
  *
  * Invenio RDM Records is free software; you can redistribute it and/or modify
  * it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/search.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/search.less
@@ -1,5 +1,6 @@
 /*
  *   Copyright (C) 2020 CERN.
+ *   Copyright (C) 2021 New York University.
  *
  * Invenio App RDM is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/search.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/search.less
@@ -39,3 +39,7 @@
     margin-left: auto;
   }
 }
+/* Override style from webpack:///node_modules/semantic-ui-less/definitions/views/item.less line 444 */
+.ui.link.items > .item:hover {
+  cursor: auto !important;
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
@@ -1,6 +1,7 @@
 /*
  *   Copyright (C) 2019-2020 CERN.
  *   Copyright (C) 2019-2020 Northwestern University.
+ *   Copyright (C) 2021 New York University.
  *
  * Invenio App RDM is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
@@ -416,9 +416,11 @@ body {
   }
 }
 
+#details {
+  margin-top: 2rem;
+}
 #record-citation {
-  margin: 0px;
-
+  margin: -1rem 0 0 0;
   label {
     font-weight: 700;
   }
@@ -458,7 +460,20 @@ body {
         border: 2px solid rgba(119, 119, 119, 0.56);
         border-radius: 4px;
         padding: 3.5px;
+        display: inline-block;
       }
     }
+  }
+}
+.ui.items > .item .creatibutors, .creatibutors {
+  .header {
+    margin: 1rem auto .5rem;
+    font-size: 1.1rem;
+  }
+ span {
+    margin-right:.5rem;
+  }
+  a {
+    color: #646464;
   }
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
@@ -42,7 +42,7 @@ body {
   }
 
   a {
-    color: #dbeaff;
+    color: #f0f6ff;
   }
 }
 
@@ -101,7 +101,7 @@ body {
 .section-content-light-bg a,
 .hp-blog-section a {
   text-decoration: none;
-  color: #0377cdb5;
+  color: #0267b2;
   font-weight: 600;
 }
 

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/message.variables
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/message.variables
@@ -3,3 +3,4 @@
 *******************************/
 
 @import "@less/invenio_theme/theme/collections/message.variables";
+@infoTextColor: #0e576c;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/message.variables
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/message.variables
@@ -1,6 +1,10 @@
-/*******************************
-    User Variable Overrides
-*******************************/
+/*
+ *   Copyright (C) 2019-2020 CERN.
+ *   Copyright (C) 2021 New York University.
+ *
+ * Invenio App RDM is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
 
 @import "@less/invenio_theme/theme/collections/message.variables";
 @infoTextColor: #0e576c;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
@@ -1,0 +1,19 @@
+/*******************************
+         Theme Overrides
+*******************************/
+.ui.items > .item > .content > .header {
+  display: block;
+  a {
+    display: inline-block;
+    padding: .5rem 0 .1rem;
+    &:hover, &:focus {
+        text-decoration: underline;
+    }
+  }
+}
+.ui.items > .item .extra {
+    color:#666666;
+}
+.ui.items > .item .meta * {
+    margin-right: 0.1em;
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
@@ -1,6 +1,11 @@
-/*******************************
-         Theme Overrides
-*******************************/
+/*
+ *   Copyright (C) 2019-2020 CERN.
+ *   Copyright (C) 2021 New York University.
+ *
+ * Invenio App RDM is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+ 
 .ui.items > .item > .content > .header {
   display: block;
   a {

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
@@ -7,7 +7,10 @@
  */
 
 @linkColor: #005b9e;
+@linkUnderline: none;
 @linkHoverColor: darken(saturate(@linkColor, 20), 15, relative);
+@linkHoverUnderline: underline;
+
 @navbar_background_image: linear-gradient(12deg, rgba(3, 119, 205, 1), rgba(3, 119, 205, 1) 15%, rgba(251, 130, 115, 0.69));
 @navbar_background_color: rgba(3,119,205,1);
 @brand-primary: #0377cd;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
@@ -6,11 +6,14 @@
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
+@linkColor: #005b9e;
+@linkHoverColor: darken(saturate(@linkColor, 20), 15, relative);
 @navbar_background_image: linear-gradient(12deg, rgba(3, 119, 205, 1), rgba(3, 119, 205, 1) 15%, rgba(251, 130, 115, 0.69));
 @navbar_background_color: rgba(3,119,205,1);
 @brand-primary: #0377cd;
 @versionActive: #d9edf7;
 
+@green: #048622;
 @signupColor: @green;
 @searchButtonColor: #fb8273;
 
@@ -28,7 +31,7 @@
 
 @footerLightColor: #0377cd;
 @footerDarkColor: #0047a8;
-@footerTextLightColor: rgba(255, 255, 255, 0.86);
+@footerTextLightColor:#ffffff;
 @footerTextDarkColor: #ffffff;
 
 @font-size-base: 14px;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
@@ -1,6 +1,7 @@
 /*
  *   Copyright (C) 2019-2020 CERN.
  *   Copyright (C) 2019-2020 Northwestern University.
+ *   Copyright (C) 2021 New York University.
  *
  * Invenio App RDM is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/frontpage.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/frontpage.html
@@ -1,6 +1,7 @@
 {#
   Copyright (C) 2019-2020 CERN.
   Copyright (C) 2019-2020 Northwestern University.
+  Copyright (C) 2021 New York University.
 
   Invenio App RDM is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/frontpage.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/frontpage.html
@@ -13,8 +13,8 @@
 
 {%- block page_body %}
 {%- block first_section%}
-<section class="get-started-section section-content-white-bg">
-  <span class="section-title frontpage-title">{{ _("You've successfully installed InvenioRDM! What is ahead?") }}</span>
+<main class="get-started-section section-content-white-bg">
+  <h2 class="section-title frontpage-title">{{ _("You've successfully installed InvenioRDM! What is ahead?") }}</h2>
   <div class="ui container">
     <div class="ui padded relaxed centered grid">
       <div class="invenio-rdm-project-goals">
@@ -67,6 +67,6 @@
       </div>
     </div>
   </div>
-</section>
+</main>
 {%- endblock first_section%}
 {%- endblock page_body%}


### PR DESCRIPTION
This PR address 3 Accessibility issues:

- Some of the colors used are a bit too low-contrast. They are bumped up to at least 4.5:1.
- Semantic markup: some "Landmarks" are added. Also more headings tags (h2, mainly.) 
- For search results, instead of the whole item being linked, just the title is.  (Also, for this to work, the authors links needed to be updated.) 