### PR TITLE
A11y: iframe gets a title attribute

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -3,6 +3,7 @@
   Copyright (C) 2020 Northwestern University.
   Copyright (C) 2021 Graz University of Technology.
   Copyright (C) 2021 TU Wien.
+  Copyright (C) New York University.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -15,6 +15,7 @@
     {%- set preview_url = url_for(preview_endpoint, pid_value=pid_value, filename=filename) -%}
   {% endif %}
   <iframe
+    title="{{_("Preview")}}" 
     class="preview-iframe"
     id="{{id}}"
     name="{{id}}"


### PR DESCRIPTION
Iframes should have a title attribute, "to describe the contents of each frame. This provides a label for the frame so users can determine which frame to enter and explore in detail. "

see: https://www.w3.org/WAI/GL/WCAG20-TECHS/H64.html