### PR TITLE
request record preview header: add missing spacing

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/message.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/message.overrides
@@ -11,6 +11,10 @@
   }
 }
 
+#record-tab > .banners .ui.flashed.message.manage {
+  padding: 1rem;
+}
+
 .ui.message.file-box-message {
   box-shadow: none !important;
   border-bottom-right-radius: 10px !important;


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1524

Added padding to preview header in request details record tab.

## Screenshot
![Screenshot 2022-05-10 at 10 22 03](https://user-images.githubusercontent.com/21052053/167585396-6cb46fb1-a891-48a0-b0e8-cf18a4984265.png)
