### PR TITLE
Search Facets: disclosure arrows and global focus-visible styles

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -194,10 +194,13 @@ export const RDMRecordFacetsValues = ({
           </Label>
         </List.Content>
         {hasChildren ? (
-          <i
-            className={`angle ${isActive ? "down" : "right"} icon`}
+          <button
+            className={`iconhold`}
             onClick={() => setisActive(!isActive)}
-          ></i>
+            aria-label={`${isActive ? i18next.t("hide subfacets") : i18next.t("show subfacets") }`}
+          >
+            <i className={`angle ${isActive ? "down" : "right"} icon`}></i>
+          </button>
         ) : null}
         <Checkbox
           label={bucket.label || keyField}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -195,7 +195,7 @@ export const RDMRecordFacetsValues = ({
         </List.Content>
         {hasChildren ? (
           <button
-            className={`iconhold`}
+            className="iconhold"
             onClick={() => setisActive(!isActive)}
             aria-label={`${isActive ? i18next.t("hide subfacets") : i18next.t("show subfacets") }`}
           >

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/button.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/button.overrides
@@ -9,3 +9,15 @@
 .copy.button {
     margin-right: 0px;
 }
+
+button.iconhold  {
+    background-color: inherit;
+    border: none;
+    padding: 5px 5px 5px 0;
+    text-align: center;
+    width: 17px;
+    margin-right: 3px;
+    &:hover, &:focus {
+        background-color: inherit;
+    }
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -3,3 +3,7 @@
 *******************************/
 
 @import "@less/invenio_theme/theme/globals/site.overrides";
+
+*:focus-visible {
+    outline: 3px solid @focusedFormBorderColor !important;
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
@@ -12,6 +12,9 @@
 @linkHoverColor: darken(saturate(@linkColor, 20), 15, relative);
 @linkHoverUnderline: underline;
 
+@focusedFormBorderColor: #2185D0;
+@focusedFormMutedBorderColor: #2185D0;
+
 @navbar_background_image: linear-gradient(12deg, rgba(3, 119, 205, 1), rgba(3, 119, 205, 1) 15%, rgba(251, 130, 115, 0.69));
 @navbar_background_color: rgba(3,119,205,1);
 @brand-primary: #0377cd;


### PR DESCRIPTION
- wrapping the `<i>` icon in a `<button>` element, because button natively gets focus and is recognized as such (you can tab to it, and screenreaders know it is interactive)
- surfacing semantic ui's @focusedFormBorderColor variable; setting global focus-visible styles (used mainly when an element is tabbed to