### PR TITLE
remove hidden-class from global overrides

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/header.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/header.overrides
@@ -33,3 +33,9 @@
     font-size: 1rem;
   }
 }
+
+aside.sidebar {
+  h3.hidden {
+    display: none;
+  }
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -14,10 +14,6 @@ body {
   flex-direction: column;
 }
 
-.hidden {
-  display: none;
-}
-
 .mobile.only {
   display: none;
 


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1486

- Removed the hidden-class from `site.overrides` and applied it only to the `h3` header in the sidebar.
- The hidden-class was added in this commit https://github.com/inveniosoftware/invenio-app-rdm/commit/d71ca9d52f0cb12d37a16bb46f03b6314238f96a , just 5 days ago, so unlikely it's used anywhere else.