### PR TITLE
A11y: markup for definition lists

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/export.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/export.html
@@ -2,6 +2,7 @@
   Copyright (C) 2020 CERN.
   Copyright (C) 2020 Northwestern University.
   Copyright (C) 2021 TU Wien.
+  Copyright (C) 2022 New York University.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/export.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/export.html
@@ -9,7 +9,7 @@
 
 {%- if config.get("APP_RDM_RECORD_EXPORTERS") -%}
 {# if no export formats are specified, don't bother showing the box #}
-<div class="ui segment rdm-sidebar exports">
+<dl class="ui segment rdm-sidebar exports">
   <dt><b>{{ _('Export')}}</b></dt>
   <hr class="thin-line">
   </hr>
@@ -27,5 +27,5 @@
       {%- endfor -%}
     </div>
   </dd>
-</div>
+</dl>
 {%- endif -%}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/export.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/export.html
@@ -10,9 +10,9 @@
 {%- if config.get("APP_RDM_RECORD_EXPORTERS") -%}
 {# if no export formats are specified, don't bother showing the box #}
 <dl class="ui segment rdm-sidebar exports">
-  <dt><b>{{ _('Export')}}</b></dt>
-  <hr class="thin-line">
-  </hr>
+  <dt><b>{{ _('Export')}}</b>
+    <hr class="thin-line">
+  </dt>
   <dd class="top-bottom-padded">
     <div class="ui celled horizontal list separated-list">
       {# dynamically create the list of export formats #}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/metrics.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/metrics.html
@@ -10,9 +10,9 @@
 {#
 <!-- TODO add again once the metrics are working -->
 <dl class="ui segment rdm-sidebar">
-  <dt><b>{{ _('Metrics')}}</b></dt>
-  <hr class="thin-line">
-  </hr>
+  <dt><b>{{ _('Metrics')}}</b>
+    <hr class="thin-line">
+  </dt>
   <dd>
     <!-- Stats -->
     {%- include "invenio_app_rdm/landing_page/details/stats.html" %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/metrics.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/metrics.html
@@ -9,7 +9,7 @@
 
 {#
 <!-- TODO add again once the metrics are working -->
-<div class="ui segment rdm-sidebar">
+<dl class="ui segment rdm-sidebar">
   <dt><b>{{ _('Metrics')}}</b></dt>
   <hr class="thin-line">
   </hr>
@@ -17,5 +17,5 @@
     <!-- Stats -->
     {%- include "invenio_app_rdm/landing_page/details/stats.html" %}
   </dd>
-</div>
+</dl>
 #}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/metrics.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/metrics.html
@@ -2,6 +2,7 @@
   Copyright (C) 2020 CERN.
   Copyright (C) 2020 Northwestern University.
   Copyright (C) 2021 TU Wien.
+  Copyright (C) 2022 New York University.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/versions.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/versions.html
@@ -7,11 +7,11 @@
   it under the terms of the MIT License; see LICENSE file for more details.
 -#}
 
-<div class="ui segment rdm-sidebar">
+<dl class="ui segment rdm-sidebar">
   <dt><b>{{ _('Versions')}}</b></dt>
   <hr class="thin-line">
   </hr>
   <dd class="versions">
     <div id="recordVersions" data-record='{{ record | tojson }}' data-preview='{{ is_preview | tojson }}'></div>
   </dd>
-</div>
+</dl>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/versions.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/versions.html
@@ -8,9 +8,9 @@
 -#}
 
 <dl class="ui segment rdm-sidebar">
-  <dt><b>{{ _('Versions')}}</b></dt>
-  <hr class="thin-line">
-  </hr>
+  <dt><b>{{ _('Versions')}}</b>
+    <hr class="thin-line">
+  </dt>
   <dd class="versions">
     <div id="recordVersions" data-record='{{ record | tojson }}' data-preview='{{ is_preview | tojson }}'></div>
   </dd>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/versions.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/versions.html
@@ -2,6 +2,7 @@
   Copyright (C) 2020 CERN.
   Copyright (C) 2020 Northwestern University.
   Copyright (C) 2021 TU Wien.
+  Copyright (C) 2022 New York University.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.


### PR DESCRIPTION
Updating markup to meet requirements:

- `<dt>` and `<dd>` elements must be contained by a `<dl>`
-- https://dequeuniversity.com/rules/axe/4.3/dlitem
- `<dl>` elements must only directly contain properly-ordered `<dt>` and `<dd>`groups, `<script>`, or `<template>` elements
-- https://dequeuniversity.com/rules/axe/4.3/definition-list 