### PR TITLE
Make ORCID icons larger and swap order

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,30 +33,9 @@ jobs:
     strategy:
       matrix:
           python-version: [3.7, 3.8, 3.9]
-          requirements-level: [min, pypi]
+          requirements-level: [pypi]
           db-service: [postgresql10, postgresql13]
-          search-service: [elasticsearch6, elasticsearch7]
-          exclude:
-          - python-version: 3.7
-            requirements-level: pypi
-
-          - python-version: 3.8
-            requirements-level: min
-
-          - python-version: 3.9
-            requirements-level: min
-
-          - db-service: postgresql13
-            requirements-level: min
-
-          - search-service: elasticsearch7
-            requirements-level: min
-
-          - db-service: postgresql10
-            requirements-level: pypi
-
-          - search-service: elasticsearch6
-            requirements-level: pypi
+          search-service: [elasticsearch7]
           include:
           - db-service: postgresql10
             DB_EXTRAS: "postgresql"
@@ -64,12 +43,8 @@ jobs:
           - db-service: postgresql13
             DB_EXTRAS: "postgresql"
 
-          - search-service: elasticsearch6
-            SEARCH_EXTRAS: "elasticsearch6"
-
           - search-service: elasticsearch7
             SEARCH_EXTRAS: "elasticsearch7"
-
     env:
       DB: ${{ matrix.db-service }}
       SEARCH: ${{ matrix.search-service }}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
@@ -2,7 +2,7 @@
     Copyright (C) 2020 CERN.
     Copyright (C) 2020 Northwestern University.
     Copyright (C) 2021 Graz University of Technology.
-    Copyright (C) 2021 New York University.
+    Copyright (C) 2021-2022 New York University.
 
     Invenio RDM Records is free software; you can redistribute it and/or modify
     it under the terms of the MIT License; see LICENSE file for more details.
@@ -35,8 +35,7 @@
 {% macro show_creatibutors(creatibutors, show_affiliations=False) %}
   {% for creatibutor in creatibutors %}
   <dd class="creatibutor-wrap">
-    {{ creatibutor_icon(creatibutor) }}
-    <a class="ui tooltip-popup text-muted creatibutor-link"
+    <a class="ui tooltip-popup creatibutor-link"
       {% if show_affiliations and creatibutor.affiliations %}
         data-content="{{ creatibutor.affiliations|join('; ', attribute='1') }}"
       {% endif %}
@@ -44,15 +43,20 @@
     >
 
       <span class="creatibutor-name">
-        {{ creatibutor.person_or_org.name }}
+        {{- creatibutor.person_or_org.name -}}
       </span>
-
-      <sup class="font-tiny text-muted">
-        {% for affiliation in creatibutor.affiliations %}
+      {%- if creatibutor.affiliations -%}
+      <sup class="font-tiny">
+        {%- for affiliation in creatibutor.affiliations -%}
           {{ affiliation[0] }}{{ ", " if not loop.last }}
-        {% endfor %}
+        {%- endfor -%}
       </sup>
+      {%- endif -%}
     </a>
+    {{- creatibutor_icon(creatibutor) -}}
+    {%- if not loop.last -%}
+       <span class="separator">;</span>
+    {%- endif -%}
   </dd>
   {% endfor %}
 {%- endmacro %}
@@ -66,13 +70,13 @@
   </div>
 </div>
 
-<section class="ui sixteen wide column content" id="{{ group }}-affiliations" aria-label="{{ _('Affiliations for') }} {{ group }}">
+<section class="ui sixteen wide column content affiliations-list" id="{{ group }}-affiliations" aria-label="{{ _('Affiliations for') }} {{ group }}">
   <dl>
   {% for affiliation in affiliations %}
-      <dd class="text-muted">
+      <dd>
           {{ affiliation[0] }}.
 
-          {%- if affiliation[2] %}
+          {% if affiliation[2] %}
           <a class="identifier-link"
              href="https://ror.org/{{affiliation[2]}}"
              aria-label="{{ affiliation[1] }}'s ROR {{ _('profile') }}"

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -83,9 +83,9 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
         <Item.Header as="h2">
           <a href={viewLink}>{title}</a>
         </Item.Header>
-        <Item.Meta className="creatibutors">
+        <Item className="creatibutors">
           <SearchItemCreators creators={creators} />
-        </Item.Meta>
+        </Item>
         <Item.Description>
           {_truncate(description_stripped, { length: 350 })}
         </Item.Description>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
