### PR TITLE
search: redesign no-results page and add clear facets button

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -223,20 +223,11 @@ export const RDMRecordFacetsValues = ({
 export const SearchHelpLinks = () => {
   return (
     <Overridable id={"RdmSearch.SearchHelpLinks"}>
-      <Grid className="padded-small">
-        <Grid.Row className="no-padded">
-          <Grid.Column></Grid.Column>
-        </Grid.Row>
-        <Grid.Row className="no-padded">
-          <Grid.Column>
-            <Card className="borderless-facet">
-              <Card.Content>
-                <a href="/help/search">{i18next.t("Search guide")}</a>
-              </Card.Content>
-            </Card>
-          </Grid.Column>
-        </Grid.Row>
-      </Grid>
+      <List>
+        <List.Item>
+          <a href="/help/search">{i18next.t("Search guide")}</a>
+        </List.Item>
+      </List>
     </Overridable>
   );
 };
@@ -256,16 +247,42 @@ export const RDMRecordFacets = ({ aggs, currentResultsState }) => {
           </div>
         );
       })}
-      <SearchHelpLinks />
+      <Card className="borderless-facet">
+        <Card.Content>
+          <Card.Header>{ i18next.t('Help') }</Card.Header>
+          <SearchHelpLinks />
+        </Card.Content>
+      </Card>
     </aside>
   );
 };
 
-export const RDMBucketAggregationElement = ({ title, containerCmp }) => {
+export const RDMBucketAggregationElement = ({agg, title, containerCmp, updateQueryFilters}) => {
+
+  const clearFacets = () => {
+    if (containerCmp.props.selectedFilters.length) {
+      updateQueryFilters(
+        [agg.aggName, ''],
+        containerCmp.props.selectedFilters
+      );
+    }
+  }
+
   return (
     <Card className="borderless-facet">
       <Card.Content>
-        <Card.Header>{title}</Card.Header>
+        <Card.Header>
+          {title}
+          <Button basic icon
+                  size="mini"
+                  floated="right"
+                  onClick={clearFacets}
+                  aria-label={ i18next.t('Clear selection') }
+                  title={ i18next.t('Clear selection') }
+          >
+            { i18next.t('Clear') }
+          </Button>
+        </Card.Header>
       </Card.Content>
       <Card.Content>{containerCmp}</Card.Content>
     </Card>
@@ -317,20 +334,46 @@ export const RDMCountComponent = ({ totalResults }) => {
 
 export const RDMEmptyResults = (props) => {
   const queryString = props.queryString;
+  const searchPath = props.searchPath || '/search';
+
   return (
-    <>
-      <Segment placeholder textAlign="center">
-        <Header icon>
-          <Icon name="search" />
-          {i18next.t("No results found!")}
-        </Header>
-        {queryString && (
-          <Button primary onClick={() => props.resetQuery()}>
-            {i18next.t("Reset search")}
-          </Button>
-        )}
-      </Segment>
-    </>
+      <Grid>
+        <Grid.Row centered>
+          <Grid.Column width={12} textAlign="center">
+            <Header as="h2">
+              {i18next.t("We couldn't find any matches for ")}
+              {queryString && (`'${queryString}'`) || i18next.t('your search')}
+            </Header>
+          </Grid.Column>
+        </Grid.Row>
+        <Grid.Row centered>
+          <Grid.Column width={8} textAlign="center">
+            <Button primary onClick={props.resetQuery}>
+              <Icon name="search"/>
+              { i18next.t('Start over') }
+              </Button>
+          </Grid.Column>
+        </Grid.Row>
+        <Grid.Row centered>
+          <Grid.Column width={12}>
+            <Segment secondary padded size="large">
+              <Header as="h3" size="small">{i18next.t('ProTip')}!</Header>
+              <p>
+                <a href={`${searchPath}?q=metadata.publication_date:[2017-01-01 TO *]`}>
+                  metadata.publication_date:[2017-01-01 TO *]
+                </a> { i18next.t('will give you all the publications from 2017 until today') }.
+              </p>
+              <p>
+              {i18next.t('For more tips, check out our ')}
+              <a href="/help/search" title={i18next.t('Search guide')}>
+                {i18next.t('search guide')}
+              </a>
+              {i18next.t(' for defining advanced search queries')}.
+              </p>
+            </Segment>
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
   );
 };
 

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/components/uploads.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/components/uploads.js
@@ -32,6 +32,7 @@ import {
   RDMRecordFacetsValues,
   RDMRecordSearchBarElement,
   RDMToggleComponent,
+  RDMEmptyResults as RDMNoSearchResults
 } from "../../search/components";
 import { DashboardResultView, DashboardSearchLayoutHOC } from "./base";
 
@@ -252,14 +253,8 @@ export const RDMEmptyResults = (props) => {
       </Segment>
     </Segment.Group>
   ) : (
-    <Segment placeholder textAlign="center">
-      <Header icon>
-        <Icon name="search" />
-        {i18next.t("No uploads found!")}
-      </Header>
-      <Button primary onClick={() => props.resetQuery()}>
-        {i18next.t("Reset search")}
-      </Button>
+    <Segment padded="very">
+      <RDMNoSearchResults {...props} searchPath='/me/uploads' />
     </Segment>
   );
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme.less
@@ -339,7 +339,8 @@ body {
   .content {
     border-top: none;
 
-    .header {
+    .header:not(.ui) {
+      margin-top: 1rem;
       font-size: 1.1em !important;
     }
   }


### PR DESCRIPTION
Closes #251

- Redesigned the no-results page-component
- Added clear-selection button to facet headers
- Added header to help-links

__Changes from initial mockup__
- Replaced the additional search bar with "start over"-button
- Moved search icon from above the header to the "start over"-button, as it looked a bit messy (imo), especially on the uploads-page

__Note:__ The semantic-ui padding setting in the segment is not functioning, most likely because the `.ui.segment.secondary`-class is overwritten in invenio-theme. This can be solved by adding the default setting to the overrides-file (which should be done, rather than adding more custom css).

## Screenshots
__No results for search term__
<img width="1213" alt="Screenshot 2022-02-22 at 14 58 18" src="https://user-images.githubusercontent.com/21052053/155152929-1b7e0f26-bd0c-4e91-b27c-2265568a5dc6.png">


__No search term__
<img width="1212" alt="Screenshot 2022-02-22 at 14 58 32" src="https://user-images.githubusercontent.com/21052053/155152890-ea46dbc6-dc6d-4757-8fdd-7b6e1a723255.png">


__Updated sidebar__
<img width="292" alt="Screenshot 2022-02-22 at 14 03 45" src="https://user-images.githubusercontent.com/21052053/155140423-df0224f9-d324-4939-bd05-577b9edc13bc.png">

__Uploads page__
<img width="1213" alt="Screenshot 2022-02-22 at 14 57 19" src="https://user-images.githubusercontent.com/21052053/155153072-03d7b707-49e6-434a-9532-53d4dbd18e70.png">

