### PR TITLE
[TO DISCUSS] Make text on the publish modal configurable

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -632,6 +632,14 @@ APP_RDM_DEPOSIT_FORM_QUOTA = {
 }
 """Deposit file upload quota """
 
+APP_RDM_DEPOSIT_FORM_FILE_AREA_WARNING = (
+    "Note: File addition, removal, or modification are not allowed after you "
+    "have published your upload. "
+    "This is because a Digital Object Identifier (DOI) is registered with "
+    "<a href=\"https://datacite.org/\">DataCite</a> for each upload."
+)
+"""The warning text to be displayed in the file uploader area."""
+
 APP_RDM_DEPOSIT_FORM_PUBLISH_WARNING = (
     "<p><b>"
     "Once the record is published you will no longer be able to change "

--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -632,6 +632,18 @@ APP_RDM_DEPOSIT_FORM_QUOTA = {
 }
 """Deposit file upload quota """
 
+APP_RDM_DEPOSIT_FORM_PUBLISH_WARNING = (
+    "<p><b>"
+    "Once the record is published you will no longer be able to change "
+    "the files in the upload!"
+    "</b></p><p>"
+    "This is because a Digital Object Identifier (DOI) will be registered "
+    "immediately after publishing. "
+    "However, you will still be able to update the record's metadata later."
+    "</p>"
+)
+"""The warning text to be displayed in the publish modal."""
+
 RDM_CITATION_STYLES = [
     ('apa', _('APA')),
     ('harvard-cite-them-right', _('Harvard')),

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -263,6 +263,8 @@ def get_form_config(**kwargs):
         quota=current_app.config.get('APP_RDM_DEPOSIT_FORM_QUOTA'),
         publish_warning=current_app.config.get(
             'APP_RDM_DEPOSIT_FORM_PUBLISH_WARNING'),
+        file_area_warning=current_app.config.get(
+            'APP_RDM_DEPOSIT_FORM_FILE_AREA_WARNING'),
         **kwargs
     )
 

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -261,6 +261,8 @@ def get_form_config(**kwargs):
         default_locale=current_app.config.get('BABEL_DEFAULT_LOCALE', 'en'),
         pids=get_form_pids_config(),
         quota=current_app.config.get('APP_RDM_DEPOSIT_FORM_QUOTA'),
+        publish_warning=current_app.config.get(
+            'APP_RDM_DEPOSIT_FORM_PUBLISH_WARNING'),
         **kwargs
     )
 

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -360,7 +360,10 @@ export class RDMDepositForm extends Component {
                         </Grid.Column>
 
                         <Grid.Column width={16} className="pt-10">
-                          <PublishButton fluid />
+                          <PublishButton
+                            fluid
+                            publishWarning={this.config.publish_warning}
+                          />
                         </Grid.Column>
                       </Grid>
                     </Card.Content>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -161,6 +161,7 @@ export class RDMDepositForm extends Component {
                 <FileUploader
                   isDraftRecord={!record.is_published}
                   quota={this.config.quota}
+                  fileAreaWarning={this.config.file_area_warning}
                 />
               </AccordionField>
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This PR adds support for displaying a custom warning message on the modal that pops up when the "Publish" button is being pressed.
This can be used to raise the user's awareness that the files are not going to be editable after publication of the record, and maybe also refer them to a test/staging instance if there is such a thing.

**Note**: The configured message is displayed, *however* the tags are escaped by [`tojson`](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/deposit.html#L28) [here](https://github.com/pallets/jinja/blob/main/src/jinja2/filters.py#L1688) and [here](https://github.com/pallets/jinja/blob/main/src/jinja2/utils.py#L657-L663), causing formatting tags not to be rendered:
![image](https://user-images.githubusercontent.com/6437519/162755473-1dbf5137-a4e0-4d0b-8649-e97e121aec38.png)

I think that could either be handled by not escaping as aggressively in the back-end (after all, it's configuration input by the devs/ops, and not some untrusted user input), or maybe evaluating the value differently in the front-end.
WDYT, @lnielsen ?

Partially closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1204
Requires https://github.com/inveniosoftware/react-invenio-deposit/pull/466

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