@@ -53,6 +53,7 @@ export function SearchItemCreators({ creators }) {
       case "orcid":
         icon = (
           <a
+            className="identifier-link"
             href={"https://orcid.org/" + `${firstId.identifier}`}
             aria-label={`${creatorName}: ${i18next.t("ORCID profile")}`}
             title={`${creatorName}: ${i18next.t("ORCID profile")}`}
@@ -90,18 +91,19 @@ export function SearchItemCreators({ creators }) {
     let creatorName = _get(creator, "person_or_org.name", "No name");
     let link = (
       <a
+        class="creatibutor-link"
         href={`/search?q=metadata.creators.person_or_org.name:"${creatorName}"`}
         title={`${creatorName}: ${i18next.t("Search")}`}
       >
-        {creatorName}
+        <span class="creatibutor-name">{creatorName}</span>
       </a>
     );
     return link;
   }
   return creators.map((creator, index) => (
-    <span key={index}>
-      {getIcon(creator)}
+    <span class="creatibutor-wrap" key={index}>
       {getLink(creator)}
+      {getIcon(creator)}
       {index < creators.length - 1 && ";"}
     </span>
   ));

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
@@ -2,12 +2,61 @@
  *   Copyright (C) 2020 CERN.
  *   Copyright (C) 2020 Northwestern University.
  *   Copyright (C) 2021 Graz University of Technology.
- *   Copyright (C) 2021 New York University.
+ *   Copyright (C) 2021-2022 New York University.
  *
  * Invenio RDM Records is free software; you can redistribute it and/or modify
  * it under the terms of the MIT License; see LICENSE file for more details.
  */
 
+.creatibutors {
+  margin: 0rem 0rem 0.5rem 0rem;
+  display: flex;
+  flex-wrap: wrap;
+  &:last-child {
+    margin-bottom: 0rem;
+  }
+
+  dt {
+    font-weight: bold;
+    margin: 0rem 0.25rem 0rem 0rem;
+
+    &.hidden {
+      display: none;
+    }
+  }
+
+  .creatibutor-wrap {
+    color: @mutedTextColor;
+    display: flex;
+    flex-wrap: wrap;
+    &:nth-child(n):not(:last-child) {
+      margin-right: 1rem;
+    }
+    .identifier-link, .group.icon {
+      margin: 0 .1rem 0 .2rem;
+    }
+  }
+}
+.creatibutor-link {
+  color: @mutedTextColor;
+  &:hover {
+    text-decoration: none;
+    span {
+      color: @mutedTextColor;
+      text-decoration: underline;
+    }
+    sup {
+      color: @mutedTextColor;
+    }
+  }
+  sup {
+    color: @mutedTextColor;
+    padding-left: .1rem;
+  }
+}
+.affiliations-list {
+  color: @mutedTextColor;
+}
 .row.ui.accordion.affiliations-accordion {
   padding-bottom: 1.5rem;
 
@@ -38,37 +87,10 @@
       min-width: max-content;
     }
   }
-
-  dl.creatibutors {
-    margin: 0rem 0rem 0.5rem 0rem;
-
-    &:last-child {
-      margin-bottom: 0rem;
-    }
-
-    dt {
-      display: inline;
-      font-weight: bold;
-      margin: 0rem 0.25rem 0rem 0rem;
-
-      &.hidden {
-        display: none;
-      }
-    }
-
-    dd.creatibutor-wrap {
-      display: inline;
-
-      &:nth-child(n):not(:last-child) {
-        margin-right: 0.5rem;
-      }
-    }
-  }
-
   .content {
     dl {
       font-size: @font-size-small;
-      background-color: #F9FAFB;
+      background-color: #f9fafb;
       padding: 1rem;
       margin: 1.2rem 0rem 0rem 0rem;
     }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
@@ -354,10 +354,9 @@ body {
 }
 
 .inline-id-icon {
-  height: @font-size-base;
-  vertical-align: middle;
-  margin-bottom: 3px;
-  padding-right: 2px;
+  height: 16px;
+  width: auto;
+  vertical-align: text-bottom;
 }
 
 .ui.grid {
@@ -470,8 +469,8 @@ body {
   display: inline-block;
   padding: .18rem .6rem;
   box-sizing: border-box;
-  color: #757575;
-  border: 2px solid rgba(119, 119, 119, 0.56);
+  color: @mutedTextColor;
+  border: 2px solid @lightTextColor;
   border-radius: 4px;
   cursor: pointer;
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
@@ -17,8 +17,5 @@
   }
 }
 .ui.items > .item .extra {
-    color:#666666;
-}
-.ui.items > .item .meta * {
-    margin-right: 0.1em;
+    color: @mutedTextColor;
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/variables.less
@@ -1,7 +1,7 @@
 /*
  *   Copyright (C) 2019-2020 CERN.
  *   Copyright (C) 2019-2020 Northwestern University.
- *   Copyright (C) 2021 New York University.
+ *   Copyright (C) 2021-2022 New York University.
  *
  * Invenio App RDM is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
@@ -16,6 +16,7 @@
 @focusedFormMutedBorderColor: #2185d0;
 
 @errorText: #9f3a38;
+@mutedTextColor: #757575;
 
 @navbar_background_image: linear-gradient(
   12deg,


### PR DESCRIPTION
* moves Icon after name for both landing page and search results
* standardizes the color of the linked names
* standardizes html classes for landing page and search results so they can be styled together
* closes #1161 
