### PR TITLE
deposit: add draft curation button

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -15,8 +15,9 @@
 
 {%- from "invenio_app_rdm/records/macros/files.html" import file_list_box, preview_file_box %}
 
-{%- set title = record.metadata.title -%}
+{%- set title = record.metadata.title %}
 {%- set metadata = record.metadata %}
+{%- set can_manage_record = permissions is defined and ((permissions.can_edit and not is_preview) or (is_draft and permissions.can_update_draft) ) %}
 
 {%- block page_body %}
   <section id="banners" class="banners" aria-label="{{ _('Information banner') }}">
@@ -128,9 +129,9 @@
                   </nav>
                 {% endif %}
 
-              {%- endblock record_header_button -%}
+              {% endblock record_header_button %}
 
-              {% if permissions is defined and permissions.can_edit and not is_preview %}
+              {% if can_manage_record is sameas true %}
                 <section id="mobile-record-management" class="ui grid tablet only mobile only">
                   <div class="sixteen wide column right aligned">
                     <button id="manage-record-btn"
@@ -145,6 +146,9 @@
                   <div id="recordManagementMobile"
                        role="dialog"
                        class="ui flowing popup transition hidden"
+                       data-record='{{ record | tojson }}'
+                       data-permissions='{{ permissions | tojson }}'
+                       data-is-draft="{{ is_draft | tojson }}"
                   >
                   </div>
                 </section>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/manage_menu.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/manage_menu.html
@@ -5,7 +5,7 @@ Invenio RDM Records is free software; you can redistribute it and/or modify
 it under the terms of the MIT License; see LICENSE file for more details.
 #}
 
-{% if permissions is defined and permissions.can_edit and not is_preview %}
+{% if can_manage_record is sameas true %}
   <section id="record-manage-menu"
            aria-label="{{ _('Record management') }}"
            class="ui grid segment computer only rdm-sidebar"
@@ -14,6 +14,7 @@ it under the terms of the MIT License; see LICENSE file for more details.
          id="recordManagement"
          data-record='{{ record | tojson }}'
          data-permissions='{{ permissions | tojson }}'
+         data-is-draft="{{ is_draft | tojson }}"
     >
     </div>
   </section>

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -333,5 +333,5 @@ def deposit_edit(draft=None, draft_files=None, pid_value=None):
         communities_enabled=current_app.config["COMMUNITIES_ENABLED"],
         files=draft_files.to_dict(),
         searchbar_config=dict(searchUrl=get_search_url()),
-        permissions=draft.has_permissions_to(['new_version'])
+        permissions=draft.has_permissions_to(['new_version', 'delete_draft'])
     )

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -370,17 +370,18 @@ export class RDMDepositForm extends Component {
                     label={i18next.t("Visibility")}
                     labelIcon={"shield"}
                   />
-
-                  <Card>
-                    <Card.Content>
-                      <DeleteButton
-                        fluid
-                        // TODO: make is_published part of the API response
-                        //       so we don't have to do this
-                        isPublished={record.is_published}
-                      />
-                    </Card.Content>
-                  </Card>
+                  {permissions.can_delete_draft &&
+                    <Card>
+                      <Card.Content>
+                        <DeleteButton
+                          fluid
+                          // TODO: make is_published part of the API response
+                          //       so we don't have to do this
+                          isPublished={record.is_published}
+                        />
+                      </Card.Content>
+                    </Card>
+                  }
                 </Sticky>
               </Grid.Column>
             </Ref>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
@@ -8,13 +8,13 @@
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 
 import React, { useState } from "react";
-import { Grid, Message } from "semantic-ui-react";
+import { Button, Grid, Icon, Message } from 'semantic-ui-react';
 
 import { EditButton } from "./EditButton";
 import { ShareButton } from "./ShareButton";
 import { NewVersionButton } from "react-invenio-deposit";
 
-export const RecordManagement = ({ record, permissions }) => {
+export const RecordManagement = ({ record, permissions, isDraft }) => {
   const { id: recid } = record;
   const [error, setError] = useState("");
   const handleError = (errorMessage) => {
@@ -25,7 +25,22 @@ export const RecordManagement = ({ record, permissions }) => {
   return (
     <Grid columns={1} className="record-management">
       <Grid.Column className="pb-5">
-        <EditButton recid={recid} onError={handleError} />
+        {permissions.can_edit && !isDraft && (
+          <EditButton recid={recid} onError={handleError} />
+        )}
+        {permissions.can_update_draft && isDraft && (
+          <Button
+            fluid
+            color="orange"
+            size="medium"
+            onClick={() => window.location = `/uploads/${recid}`}
+            icon
+            labelPosition="left"
+          >
+            <Icon name="edit" />
+            {i18next.t("Edit submission")}
+          </Button>
+        )}
       </Grid.Column>
       <Grid.Column className="pt-5 pb-5">
         <NewVersionButton

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
@@ -31,6 +31,7 @@ function renderRecordManagement(element) {
     <RecordManagement
       record={JSON.parse(recordManagementAppDiv.dataset.record)}
       permissions={JSON.parse(recordManagementAppDiv.dataset.permissions)}
+      isDraft={JSON.parse(recordManagementAppDiv.dataset.isDraft)}
     />,
     element
   );


### PR DESCRIPTION
* enable community curator to access deposit form
  of the draft submitted for community review and
  curate the record

* remove delete button in draft deposit
  (community curator only)
  
* closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1485
  
USER view of the request record preview:
<img width="1791" alt="Screenshot 2022-04-28 at 17 21 00" src="https://user-images.githubusercontent.com/38131488/165788611-ba5b2000-7e6d-4297-8df6-3c4f9798bc86.png">

USER view of the deposit form of the submitted draft
<img width="1800" alt="Screenshot 2022-04-28 at 16 38 46" src="https://user-images.githubusercontent.com/38131488/165788619-be5b07ad-1926-4f2c-94c4-f7a68db97ec1.png">

community curator view: deposit form of a draft submitted for review
<img width="1868" alt="Screenshot 2022-04-28 at 16 38 34" src="https://user-images.githubusercontent.com/38131488/165788622-dbf56120-4d07-466a-8f8b-85569c9deaac.png">

community curator view: request record preview
<img width="1772" alt="Screenshot 2022-04-28 at 16 38 21" src="https://user-images.githubusercontent.com/38131488/165788592-321ce678-fc9b-48f7-8e5d-f0af256b0b2d.png">
