### PR TITLE
Files: add option to display file sizes in binary or decimal units

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -632,6 +632,9 @@ APP_RDM_DEPOSIT_FORM_QUOTA = {
 }
 """Deposit file upload quota """
 
+APP_RDM_DISPLAY_DECIMAL_FILE_SIZES = True
+"""Display the file sizes in powers of 1000 (KB, ...) or 1024 (KiB, ...)."""
+
 RDM_CITATION_STYLES = [
     ('apa', _('APA')),
     ('harvard-cite-them-right', _('Harvard')),

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -55,6 +55,7 @@
       </tr>
     </thead>
     <tbody>
+    {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
     {% for file in files %}
       {% if is_preview %}
         {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1, preview=1) %}
@@ -75,7 +76,7 @@
           </div>
           </small>
         </td>
-        <td>{{ file.size|filesizeformat }}</td>
+        <td>{{ file.size|filesizeformat(binary=binary_sizes) }}</td>
         <td class="right aligned">
           <span>
             {% if with_preview and file_type|lower is previewable %}
@@ -97,11 +98,12 @@
 
 
 {% macro file_list_box(files, pid, is_preview, record) %}
+{%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
 <div class="">
   <div class="ui accordion panel mb-10 {{record.ui.access_status.id}}" id="preview" href="#collapsablePreview">
     <div class="active title panel-heading pt-10 {{record.ui.access_status.id}}" tabindex="0">
       {{ _("Files") }}
-      <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat}}){% endif %}</small>
+      <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat(binary=binary_sizes)}}){% endif %}</small>
       <i class="angle down icon"></i>
     </div>
     <div class="active content rm-pt">

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -261,6 +261,8 @@ def get_form_config(**kwargs):
         default_locale=current_app.config.get('BABEL_DEFAULT_LOCALE', 'en'),
         pids=get_form_pids_config(),
         quota=current_app.config.get('APP_RDM_DEPOSIT_FORM_QUOTA'),
+        decimal_size_display=current_app.config.get(
+            'APP_RDM_DISPLAY_DECIMAL_FILE_SIZES', True),
         **kwargs
     )
 

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -161,6 +161,7 @@ export class RDMDepositForm extends Component {
                 <FileUploader
                   isDraftRecord={!record.is_published}
                   quota={this.config.quota}
+                  decimalSizeDisplay={this.config.decimal_size_display}
                 />
               </AccordionField>
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Usually (but not necessarily), the back-end specifies file sizes and their limits in binary format (i.e. powers of 1024: KiB, MiB, GiB) rather than decimal format (i.e. powers of 1000: KB, MB, GB).
Until now, the front-end simply calculated file sizes in decimal format, which *could* be incongruent with the specification in the back-end.
This PR introduces a new configuration variable that allows switching between the formats, to enable sticking to the same format.

Decimal format:
![image](https://user-images.githubusercontent.com/6437519/162778980-5bd9e22c-31af-450e-b719-b6dee2ee6d8d.png)

vs. binary format (same file size limit):
![image](https://user-images.githubusercontent.com/6437519/162779188-11b90339-1384-4ab2-88b0-31c52cdcd20a.png)


Requires https://github.com/inveniosoftware/react-invenio-deposit/pull/467

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
