### PR TITLE
A11y: facet arrows, affiliation buttons, ROR icons, one duplicate ID

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/contributors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/contributors.html
@@ -1,7 +1,7 @@
 {#
     Copyright (C) 2020 CERN.
     Copyright (C) 2020 Northwestern University.
-    Copyright (C) 2021 New York University.
+    Copyright (C) 2021-2022 New York University.
 
     Invenio RDM Records is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.
@@ -15,14 +15,14 @@
       <h2 class="header">{{group.grouper}}(s)</h2>
       {{ show_creatibutors(group.list, show_affiliations=True) }}
       {% if record.ui.contributors.affiliations %}
-      <a style="cursor: pointer;" class="dropdown">
+      <button type="button" class="dropdown button-affiliations" aria-controls="affiliations-c{{loop.index}}">
         <span class="up ui label small">{{ _("Show affiliations") }}</span>
         <span class="down ui label small">{{ _("Hide affiliations") }}</span>
-      </a>
+      </button>
       {% endif %}
     </div>
     {% if record.ui.contributors.affiliations %}
-    <div class="content">
+    <div id="affiliations-c{{loop.index}}" class="content">
       <div class="transition hidden">
         {{ show_affiliations(record.ui.contributors.affiliations) }}
       </div>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creators.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creators.html
@@ -2,6 +2,7 @@
     Copyright (C) 2020 CERN.
     Copyright (C) 2020 Northwestern University.
     Copyright (C) 2021 Graz University of Technology.
+    Copyright (C) 2021-2022 New York University.
 
     Invenio RDM Records is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.
@@ -13,15 +14,15 @@
   <div class="title">
     {{ show_creatibutors(record.ui.creators.creators, show_affiliations=True) }}
     {% if record.ui.creators.affiliations %}
-    <a style="cursor: pointer;" class="dropdown">
+    <button type="button" class="dropdown button-affiliations" aria-controls="affiliations-creators">
       <span class="up ui label small">{{ _("Show affiliations") }}</span>
       <span class="down ui label small">{{ _("Hide affiliations") }}</span>
-    </a>
+    </button>
     {% endif %}
   </div>
 
   {% if record.ui.creators.affiliations %}
-  <div class="content">
+  <div id="affiliations-creators" class="content">
     <div class="transition hidden">
       {{ show_affiliations(record.ui.creators.affiliations) }}
     </div>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
@@ -2,7 +2,7 @@
     Copyright (C) 2020 CERN.
     Copyright (C) 2020 Northwestern University.
     Copyright (C) 2021 Graz University of Technology.
-    Copyright (C) 2021 New York University.
+    Copyright (C) 2021-2022 New York University.
 
     Invenio RDM Records is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.
@@ -54,7 +54,7 @@
   {% for affiliation in affiliations %}
       {{ affiliation[0] }}.
       {%- if affiliation[2] %}
-        <a href="https://ror.org/{{affiliation[2]}}"><img class="inline-id-icon" src="{{ url_for('static', filename='images/ror-icon.svg') }}"/></a>
+        <a href="https://ror.org/{{affiliation[2]}}" aria-label="{{ affiliation[1] }}: {{ _("ROR profile") }}"><img class="inline-id-icon" src="{{ url_for('static', filename='images/ror-icon.svg') }}" alt="" /></a>
       {%- endif %}
       {{affiliation[1]}}
     <br />

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCitationField.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCitationField.js
@@ -108,13 +108,13 @@ export class RecordCitationField extends Component {
     })
 
     return (
-      <Grid id="record-citation">
-        <Grid.Row verticalAlign="middle" className="relaxed">
-          <Grid.Column mobile={8} tablet={8} computer={12} className="no-padding">
+      <Grid>
+        <Grid.Row verticalAlign="middle" >
+          <Grid.Column mobile={8} tablet={8} computer={10}>
             <Header as="h2">{i18next.t("Citation")}</Header>
           </Grid.Column>
 
-          <Grid.Column mobile={8} tablet={8} computer={4} className="no-padding" textAlign="right">
+          <Grid.Column mobile={8} tablet={8} computer={6} textAlign="right">
             <div className="citation-style-selector">
               <label id="citation-style-label">{i18next.t("Style")}</label>
               <Dropdown
@@ -133,13 +133,13 @@ export class RecordCitationField extends Component {
         </Grid.Row>
 
         <Grid.Row verticalAlign="bottom">
-          <Grid.Column computer={12} className="no-padding">
+          <Grid.Column computer={12}>
             <div id="citation-text">
               {loading ? this.placeholderLoader() : citation}
             </div>
           </Grid.Column>
 
-          <Grid.Column computer={4} className="no-padding" textAlign="right">
+          <Grid.Column computer={4} textAlign="right">
             <CopyButton text={citation}/>
           </Grid.Column>
         </Grid.Row>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2020-2021 CERN.
 // Copyright (C) 2020-2021 Northwestern University.
 // Copyright (C) 2021 Graz University of Technology.
-// Copyright (C) 2021 New York University.
+// Copyright (C) 2021-2022 New York University.
 //
 // Invenio App RDM is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -194,10 +194,13 @@ export const RDMRecordFacetsValues = ({
           </Label>
         </List.Content>
         {hasChildren ? (
-          <i
-            className={`angle ${isActive ? "down" : "right"} icon`}
+          <button
+            className="iconhold"
             onClick={() => setisActive(!isActive)}
-          ></i>
+            aria-label={`${isActive ? i18next.t("hide subfacets") : i18next.t("show subfacets") }`}
+          >
+            <i className={`angle ${isActive ? "down" : "right"} icon`}></i>
+          </button>
         ) : null}
         <Checkbox
           label={bucket.label || keyField}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -28,6 +28,9 @@
         margin-left: 10px;
       }
     }
