### PR TITLE
landing page: link subjects to search results

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/subjects.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/subjects.html
@@ -12,19 +12,33 @@
 {% if subjects %}
   {% set keywords = subjects|rejectattr("scheme")|list %}
   {% if keywords %}
-  <dl class="details-list" aria-label="{{ _('Keywords') }}">
+  <dl class="details-list subjects" aria-label="{{ _('Keywords') }}">
     <dt class="hidden">{{ _('Keywords') }}</dt>
     {%- for subject in keywords %}
-      <dd class="subject">{{ subject.subject}}</dd>
+      <dd>
+        <a href='/search?q=metadata.subjects.subject:"{{ subject.subject }}"'
+           class="subject"
+           title="{{ _('Search results for ') + subject.subject }}"
+        >
+          {{ subject.subject }}
+        </a>
+      </dd>
     {%- endfor %}
   </dl>
   {% endif %}
 
   {%- for scheme, subjects in subjects|selectattr("scheme")|groupby('scheme')|sort(attribute='scheme') %}
-  <dl class="details-list" aria-label="{{ _('Subjects') }}">
+  <dl class="details-list subjects" aria-label="{{ _('Subjects') }}">
     <dt class="ui tiny header">{{scheme}}</dt>
     {%- for subject in subjects %}
-      <dd class="subject">{{ subject.subject}}</dd>
+    <dd>
+      <a href='/search?q=metadata.subjects.subject:"{{ subject.subject }}"'
+         class="subject"
+         title="{{ _('Search results for ') + subject.subject }}"
+      >
+        {{ subject.subject }}
+      </a>
+    </dd>
     {%- endfor %}
   </dl>
   {%- endfor %}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -322,6 +322,17 @@ dl.details-list {
       margin-bottom: 0.25rem;
     }
   }
+
+  &.subjects dd {
+    display: inline-block;
+    margin-bottom: .4rem;
+    margin-right: .1rem;
+
+    &:last-child {
+      margin-bottom: 0;
+      margin-right: 0;
+    }
+  }
 }
 
 .language {

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
@@ -477,12 +477,18 @@ body {
 
 .subject {
   display: inline-block;
-  padding: 3px 10px;
-  margin-bottom: 3px;
+  padding: .18rem .6rem;
   box-sizing: border-box;
-  color: #777;
+  color: #757575;
   border: 2px solid rgba(119, 119, 119, 0.56);
   border-radius: 4px;
+  cursor: pointer;
+}
+
+a.subject:hover {
+  background-color: rgba(119, 119, 119, 0.07);
+  color: darken(#757575, 15%);
+  text-decoration: none;
 }
 
 .ui.segment.rdm-sidebar dl {


### PR DESCRIPTION
Closes #1226
Linked subjects to search result page for the respective subject

__Screenshots__
<img width="312" alt="Screenshot 2022-02-16 at 14 48 10" src="https://user-images.githubusercontent.com/21052053/154279794-8e75e369-7218-482b-ae14-1f7d5fbaeb91.png">

__Hover state__
<img width="312" alt="Screenshot 2022-02-16 at 14 48 16" src="https://user-images.githubusercontent.com/21052053/154279963-0a4b6571-fbba-4dbe-9ab8-ef6a29f87ccd.png">

