### PR TITLE
facets-sidebar: fix inconsistencies in layout

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -291,7 +291,7 @@ export const RDMRecordFacets = ({ aggs, currentResultsState }) => {
           </div>
         );
       })}
-      <Card className="borderless facet">
+      <Card className="borderless facet mt-0">
         <Card.Content>
           <Card.Header as="h2">{i18next.t("Help")}</Card.Header>
           <SearchHelpLinks />
@@ -337,8 +337,8 @@ export const RDMBucketAggregationElement = ({
             </Button>
           }
         </Card.Header>
+        {containerCmp}
       </Card.Content>
-      <Card.Content>{containerCmp}</Card.Content>
     </Card>
   );
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/communities.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/communities.js
@@ -163,12 +163,18 @@ export const CommunitiesFacets = ({ aggs, currentResultsState }) => {
     <aside aria-label={i18next.t("filters")} id="search-filters">
       {aggs.map((agg) => {
         return (
-          <div className="rdm-facet-container">
-            <BucketAggregation title={agg.title} agg={agg} key={agg.title} />
+          <div className="rdm-facet-container" key={agg.title}>
+            <BucketAggregation title={agg.title} agg={agg} />
           </div>
         );
       })}
-      <SearchHelpLinks />
+
+      <Card className="borderless facet mt-0">
+        <Card.Content>
+          <Card.Header as="h2">{i18next.t("Help")}</Card.Header>
+          <SearchHelpLinks />
+        </Card.Content>
+      </Card>
     </aside>
   );
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/requests.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/requests.js
@@ -335,7 +335,13 @@ export const RequestsFacets = ({ aggs }) => {
           </div>
         );
       })}
-      <SearchHelpLinks />
+
+      <Card className="borderless facet mt-0">
+        <Card.Content>
+          <Card.Header as="h2">{i18next.t("Help")}</Card.Header>
+          <SearchHelpLinks />
+        </Card.Content>
+      </Card>
     </aside>
   );
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/card.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/card.overrides
@@ -14,7 +14,6 @@
   }
 }
 
-
 #deposit-form {
   /**Protection Widget*/
 


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1525

**Needs PR** https://github.com/inveniosoftware/invenio-communities/pull/644

- Added card container and headline to all `<SearchHelpLinks />` for it to be consistent with the `<BucketAggregationElement />`. 
- Put header and content in the same `<Card.Content>` in all `.rdm-facet-container`s to gather related content and reduce spacing between heading and content.
- Added same logic to all `Clear facets` buttons (only visible if facets selected).

## Screenshots
<img width="1302" alt="Screenshot 2022-05-11 at 11 55 34" src="https://user-images.githubusercontent.com/21052053/167824625-0ec77332-6df8-49ef-966c-0699fa01e98b.png">
<img width="1398" alt="Screenshot 2022-05-11 at 11 56 00" src="https://user-images.githubusercontent.com/21052053/167824634-9595c326-bd0c-427b-b452-5de15b7c2350.png">
<img width="1388" alt="Screenshot 2022-05-11 at 11 56 08" src="https://user-images.githubusercontent.com/21052053/167824641-64076c38-4f11-4fca-9438-a766c69b8f6a.png">
<img width="1350" alt="Screenshot 2022-05-11 at 11 56 24" src="https://user-images.githubusercontent.com/21052053/167824644-de74ef2d-bc53-464a-83a3-de0eabd07461.png">
<img width="1406" alt="Screenshot 2022-05-11 at 11 57 42" src="https://user-images.githubusercontent.com/21052053/167824646-211ce2a4-3e30-490e-be73-dfb291297abc.png">

