### PR TITLE
share-modal: copy on get link

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareButton.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareButton.js
@@ -28,6 +28,7 @@ export const ShareButton = (props) => {
             disabled={props.disabled}
             primary
             size="mini"
+            aria-haspopup="dialog"
           >
             <Icon name="share square" />
             {i18next.t("Share")}


### PR DESCRIPTION
Closes #848

__ShareModal__
- Added copy functionality to "Get link"-button.
- Added popup on click (this is also showing when clicking the "Get link" button).
- Added cleanups for async functions in useEffect functions
- Made the dropdown more screen-reader friendly by adding `selectOnNavigation={false}`

I also made some accessibility improvement for the existing __CopyButton__-component:
- Merged the two popups into one, to avoid the need to click twice (on keyboard) to get the "Copied"-feedback.
- Added alert-role to announce the copied-message to screen readers (in the CopyButton this could be added directly on the Popup-component, as the content is changing when hovering/clicking).

I was considering to use the existing CopyButton in the ShareModal and adjust it to be more flexible: 
- Possibility for having button text 
- Optional hover-popup
- Custom copy function 

I decided not to, as it would require a different button than SimpleCopyButton (because of different functionality), and it seemed a bit like cluttering things, rather than making it cleaner. That being said, I'm still not 100% convinced that the current solution is the best one, so please lmk if you think the CopyButton should be adjusted for special cases like this one.

__Screenshot__ 
<img width="170" alt="Screenshot 2022-02-25 at 14 26 53" src="https://user-images.githubusercontent.com/21052053/155722934-8f8ef6a0-4d33-46db-8394-3db5e269dd1f.png">


