### PR TITLE
my dashboard: add responsive layout

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/components/base.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/components/base.js
@@ -23,7 +23,8 @@ import {
   SearchBar,
   Sort,
 } from "react-searchkit";
-import { Container, Grid, Segment } from "semantic-ui-react";
+import { GridResponsiveSidebarColumn } from "react-invenio-forms";
+import { Grid, Segment, Button } from "semantic-ui-react";
 
 import Overridable from "react-overridable";
 
@@ -115,26 +116,43 @@ export const DashboardSearchLayoutHOC = ({
   newBtn = () => null,
   ...props
 }) => {
-  const DashboardUploadsSearchLayout = (props) => (
-    <Container>
+
+  const DashboardUploadsSearchLayout = (props) => {
+    const [sidebarVisible, setSidebarVisible] = React.useState(false);
+
+    return (
       <Grid>
-        <Grid.Row columns={3}>
-          <Grid.Column width={4} />
-          <Grid.Column width={8}>
-            <SearchBar placeholder={searchBarPlaceholder} />
-          </Grid.Column>
-          <Grid.Column width={4}>{newBtn}</Grid.Column>
-        </Grid.Row>
+        <Grid.Column only="mobile tablet" mobile={2} tablet={1}>
+          <Button
+            basic
+            icon="sliders"
+            onClick={() => setSidebarVisible(true)}
+            aria-label={i18next.t("Filter results")}
+          />
+        </Grid.Column>
+
+        <Grid.Column mobile={14} tablet={11} computer={8} floated="right">
+          <SearchBar placeholder={searchBarPlaceholder} />
+        </Grid.Column>
+
+        <Grid.Column mobile={16} tablet={4} computer={4} align="right">
+          {newBtn}
+        </Grid.Column>
+
         <Grid.Row>
-          <Grid.Column width={4}>
-            <SearchAppFacets aggs={props.config.aggs} />
-          </Grid.Column>
-          <Grid.Column width={12}>
+          <GridResponsiveSidebarColumn
+            width={4}
+            open={sidebarVisible}
+            onHideClick={() => setSidebarVisible(false)}
+            children={
+              <SearchAppFacets aggs={props.config.aggs} />
+            }
+          />
+          <Grid.Column mobile={16} tablet={16} computer={12}>
             <SearchAppResultsPane layoutOptions={props.config.layoutOptions} />
           </Grid.Column>
         </Grid.Row>
       </Grid>
-    </Container>
-  );
+  )}
   return DashboardUploadsSearchLayout;
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/index.js
@@ -121,7 +121,7 @@ class DashboardMenu extends Component {
           </Container>
         </Container>
         <Container>
-          <Segment className="borderless shadowless">
+          <Segment className="borderless shadowless p-0">
             <div className="rel-pt-2">
               <SearchApp
                 appName={activeContent.appId}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/container.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/container.overrides
@@ -8,6 +8,11 @@
   padding-bottom: @celledPadding;
   margin-bottom: @defaultMargin;
 
+  @media screen and (max-width: @largestMobileScreen) {
+    margin-left: 0 !important; // Overwriting semantic-ui's !important. Please don't remove.
+    margin-right: 0 !important;
+  }
+
   &.with-submenu {
     padding-bottom: 0;
     margin-bottom: 0;


### PR DESCRIPTION
**Needs [react-invenio-forms PR 118](https://github.com/inveniosoftware/react-invenio-forms/pull/118)**

Solves the responsibility issues for the My dashboard page of #1360. Search result page issues are solved in `invenio-search-ui` [PR #129](https://github.com/inveniosoftware/invenio-search-ui/pull/129).

- Changed the column width of the tab content to be full grid-width for mobile and tablet.
- Moved the facet filter to a slide-in sidebar triggered by a filter button for mobile and tablet.
- The desktop version remains the same as before.

The sidebar closes when clicking the close-button or by clicking outside the sidebar.

Accessibility was tested with axe DevTools and VoiceOver.

## Screenshots

### Tablet

__Filter closed__
<img width="575" alt="Screenshot 2022-03-10 at 11 11 00" src="https://user-images.githubusercontent.com/21052053/157692157-25f3683f-5d73-4778-aa65-3fb3d62577cf.png">

__Filter open__
<img width="575" alt="Screenshot 2022-03-10 at 11 10 51" src="https://user-images.githubusercontent.com/21052053/157692180-e43411cb-6dd7-4d15-bf89-189a2ee37709.png">

### Mobile

__Filter closed__
<img width="489" alt="Screenshot 2022-03-10 at 15 43 49" src="https://user-images.githubusercontent.com/21052053/157692287-0c29d85a-b7ec-4a18-96f9-3c6c4946869c.png">


__Filter open__
<img width="489" alt="Screenshot 2022-03-10 at 15 43 58" src="https://user-images.githubusercontent.com/21052053/157692301-868c06ac-1550-43d0-920a-e42c4cf36529.png">


