### PR TITLE
views: remove usage of system_identity to query vocabularies

### DIFF
--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -12,10 +12,9 @@
 import re
 
 from elasticsearch_dsl import Q
-from flask import current_app, render_template
+from flask import current_app, g, render_template
 from flask_babelex import lazy_gettext as _
 from flask_login import login_required
-from invenio_access.permissions import system_identity
 from invenio_i18n.ext import current_i18n
 from invenio_rdm_records.proxies import current_rdm_records
 from invenio_rdm_records.resources.serializers import UIJSONSerializer
@@ -109,7 +108,7 @@ class VocabulariesOptions:
         """Dump resource type vocabulary."""
         type_ = 'resourcetypes'
         all_resource_types = vocabulary_service.read_all(
-            system_identity,
+            g.identity,
             fields=["id", "props", "title", "icon"],
             type=type_,
             # Sorry, we have over 100+ resource types entry at NU actually
@@ -120,7 +119,7 @@ class VocabulariesOptions:
             for hit in all_resource_types.to_dict()["hits"]["hits"]
         }
         subset_resource_types = vocabulary_service.read_all(
-            system_identity,
+            g.identity,
             fields=["id", "props", "title", "icon"],
             type=type_,
             extra_filter=extra_filter,
@@ -140,7 +139,7 @@ class VocabulariesOptions:
     def _dump_vocabulary_w_basic_fields(self, vocabulary_type):
         """Dump vocabulary with id and title field."""
         results = vocabulary_service.read_all(
-            system_identity, fields=["id", "title"], type=vocabulary_type)
+            g.identity, fields=["id", "title"], type=vocabulary_type)
         return [
             {
                 "text": self._get_label(hit),

--- a/tests/ui/test_deposits.py
+++ b/tests/ui/test_deposits.py
@@ -63,7 +63,7 @@ def additional_resource_types(running_app):
     Vocabulary.index.refresh()
 
 
-def test_resource_types(additional_resource_types):
+def test_resource_types(app, client_with_login, additional_resource_types):
     options = VocabulariesOptions()
     expected = [
         # If no corresponding parent type entry (e.g. image-photo), type_name


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1516

Since all the occurrences happen at _views_ level it is accepted to access the `g` object. The `current_user` does not provide an identity (it provides `id` and `roles`) and we would need to build the identity from it, which is already stored in `g.identity`.