### PR TITLE
config: add indexer to celery beat

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -258,10 +258,10 @@ BROKER_URL = "amqp://guest:guest@localhost:5672/"
 """URL of message broker for Celery 3 (default is RabbitMQ)."""
 
 CELERY_BEAT_SCHEDULE = {
-    # 'indexer': {
-    #     'task': 'invenio_indexer.tasks.process_bulk_queue',
-    #     'schedule': timedelta(minutes=5),
-    # },
+    'indexer': {
+        'task': 'invenio_records_resources.tasks.manage_indexer_queues',
+        'schedule': timedelta(seconds=10),
+    },
     'accounts_sessions': {
         'task': 'invenio_accounts.tasks.clean_session_table',
         'schedule': timedelta(minutes=60),


### PR DESCRIPTION
- requires https://github.com/inveniosoftware/invenio-records-resources/pull/331
- closes https://github.com/inveniosoftware/invenio-communities/issues/584

https://user-images.githubusercontent.com/6756943/166913355-0745d4a3-b835-4d8f-9bbd-b8f9cae6ac54.mov


Working with redis and rabbitmq, can be seen the queue/key is there and then dissapears after it's consumed.

![Screenshot 2022-05-05 at 14 09 05](https://user-images.githubusercontent.com/6756943/166920663-4c48592f-8b82-461b-bf8d-b3fc615855e1.png)
![Screenshot 2022-05-05 at 14 07 29](https://user-images.githubusercontent.com/6756943/166920671-6ee5e580-bbe5-404e-8e3a-ddca53eb1467.png)

