### PR TITLE
request details: show preview if user own request

### DIFF
--- a/invenio_app_rdm/requests_ui/views/requests.py
+++ b/invenio_app_rdm/requests_ui/views/requests.py
@@ -26,7 +26,10 @@ from sqlalchemy.orm.exc import NoResultFound
 
 def _resolve_topic_draft(request):
     """Resolve the record in the topic when it is a draft."""
-    if request["is_closed"]:
+    user_owns_request = \
+        str(request["expanded"]["created_by"]["id"]) == str(current_user.id)
+
+    if request["is_closed"] and not user_owns_request:
         return dict(permissions={}, record_ui=None)
 
     recid = ResolverRegistry.resolve_entity_proxy(


### PR DESCRIPTION
record tab was being hidden if the request was closed, for everyone. Now keeps it visible if is your own request, otherwise still hidden.

closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1521

![Screenshot from 2022-05-12 16-28-54](https://user-images.githubusercontent.com/55200060/168101277-20a5a41e-5b5e-4431-8e4d-9414e20e6558.png)
![Screenshot from 2022-05-12 16-28-09](https://user-images.githubusercontent.com/55200060/168101287-7fd53541-74e1-4260-9188-d12b38ee8182.png)


