### PR TITLE
CSS: standardize identity icon display

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
@@ -143,9 +143,9 @@ export const RDMRecordResultsListItem = ({ result, index }) => {
         <Item.Header as="h2">
           <a href={viewLink}>{title}</a>
         </Item.Header>
-        <Item.Meta className="creatibutors">
+        <Item className="creatibutors">
           <SearchItemCreators creators={creators} />
-        </Item.Meta>
+        </Item>
         <Item.Description>
           {_truncate(description_stripped, {
             length: 350,

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
@@ -59,7 +59,7 @@ export function SearchItemCreators({ creators }) {
             title={`${creatorName}: ${i18next.t("ORCID profile")}`}
           >
             <img
-              className="inline-id-icon"
+              className="ml-5 inline-id-icon"
               src="/static/images/orcid.svg"
               alt=""
             />
@@ -74,7 +74,7 @@ export function SearchItemCreators({ creators }) {
             title={`${creatorName}: ${i18next.t("ROR profile")}`}
           >
             <img
-              className="inline-id-icon"
+              className="ml-5 inline-id-icon"
               src="/static/images/ror-icon.svg"
               alt=""
             />
@@ -89,7 +89,7 @@ export function SearchItemCreators({ creators }) {
             title={`${creatorName}: ${i18next.t("GND profile")}`}
           >
             <img
-              className="inline-id-icon"
+              className="ml-5 inline-id-icon"
               src="/static/images/gnd-icon.svg"
               alt=""
             />

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/icon.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/icon.overrides
@@ -3,7 +3,8 @@
 ***********************************************/
 
 .inline-id-icon {
-  height: @fontSizeBase;
+  height: 1rem;
+  min-height: 16px;
   width: auto;
   vertical-align: text-bottom;
 }


### PR DESCRIPTION
### Description

Small CSS changes to standardize displays of creatibutors' identity icons between views --  landing page view,  public search results view,  and dashboard view.  This affects the spacing between the name and the icon, the spacing between the name-icon groups, and the size of the icons.

### Checklist

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).




