### PR TITLE
Communities: hide content when communities are not enabled.

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/dashboard.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/dashboard.html
@@ -35,6 +35,7 @@
   data-invenio-search-user-uploads-config='{{ search_app_user_uploads_config(app_id="user-uploads-search") | tojson }}'
   data-invenio-search-user-communities-config='{{ search_app_user_communities_config(app_id="user-communities-search") | tojson }}'
   data-invenio-search-user-requests-config='{{ search_app_user_requests_config(app_id="user-requests-search") | tojson }}'
-  data-active-tab-name={{dashboard_name}}>
+  data-active-tab-name='{{dashboard_name | tojson }}'
+  data-communities-enabled ='{{communities_enabled | tojson}}'>
 </div>
 {%- endblock page_body %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -27,6 +27,7 @@
   {%- if forms_config %}
   <input type="hidden" name="deposits-config" value='{{forms_config | tojson }}'></input>
   {%- endif %}
+  <input type="hidden" name="communities-enabled" value='{{communities_enabled | tojson }}'></input>
   {%- if permissions %}
   <input id="deposits-record-permissions" type="hidden" name="deposits-record-permissions" value='{{permissions | tojson }}'></input>
   {%- endif %}

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -287,11 +287,13 @@ def new_record():
 @login_required
 def dashboard(dashboard_name=None):
     """Display user dashboard page."""
+    if not current_app.config["COMMUNITIES_ENABLED"] or not dashboard_name:
+        dashboard_name = current_app.config["_DASHBOARD_ROUTES"][0]
     return render_template(
         "invenio_app_rdm/records/dashboard.html",
-        dashboard_name=dashboard_name or current_app.config[
-            "_DASHBOARD_ROUTES"][0],
+        dashboard_name=dashboard_name,
         searchbar_config=dict(searchUrl=get_search_url()),
+        communities_enabled=current_app.config["COMMUNITIES_ENABLED"]
     )
 
 
@@ -307,6 +309,7 @@ def deposit_create(community=None):
         files=dict(
             default_preview=None, entries=[], links={}
         ),
+        communities_enabled=current_app.config["COMMUNITIES_ENABLED"],
         community=community
     )
 
@@ -325,6 +328,7 @@ def deposit_edit(draft=None, draft_files=None, pid_value=None):
         forms_config=get_form_config(apiUrl=f"/api/records/{pid_value}/draft"),
         record=record,
         community=community_uuid,
+        communities_enabled=current_app.config["COMMUNITIES_ENABLED"],
         files=draft_files.to_dict(),
         searchbar_config=dict(searchUrl=get_search_url()),
         permissions=draft.has_permissions_to(['new_version'])

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -136,7 +136,8 @@ export class RDMDepositForm extends Component {
   };
 
   render() {
-    const { record, files, permissions, community } = this.props;
+    const { record, files, permissions, community, communitiesEnabled } =
+      this.props;
     return (
       <DepositFormApp
         config={this.config}
@@ -145,10 +146,10 @@ export class RDMDepositForm extends Component {
         files={files}
         permissions={permissions}
       >
-        <CommunityHeader
+        {communitiesEnabled && <CommunityHeader
           community={community}
           imagePlaceholderLink="/static/images/square-placeholder.png"
-        />
+        />}
         <FormFeedback fieldPath="message" />
         <Container style={{ marginTop: "10px" }}>
           <DepositFormTitle />

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/index.js
@@ -19,6 +19,7 @@ ReactDOM.render(
     files={getInputFromDOM("deposits-record-files")}
     config={getInputFromDOM("deposits-config")}
     permissions={getInputFromDOM("deposits-record-permissions")}
+    communitiesEnabled={getInputFromDOM("communities-enabled")}
   />,
   document.getElementById("deposit-form")
 );

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header.html
@@ -75,7 +75,7 @@
                     </li>
                 {% endfor %}
                 {%- if config.ACCOUNTS and current_user.is_authenticated %}
-                  {% for item in current_menu.submenu('requests').children|sort(attribute='order') if item.visible recursive %}
+                  {% for item in current_menu.submenu('notifications').children|sort(attribute='order') if item.visible recursive %}
                       <li class="navbar-item">
                         <a href="{{ item.url }}"><i class="fitted inbox icon inverted"></i></a>
                       </li>

--- a/invenio_app_rdm/theme/views.py
+++ b/invenio_app_rdm/theme/views.py
@@ -41,19 +41,20 @@ def create_blueprint(app):
             order=1
         )
 
-        current_menu.submenu('requests.deposit').register(
-            'invenio_app_rdm_records.dashboard',
-            endpoint_arguments_constructor=lambda: {
-                           'dashboard_name': 'requests',
-            },
-            order=1
-        )
-
         current_menu.submenu('plus.deposit').register(
             'invenio_app_rdm_records.deposit_create',
             _('New upload'),
             order=1,
         )
+
+        if app.config.get("COMMUNITIES_ENABLED", False):
+            current_menu.submenu("notifications.requests").register(
+                "invenio_app_rdm_records.dashboard",
+                endpoint_arguments_constructor=lambda: {
+                    "dashboard_name": "requests",
+                },
+                order=1,
+            )
 
     return blueprint
 


### PR DESCRIPTION
Hide communities from dashboard.
Hide requests from dashboard.
Ensure is properly redirected when trying to access hidden content.
Hide selected community from deposit form.
Move the requests notifications link responsability to invenio-communities.
closes inveniosoftware/invenio-app-rdm#1268
![Screenshot from 2022-02-24 17-26-57](https://user-images.githubusercontent.com/25476209/155566465-98a3e72b-ec35-4cf5-8728-cee90db43233.png)
![Screenshot from 2022-02-24 17-27-27](https://user-images.githubusercontent.com/25476209/155566469-a26742f0-dcb4-45a6-a2e4-9d63daeda329.png)
![Screenshot from 2022-02-24 17-33-59](https://user-images.githubusercontent.com/25476209/155567046-09e4ab5c-ecbe-4365-baf1-94974a5c9d8c.png)
![Screenshot from 2022-02-24 17-34-17](https://user-images.githubusercontent.com/25476209/155567052-2cd96178-05ca-41ba-88a5-24f1c42e78c0.png)


