### PR TITLE
landing page: add missing class to tab menu

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
@@ -25,7 +25,7 @@ show_alternate_identifiers, show_related_identifiers, show_funding, show_dates %
   <h2 id="record-details-heading">{{ _('Additional details') }}</h2>
 
   {# Tabs #}
-  <div role="tablist" class="ui top attached tabs menu">
+  <div role="tablist" class="ui top attached tabs menu invenio-tab-menu">
     {% if record.ui.additional_titles %}
       <a role="tab"
         aria-selected="{{ active }}"


### PR DESCRIPTION
Closes #1451

Added class needed to activate the tab menu on the landing page.