### PR TITLE
landing page: make all licenses clickable

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/licenses.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/licenses.html
@@ -19,24 +19,19 @@
 
 {% set rights = record.ui.get('rights') %}
 {% if rights %}
-<section id="licenses" aria-label="{{ _('Licenses') }}" class="ui segment rdm-sidebar">
-  <h2 class="ui small header">{{ _('Licenses') }}</h2>
+<section id="licenses" aria-label="{{ _('Rights') }}" class="ui segment rdm-sidebar">
+  <h2 class="ui small header">{{ _('Rights') }}</h2>
   <ul class="details-list">
 
     {%- for license in rights%}
-      <li id="license-{{license.id}}-{{loop.index}}"
-          class="{{ 'has-popup' if license.description_l10n }}"
-      >
+      <li id="license-{{license.id}}-{{loop.index}}" class="has-popup">
         <div id="title-{{license.id}}-{{loop.index}}"
-             class="license {{ 'clickable' if license.description_l10n }}"
-
-             {% if license.description_l10n %}
-               tabindex="0"
-               aria-haspopup="dialog"
-               aria-expanded="false"
-               role="button"
-               aria-label="{{ license.title_l10n }}"
-             {% endif %}
+             class="license clickable"
+             tabindex="0"
+             aria-haspopup="dialog"
+             aria-expanded="false"
+             role="button"
+             aria-label="{{ license.title_l10n }}"
         >
           {% if license.icon %}
             {% set iconFile = 'icons/licenses/{}.svg'.format(license.icon) %}
@@ -47,28 +42,22 @@
 
           <span class="title-text">
             {{ license.title_l10n }}
-
-            {% if not license.description_l10n %}
-              {{ license_link(license) }}
-            {% endif %}
           </span>
         </div>
-        {% if license.description_l10n %}
-          <div id="description-{{license.id}}-{{loop.index}}"
-               class="licenses-description ui flowing popup transition hidden"
-               role="dialog"
-               aria-labelledby="title-{{license.id}}-{{loop.index}}"
-          >
-            <i role="button" tabindex="0" class="close icon text-muted" aria-label="{{ _('Close') }}"></i>
-            <div id="license-description-{{loop.index}}" class="description">
-              <span class="text-muted">
-                {{ license.description_l10n }}
-              </span>
+        <div id="description-{{license.id}}-{{loop.index}}"
+              class="licenses-description ui flowing popup transition hidden"
+              role="dialog"
+              aria-labelledby="title-{{license.id}}-{{loop.index}}"
+        >
+          <i role="button" tabindex="0" class="close icon text-muted" aria-label="{{ _('Close') }}"></i>
 
-              {{ license_link(license)}}
-            </div>
+          <div id="license-description-{{loop.index}}" class="description">
+            <span class="text-muted">
+              {{ license.description_l10n or _('No further description.')}}
+            </span>
+            {{ license_link(license)}}
           </div>
-        {% endif %}
+        </div>
       </li>
     {% endfor %}
   </ul>

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/licenses.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/licenses.less
@@ -16,37 +16,13 @@ section#licenses ul.details-list {
   li {
     margin: .5rem 0;
 
-    &:not(.has-popup) {
-      padding: 1rem;
-      border-top: 1px solid #f5f5f5;
-      border-bottom: 1px solid #f5f5f5;
-
-      & + li:not(.has-popup) {
-        border-top: none;
-        padding: .5rem 1rem 1rem 1rem;
-
-        &:last-child {
-          padding-bottom: 0;
-        }
-      }
-
-      &:last-child {
-        border-bottom: none;
-        padding-bottom: 0;
-      }
-
-      &:only-child {
-        padding: 1rem 0 0 0;
-      }
-    }
-
     &:first-child {
       margin-top: 0;
       border-top: none;
     }
 
     &.has-popup {
-      background-color: #f7f7f7;
+      background-color: #f9f9f9;
       cursor: pointer;
 
       &:hover {
@@ -56,7 +32,6 @@ section#licenses ul.details-list {
 
     div.license {
       display: flex;
-      font-weight: bold;
       font-size: 1em;
 
       &.clickable {
@@ -65,8 +40,8 @@ section#licenses ul.details-list {
       }
 
       .icon-wrap {
-        min-width: 2.7rem;
-        width: 2.7rem;
+        min-width: 3.5rem;
+        width: 3.5rem;
         margin-top: .2rem;
         margin-right: .7rem;
         float: left;


### PR DESCRIPTION
- Changed licenses-title to "Rights"
- Made all licenses clickable for consistency

## Screenshots
<img width="334" alt="Screenshot 2022-03-01 at 14 58 30" src="https://user-images.githubusercontent.com/21052053/156184052-ef889267-4579-414b-9ffd-022b72a025c9.png">

<img width="338" alt="Screenshot 2022-03-01 at 14 58 36" src="https://user-images.githubusercontent.com/21052053/156184067-177fd5b0-2de6-4e9f-9e51-b7ef611245a2.png">

<img width="336" alt="Screenshot 2022-03-01 at 14 58 24" src="https://user-images.githubusercontent.com/21052053/156184082-07e5ea28-af04-435e-b727-7b3663423d95.png">

<img width="325" alt="Screenshot 2022-03-01 at 14 58 40" src="https://user-images.githubusercontent.com/21052053/156184092-18e40392-74a9-497a-9e97-5a0dd9138481.png">

