### PR TITLE
landing page: fix styling for citation section

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/citation.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/citation.html
@@ -7,7 +7,6 @@
     it under the terms of the MIT License; see LICENSE file for more details.
 #}
 
-<div class="ui divider"></div>
 <div id="recordCitation" data-record='{{ record | tojson }}'
   data-styles='{{ config.get("RDM_CITATION_STYLES") | tojson }}'
   data-defaultstyle='{{ config.get("RDM_CITATION_STYLES_DEFAULT") | tojson }}'>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCitationField.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCitationField.js
@@ -113,10 +113,10 @@ export class RecordCitationField extends Component {
     });
 
     return (
-      <Grid className="record-citation m-0">
+      <Grid className="record-citation pt-10 pb-10 m-0">
         <Grid.Row verticalAlign="middle" className="relaxed">
           <Grid.Column mobile={8} tablet={8} computer={12} className="p-0">
-            <h2 id="citation-heading">{i18next.t("Citation")}</h2>
+            <Header as="h2" id="citation-heading">{i18next.t("Citation")}</Header>
           </Grid.Column>
 
           <Grid.Column

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/grid.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/grid.overrides
@@ -16,6 +16,9 @@
   }
 
   &.record-citation {
+    border-top: 1px solid @borderColor;
+    border-bottom: 1px solid @borderColor;
+
     label {
       font-weight: 700;
     }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/dropdown.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/dropdown.overrides
@@ -61,3 +61,7 @@
   .dropdown.right:before { content: "\f0da"; }
   .dropdown.close:before { content: "\f00d"; }
 */
+
+.ui.dropdown.citation-dropdown {
+  min-width: 10em;
+}


### PR DESCRIPTION
Closes #1429 

# Screenshots
<img width="1149" alt="Screenshot 2022-04-12 at 16 51 48" src="https://user-images.githubusercontent.com/21052053/162991358-edcd113a-1165-4de4-804b-e9d1ffc7acc4.png">
<img width="822" alt="Screenshot 2022-04-12 at 16 51 30" src="https://user-images.githubusercontent.com/21052053/162991401-9cd81921-a7ee-45db-956c-b4450ecce911.png">
<img width="547" alt="Screenshot 2022-04-12 at 16 51 36" src="https://user-images.githubusercontent.com/21052053/162991377-44493f83-0de0-45bf-a1f2-1e6a13d0fb21.png">

