### PR TITLE
RDM search bar  undefined prop 'executeSearch'

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -141,18 +141,15 @@ export const RDMRecordSearchBarElement = withState(
     placeholder: passedPlaceholder,
     queryString,
     onInputChange,
-    executeSearch,
     updateQueryState,
   }) => {
     const placeholder = passedPlaceholder || i18next.t("Search");
     const onBtnSearchClick = () => {
-      updateQueryState({ filters: [] });
-      executeSearch();
+      updateQueryState({ filters: [], queryString });
     };
     const onKeyPress = (event) => {
       if (event.key === "Enter") {
-        updateQueryState({ filters: [] });
-        executeSearch();
+        updateQueryState({ filters: [], queryString });
       }
     };
     return (


### PR DESCRIPTION
Fixes an issue where the component `RDMRecordSearchBarElement` is trying to execute a function `executeSearch` which is undefined. This property is not being injected anymore by `react-searchkit`'s `SearchBar` component. 