### PR TITLE
a11y: Add name and id to the "Versions" toggle

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -294,6 +294,8 @@ export const RDMToggleComponent = ({
         <Checkbox
           toggle
           label={label}
+          name="versions-toggle"
+          id="versions-toggle"
           onClick={onToggleClicked}
           checked={isChecked}
         />


### PR DESCRIPTION
https://www.w3.org/TR/WCAG20/#minimize-error-cues

From NYU's a11y review - 

The toggle switch (checkbox) to turn on/off "All Versions" does not have a for/id association with the label/input.

Consider:

```
<div class="ui toggle checkbox">
   <input class="hidden" readonly="" tabindex="0" type="checkbox" value="" name="versions-toggle" id="versions-toggle">
   <label for="versions-toggle">View all versions</label>
</div>
```