### PR TITLE
landing page: move manage record section for mobile

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -130,6 +130,26 @@
 
               {%- endblock record_header_button -%}
 
+              {% if permissions is defined and permissions.can_edit and not is_preview %}
+                <section id="mobile-record-management" class="ui grid tablet only mobile only">
+                  <div class="sixteen wide column right aligned">
+                    <button id="manage-record-btn"
+                            class="ui small basic icon button m-0"
+                            aria-haspopup="dialog"
+                            aria-expanded="false"
+                    >
+                      <i class="cog icon"></i> {{ _('Manage record') }}
+                    </button>
+                  </div>
+
+                  <div id="recordManagementMobile"
+                       role="dialog"
+                       class="ui flowing popup transition hidden"
+                  >
+                  </div>
+                </section>
+              {% endif %}
+
               <section id="record-info" aria-label="{{ _('Publication date and version number') }}">
                 <div class="ui grid middle aligned">
                   <div class="two column row">

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/manage_menu.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/manage_menu.html
@@ -6,10 +6,15 @@ it under the terms of the MIT License; see LICENSE file for more details.
 #}
 
 {% if permissions is defined and permissions.can_edit and not is_preview %}
-<section id="record-manage-menu" aria-label="{{ _('Record versions') }}" class="ui segment rdm-sidebar">
-    <div class="ui container">
-        <div id="recordManagement" data-record='{{ record | tojson }}' data-permissions='{{ permissions | tojson }}'>
-        </div>
+  <section id="record-manage-menu"
+           aria-label="{{ _('Record management') }}"
+           class="ui grid segment computer only rdm-sidebar"
+  >
+    <div class="column"
+         id="recordManagement"
+         data-record='{{ record | tojson }}'
+         data-permissions='{{ permissions | tojson }}'
+    >
     </div>
-</section>
+  </section>
 {% endif %}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
@@ -5,6 +5,7 @@
 //
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
+import { i18next } from "@translations/invenio_app_rdm/i18next";
 
 import React, { useState } from "react";
 import { Grid, Message } from "semantic-ui-react";
@@ -23,10 +24,10 @@ export const RecordManagement = ({ record, permissions }) => {
 
   return (
     <Grid columns={1} className="record-management">
-      <Grid.Column>
+      <Grid.Column className="pb-5">
         <EditButton recid={recid} onError={handleError} />
       </Grid.Column>
-      <Grid.Column>
+      <Grid.Column className="pt-5 pb-5">
         <NewVersionButton
           fluid
           size="medium"
@@ -35,7 +36,7 @@ export const RecordManagement = ({ record, permissions }) => {
           disabled={!permissions.can_new_version}
         />
       </Grid.Column>
-      <Grid.Column>
+      <Grid.Column className="pt-5">
         {permissions.can_manage && (
           <ShareButton disabled={!permissions.can_update_draft} recid={recid} />
         )}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
@@ -14,16 +14,23 @@ import { RecordVersionsList } from "./RecordVersionsList";
 import { RecordCitationField } from "./RecordCitationField";
 
 const recordManagementAppDiv = document.getElementById("recordManagement");
+const recordManagementMobile = document.getElementById("recordManagementMobile");
+
 const recordVersionsAppDiv = document.getElementById("recordVersions");
 const recordCitationAppDiv = document.getElementById("recordCitation");
 
 if (recordManagementAppDiv) {
+  renderRecordManagement(recordManagementAppDiv);
+  recordManagementMobile && renderRecordManagement(recordManagementMobile);
+}
+
+function renderRecordManagement(element) {
   ReactDOM.render(
     <RecordManagement
       record={JSON.parse(recordManagementAppDiv.dataset.record)}
       permissions={JSON.parse(recordManagementAppDiv.dataset.permissions)}
     />,
-    recordManagementAppDiv
+    element
   );
 }
 

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
@@ -69,3 +69,18 @@ $('#licenses .licenses-description .close.icon')
       }
     }
   });
+
+
+// Record management popup (mobile)
+$('#manage-record-btn')
+.popup({
+  popup: $('#recordManagementMobile'),
+  on: 'click',
+  position: 'bottom right',
+  onVisible: function($module) {
+    $($module).attr('aria-expanded', true);
+  },
+  onHidden: function($module) {
+    $($module).attr('aria-expanded', false);
+  }
+})

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/grid.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/grid.overrides
@@ -15,13 +15,6 @@
     display: flex;
   }
 
-  &.record-management{
-    .column:not(.row):not(:last-of-type):not(:first-of-type){
-      padding-top: 0.25em !important;
-      padding-bottom: 0.25em !important;
-    }
-  }
-
   &.record-citation {
     label {
       font-weight: 700;
@@ -112,3 +105,6 @@
   }
 }
 
+#mobile-record-management.ui.grid .column {
+  border-bottom: 1px solid @borderColor;
+}


### PR DESCRIPTION
Closes #1347 

- Moved the admin-section out of the details section on mobile.
- Added a manage button on top of the page for mobile and tablet, to trigger a popup with the buttons
- Also fixed some spacing inconsistencies for the admin-box on desktop

## Screenshots

__Desktop__
<img width="1414" alt="Screenshot 2022-03-18 at 09 01 23" src="https://user-images.githubusercontent.com/21052053/158974713-37c74156-6ae3-4249-99a6-5dd82dececff.png">

__Tablet__ 
<img width="1135" alt="Screenshot 2022-03-18 at 10 29 22" src="https://user-images.githubusercontent.com/21052053/158977502-6c4a5831-8c30-48a9-b782-5cb2457e48cd.png">

<img width="1136" alt="Screenshot 2022-03-18 at 10 29 28" src="https://user-images.githubusercontent.com/21052053/158977526-acc528c8-ab85-4054-bce2-2bb0e4ed6fea.png">


__Mobile__
<img width="449" alt="Screenshot 2022-03-18 at 10 29 44" src="https://user-images.githubusercontent.com/21052053/158977571-7c7e7e61-3eb2-422b-b05c-0159b97319a5.png">
<img width="447" alt="Screenshot 2022-03-18 at 10 29 55" src="https://user-images.githubusercontent.com/21052053/158977591-f25e6b41-3230-4122-ab84-119538d8d908.png">

