### PR TITLE
parent facet value: change arrow icon to button for a11y

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -191,7 +191,12 @@ export const RDMParentFacetValue = ({
         className="facet-wrapper parent"
       >
         <List.Content className="facet-wrapper">
-          <Icon name="angle right" onClick={() => setIsActive(!isActive)} />
+          <Button
+            icon="angle right"
+            className="transparent"
+            onClick={() => setIsActive(!isActive)}
+            aria-label={i18next.t("Show all sub facets of ") + bucket.label || keyField}
+          />
           <Checkbox
             label={bucket.label || keyField}
             id={`${keyField}-facet-checkbox`}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/accordion.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/accordion.overrides
@@ -1,4 +1,5 @@
-.ui.accordion .active.title .icon, .ui.accordion .accordion .active.title .icon {
+.ui.accordion .active.title .icon:not(.button),
+.ui.accordion .accordion .active.title .icon:not(.button) {
   transform: rotate(90deg);
 }
 


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1547
**Related PR** https://github.com/inveniosoftware/invenio-communities/pull/656

- Changed the arrow icon to `<Button/>` to ensure that the icon is accessible by keyboard and with a screen reader. 
- Added `:not(.button)` to the `.ui.accordion .active.title .icon`-override as both the button `<button>` and the icon `<i>` get the class `.icon` when using the SUI icon-button, meaning the arrow is rotated 2x90 deg.

Tested with VoiceOver on Mac.