### PR TITLE
landing page: remove all versions-link if < 1, disable link if current

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordVersionsList.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordVersionsList.js
@@ -9,7 +9,7 @@
 import axios from "axios";
 import _get from "lodash/get";
 import React, { useEffect, useState } from "react";
-import { Divider, Grid, Icon, Message, Placeholder } from "semantic-ui-react";
+import { Grid, Icon, Message, Placeholder, List } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 
 const deserializeRecord = (record) => ({
@@ -26,27 +26,30 @@ const NUMBER_OF_VERSIONS = 5;
 const RecordVersionItem = ({ item, activeVersion }) => {
   const doi = _get(item.pids, "doi.identifier", "");
   return (
-    <>
-      <Grid.Row
+      <List.Item
         key={item.id}
-        columns={1}
         {...(activeVersion && { className: "version-active" })}
       >
-        <Grid.Column>
-          <small className="text-muted" style={{ float: "right" }}>
-            {item.publication_date}
-          </small>
-          <a href={`/records/${item.id}`}>{i18next.t('Version')} {item.version}</a>
-          {<br />}
+        <List.Content floated="left">
+          { activeVersion ?
+            <span>{i18next.t('Version')} {item.version}</span>
+            :
+            <a href={`/records/${item.id}`}>{i18next.t('Version')} {item.version}</a>
+          }
+
           {doi && (
-            <small className="text-muted" style={{ wordWrap: "break-word" }}>
+            <small className={'doi' + (activeVersion ? ' text-muted-on-bg' : ' text-muted')}>
               {doi}
             </small>
           )}
-        </Grid.Column>
-      </Grid.Row>
-      <Divider fitted style={{ margin: "0" }} />
-    </>
+        </List.Content>
+
+        <List.Content floated="right">
+          <small className={activeVersion ? 'text-muted-on-bg' : 'text-muted'}>
+            {item.publication_date}
+          </small>
+        </List.Content>
+      </List.Item>
   );
 };
 
@@ -67,17 +70,19 @@ const PlaceholderLoader = ({ size = NUMBER_OF_VERSIONS }) => {
 
 const PreviewMessage = () => {
   return (
-    <Grid.Row>
-      <Grid.Column className="versions-preview-info">
-        <Message info>
-          <Message.Header>
-            <Icon name="eye" />
-            {i18next.t('Preview')}
-          </Message.Header>
-          <p>{i18next.t('Only published versions are displayed.')}</p>
-        </Message>
-      </Grid.Column>
-    </Grid.Row>
+    <Grid className="preview-message">
+      <Grid.Row>
+        <Grid.Column className="versions-preview-info">
+          <Message info>
+            <Message.Header>
+              <Icon name="eye" />
+              {i18next.t('Preview')}
+            </Message.Header>
+            <p>{i18next.t('Only published versions are displayed.')}</p>
+          </Message>
+        </Grid.Column>
+      </Grid.Row>
+    </Grid>
   );
 };
 
@@ -112,7 +117,7 @@ export const RecordVersionsList = (props) => {
   return loading ? (
     <>{isPreview ? <PreviewMessage /> : <PlaceholderLoader />}</>
   ) : (
-    <Grid padded>
+    <List divided>
       {isPreview ? <PreviewMessage /> : null}
       {recordVersions.hits.map((item) => (
         <RecordVersionItem
@@ -123,18 +128,24 @@ export const RecordVersionsList = (props) => {
       ))}
       {!currentRecordInResults && (
         <>
-          <Grid.Row centered>...</Grid.Row>
+          <Grid padded className="dots">
+            <Grid.Row centered>...</Grid.Row>
+          </Grid>
           <RecordVersionItem item={record} activeVersion={true} />
         </>
       )}
-      <Grid.Row centered>
-        <a
-          href={`/search?q=parent.id:${record.parent_id}&sort=version&f=allversions:true`}
-          className="font-small"
-        >
-          {i18next.t(`View all {{total}} versions`,{total:recordVersions.total})}
-        </a>
-      </Grid.Row>
-    </Grid>
+      { recordVersions.total > 1 &&
+        <Grid className="all-versions-link">
+          <Grid.Row centered>
+            <a
+              href={`/search?q=parent.id:${record.parent_id}&sort=version&f=allversions:true`}
+              className="font-small"
+            >
+              {i18next.t(`View all {{total}} versions`,{total:recordVersions.total})}
+            </a>
+          </Grid.Row>
+        </Grid>
+      }
+    </List>
   );
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page.less
@@ -106,8 +106,36 @@ dd {
   margin-inline-start: 0px;
 }
 
-.version-active {
-  background-color: @versionActive;
+.text-muted-on-bg {
+  color: #4A4A4A;
+}
+
+.versions {
+  .ui.grid.preview-message {
+    margin: -0.5rem 0;
+
+    & + .ui.grid.dots .centered.row {
+      padding-top: 0;
+    }
+  }
+
+  .ui.divided.list .item {
+    padding: 1rem;
+
+    .doi {
+      display: block;
+      margin-top: .5rem;
+      word-wrap: break-word;
+    }
+  }
+
+  .version-active {
+    background-color: @versionActive;
+  }
+
+  .ui.grid.all-versions-link {
+    margin-top: 0;
+  }
 }
 
 .thin-line {


### PR DESCRIPTION
Closes #1093

- Removed link to all versions if total versions < 1.
- Converted the version-list from semantic ui `Grid` to `List`.
- Disabled link for current version (it was only linking to itself).
- Changed the muted text-color when on background to avoid color contrast issues.

## Screen shots
<img width="313" alt="Screenshot 2022-03-02 at 10 31 09" src="https://user-images.githubusercontent.com/21052053/156336983-28839cb0-1c21-4a1e-b4f8-d2b553dfcb04.png">
<img width="310" alt="Screenshot 2022-03-02 at 10 28 32" src="https://user-images.githubusercontent.com/21052053/156337127-532ba2b3-22d6-4637-9ca2-737f8dbfee0e.png">
<img width="314" alt="Screenshot 2022-03-02 at 10 28 08" src="https://user-images.githubusercontent.com/21052053/156337142-56b2c763-a166-4bec-a9c3-182fda8b333f.png">
<img width="316" alt="Screenshot 2022-03-02 at 10 06 48" src="https://user-images.githubusercontent.com/21052053/156337161-e7965a6e-86d8-4f59-911a-eac9621a4fc3.png">
<img width="311" alt="Screenshot 2022-03-02 at 10 00 05" src="https://user-images.githubusercontent.com/21052053/156337194-38c47db4-0ffd-4aee-ac6f-d04113072c33.png">

