### PR TITLE
Swap preview and community header

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -20,43 +20,17 @@
 
 {%- block page_body %}
   <section id="banners" class="banners" aria-label="{{ _('Information banner') }}">
-    {% if is_preview %}
-      <div class="ui info flashed top attached manage message">
-        <div class="ui container">
-          <div class="ui relaxed grid">
-            <div class="column">
-              <div class="row">
-                <div class="header">
-                  <i class="eye icon"></i>
-                  <strong>{{_ ("Preview")}}</strong>
-                </div>
-                <p>
-                  {% if not is_draft %}
-                    {{ _("You are previewing a published record.") }}
-                  {% elif record.is_published %}
-                    {{ _("You are previewing changes that have not yet been published.") }}
-                  {% elif not record.is_published and record.versions.index == 1 %}
-                    {{ _("You are previewing a new record that has not yet been published.") }}
-                  {% elif not record.is_published and record.versions.index > 1 %}
-                    {{ _("You are previewing a new record version that has not yet been published.") }}
-                  {% endif %}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    {% endif %}
 
     {% if community %}
-    <!-- TODO: Checks below must be deleted once community is resolved -->
-    {% if community.links is defined %}
-      {%- set logoLink = community.links.logo %}
-      {%- set communityTitle = community.metadata.title %}
-    {% else %}
-      {%- set logoLink = "/static/images/square-placeholder.png" %}
-      {%- set communityTitle = community %}
-    {% endif %}
+      <!-- TODO: Checks below must be deleted once community is resolved -->
+      {% if community.links is defined %}
+        {%- set logoLink = community.links.logo %}
+        {%- set communityTitle = community.metadata.title %}
+      {% else %}
+        {%- set logoLink = "/static/images/square-placeholder.png" %}
+        {%- set communityTitle = community %}
+      {% endif %}
+
       <div class="ui fluid container page-subheader-outer compact">
         <div class="ui container page-subheader">
           <div class="page-subheader-element">
@@ -71,6 +45,28 @@
         </div>
       </div>
     {% endif %}
+
+    {% if is_preview %}
+    <div class="ui info flashed top attached manage message">
+      <div class="ui container">
+        <div class="header">
+          <i class="eye icon"></i>
+          <strong>{{_ ("Preview")}}</strong>
+        </div>
+        <p>
+          {% if not is_draft %}
+            {{ _("You are previewing a published record.") }}
+          {% elif record.is_published %}
+            {{ _("You are previewing changes that have not yet been published.") }}
+          {% elif not record.is_published and record.versions.index == 1 %}
+            {{ _("You are previewing a new record that has not yet been published.") }}
+          {% elif not record.is_published and record.versions.index > 1 %}
+            {{ _("You are previewing a new record version that has not yet been published.") }}
+          {% endif %}
+        </p>
+      </div>
+    </div>
+  {% endif %}
 
     {% if record.is_published and not record.versions.is_latest %}
     <div class="ui warning flashed top attached manage message">
@@ -120,7 +116,7 @@
               {%- block record_header_button -%}
 
                 {% if is_preview and permissions.can_edit and is_draft %}
-                  <nav class="back-navigation" aria-label="{{ _('Back-navigation') }}">
+                  <nav class="back-navigation rel-pb-2 pl-0" aria-label="{{ _('Back-navigation') }}">
                     {%- set back_page = url_for('invenio_app_rdm_records.deposit_edit', pid_value=record.id, preview=1) -%}
                     {%- set back_btn_label = _('Back to edit') -%}
                     <a class="ui button labeled icon small compact" href="{{ back_page }}">

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/container.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/container.overrides
@@ -13,6 +13,12 @@
     margin-right: 0 !important;
   }
 
+  & ~ .ui.info.flashed.message.manage {
+    margin-top: -@defaultMargin;
+    /*  Using negative margin to not complicate the
+        spacing of .page-subheader-outer */
+  }
+
   &.with-submenu {
     padding-bottom: 0;
     margin-bottom: 0;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -258,12 +258,6 @@ pre.export.result {
 
 /* record details */
 
-.main-record-content {
-  nav.back-navigation {
-    padding-bottom: 1rem;
-  }
-}
-
 .font-small {
   font-size: @font-size-small
 }


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1468
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1469

Swapped the community header and preview header, and aligned back-button.

## Screenshot
<img width="1337" alt="Screenshot 2022-04-26 at 08 56 50" src="https://user-images.githubusercontent.com/21052053/165240418-3df518a1-80dd-4e40-bb15-e91bb56d6307.png">

