### PR TITLE
header login: add a11y to profile menu

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/theme.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/theme.js
@@ -58,3 +58,21 @@ $(".ui.accordion .title").on("keydown", function (event) {
   }
 });
 
+
+/* User profile dropdown */
+$('#user-profile-dropdown.ui.dropdown')
+  .dropdown({
+    showOnFocus: false,
+    selectOnKeydown: false,
+    action: (text, value, element) => {
+      // needed to trigger navigation on keyboard interaction
+      let path = element.attr('href');
+      window.location.pathname=path;
+    },
+    onShow: () => {
+      $('#user-profile-dropdown-btn').attr('aria-expanded', true)
+    },
+    onHide: () => {
+      $('#user-profile-dropdown-btn').attr('aria-expanded', false)
+    }
+  });

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/menu.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/menu.overrides
@@ -57,22 +57,32 @@
     }
 
     &.right.right-navbar {
-      padding-right: 0;
-      display: flex;
+        display: flex;
+        padding-right: 0;
 
-      .item {
+      > .item {
         padding-left: 15px;
         margin-right: 15px;
       }
     }
   }
 
-  .user-profile {
-    a.ui.button {
-      width: 13em;
+  .rdm-plus-menu {
+    padding-right: 15px;
+  }
+
+  #user-profile-dropdown {
+    width: 13em;
+
+    #user-profile-dropdown-btn {
+      width: inherit;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+
+    #user-profile-menu.ui.menu {
+      width: inherit;
     }
   }
 }

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header_login.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header_login.html
@@ -42,34 +42,45 @@
         {% endif %}
 
         {%- if config.USERPROFILES %}
-            <div class="ui buttons user-profile">
-                <a class="ui button"
-                   href="{{ url_for('invenio_userprofiles.profile') }}">
-                    <i class="user icon"></i> {{ current_user.email|truncate(31,true) }}
+          <div id="user-profile-dropdown" class="ui floating dropdown">
+            <button id="user-profile-dropdown-btn"
+                    class="ui right labeled right floated icon button text"
+                    aria-controls="user-profile-menu"
+                    aria-expanded="false"
+                    aria-haspopup="menu"
+                    aria-label="{{ _('My account') }}"
+            >
+              <span>
+                <i class="user icon"></i>
+                {{ current_user.email|truncate(31,true) }}
+              </span>
+              <i class="dropdown icon"></i>
+            </button>
+
+            <div id="user-profile-menu"
+                 class="ui menu"
+                 role="menu"
+                 aria-labelledby="user-profile-dropdown-btn"
+            >
+              {%- for item in current_menu.submenu('settings').children if item.visible %}
+                <a role="menuitem" class="item" href="{{ item.url }}" tabindex="-1">
+                  {{ item.text|safe }}
                 </a>
+              {%- endfor %}
 
-                <div class="ui dropdown icon button floating">
-                    <i class="dropdown icon"></i>
-                    <div class="menu">
-                        {%- for item in current_menu.submenu('settings').children if item.visible %}
-                            <a class="item"
-                               style="color:black;"
-                               href="{{ item.url }}">{{ item.text|safe }}
-                            </a>
-
-                        {%- endfor %}
-                        <div class="divider"></div>
-                        <a class="item" style="color:black;" href="{{ url_for_security('logout') }}">
-                            <i class="sign-out icon"></i>
-                            {{ _('Log out') }}
-                        </a>
-                    </div>
-                </div>
+              <div class="divider"></div>
+              <a role="menuitem" class="item" href="{{ url_for_security('logout') }}" tabindex="-1">
+                <i class="sign-out icon"></i>
+                {{ _('Log out') }}
+              </a>
             </div>
+          </div>
 
         {%- else %}
-            <a href=" {{ url_for_security('logout') }}" class="ui button"><i
-                    class="sign-out icon"></i> {{ _('Log out') }}</a>
+          <a role="button" href="{{ url_for_security('logout') }}" class="ui button">
+            <i class="sign-out icon"></i>
+            {{ _('Log out') }}
+          </a>
         {%- endif %}
     {%- endif %}
 {%- endif %}


### PR DESCRIPTION
Closes #1281

- Changed the global account-menu to be dropdown-only, not link + dropdown as before.
- Added aria-attributes for a11y
- Added keyboard accessibility
- Tested with VoiceOver & axe DevTools

## Screenshots
<img width="335" alt="Screenshot 2022-03-23 at 09 42 31" src="https://user-images.githubusercontent.com/21052053/159659358-0c567da4-ab88-4175-ab0f-d9a0956c35ea.png">
<img width="301" alt="Screenshot 2022-03-23 at 09 42 35" src="https://user-images.githubusercontent.com/21052053/159659370-27a5123a-5b91-4fb3-885f-e0a3f313029e.png">

