### PR TITLE
container: override width for stackable menu

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/container.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/container.overrides
@@ -39,6 +39,12 @@
     height: 3em;
   }
 
+  &.stackable.menu {
+    @media all and (max-width: @largestMobileScreen) {
+      width: 100% !important; // Overwriting semantic-ui's `auto !important` for same breakpoint on .ui.container
+    }
+  }
+
   .page-subheader-element{
     padding-left: 0.5em;
     padding-right: 0.5em;


### PR DESCRIPTION
Make stackable menu span full width on mobile.