+    .citation-error-message {
+      color: @citationErrorMessage;
+    }
    }
  }
 .font-small {

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -16,7 +16,18 @@
     font-size: 1.3rem;
    }
    &#record-citation{
-     padding-bottom: .5rem;
+    label {
+      font-weight: 700;
+    }
+    .citation-style-selector {
+      display: inline-block;
+      width: 157px;
+      .ui.selection.dropdown {
+        min-width: 112px;
+        max-width: 112px;
+        margin-left: 10px;
+      }
+    }
    }
  }
 .font-small {

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
@@ -420,27 +420,6 @@ body {
 #details {
   margin-top: 2rem;
 }
-#record-citation {
-  margin: -1rem 0 0 0;
-  label {
-    font-weight: 700;
-  }
-
-  .citation-style-selector {
-    display: inline-block;
-    width: 157px;
-
-    .ui.selection.dropdown {
-      min-width: 112px;
-      max-width: 112px;
-      margin-left: 10px;
-    }
-  }
-
-  .citation-error-message {
-    color: #9f3a38;
-  }
-}
 
 #record-subjects {
   .subject-scheme {

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/button.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/button.overrides
@@ -21,3 +21,9 @@ button.iconhold  {
         background-color: inherit;
     }
 }
+
+button.button-affiliations  {
+    background-color: inherit;
+    border: none;
+    cursor: pointer;
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/button.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/button.overrides
@@ -9,3 +9,15 @@
 .copy.button {
     margin-right: 0px;
 }
+
+button.iconhold  {
+    background-color: inherit;
+    border: none;
+    padding: 5px 5px 5px 0;
+    text-align: center;
+    width: 17px;
+    margin-right: 3px;
+    &:hover, &:focus {
+        background-color: inherit;
+    }
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -7,3 +7,8 @@
 button:focus-visible, a:focus-visible {
     outline: 3px solid @focusedFormBorderColor !important;
 }
+
+/* Overriding override in invenio_theme ... globals/site.overrides line 61 */
+.right.floated.right.aligned.column {
+    padding: 0 1rem;
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -3,3 +3,7 @@
 *******************************/
 
 @import "@less/invenio_theme/theme/globals/site.overrides";
+
+button:focus-visible, a:focus-visible {
+    outline: 3px solid @focusedFormBorderColor !important;
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
@@ -12,6 +12,9 @@
 @linkHoverColor: darken(saturate(@linkColor, 20), 15, relative);
 @linkHoverUnderline: underline;
 
+@focusedFormBorderColor: #2185D0;
+@focusedFormMutedBorderColor: #2185D0;
+
 @navbar_background_image: linear-gradient(12deg, rgba(3, 119, 205, 1), rgba(3, 119, 205, 1) 15%, rgba(251, 130, 115, 0.69));
 @navbar_background_color: rgba(3,119,205,1);
 @brand-primary: #0377cd;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
@@ -23,6 +23,7 @@
 @green: #048622;
 @signupColor: @green;
 @searchButtonColor: #fb8273;
+@citationErrorMessage: #9f3a38;
 
 @coverPageDefaultMargin: 0;
 


### PR DESCRIPTION
- Search facets' disclosure arrows - wrapping the `<i>` icon in a `<button>` element, because `button` natively gets focus and is recognized as such (you can tab to it, and screenreaders know it is interactive)
- Surfacing semantic ui's @focusedFormBorderColor variable; setting global `focus-visible` styles (used mainly when an element is tabbed to
- Affiliations buttons - wrapping the `<i>` icon in a `<button>` element
- Affiliations buttons - associating them with the element they control
- ROR icons - aria-labels and alt tags
- Landing page record citation area -- the id "record-citation" should only appear once.  
- Landing page record citation area, tidying some grid-related alignment issues

Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1195
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1194
