### PR TITLE
record details: fix title overflowing if too long

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -194,7 +194,7 @@
             {# Title #}
             {%- block record_title -%}
               <section id="record-title-section" aria-label="{{ _('Record title and creators') }}">
-                <h1 id="record-title">{{ metadata.title }}</h1>
+                <h1 id="record-title" class="wrap-overflowing-text">{{ metadata.title }}</h1>
 
                 {% if record.ui.creators or record.ui.contributors %}
                 <section id="creatibutors" aria-label="{{ _('Creators and contributors') }}">

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCitationField.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCitationField.js
@@ -145,7 +145,7 @@ export class RecordCitationField extends Component {
 
         <Grid.Row verticalAlign="bottom">
           <Grid.Column computer={12} className="p-0">
-            <div id="citation-text">
+            <div id="citation-text" className="wrap-overflowing-text">
               {loading ? this.placeholderLoader() : citation}
             </div>
           </Grid.Column>

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -68,6 +68,10 @@ button:focus-visible, a:focus-visible {
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
+.wrap-overflowing-text {
+  word-wrap: break-word;
+}
+
 // Log-in and sign-up
 .cover-page {
   background-image: @navbarBackgroundImage;


### PR DESCRIPTION
Now wraps to show the whole title instead of overflowing out of the layout

closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1568

before:
![Screenshot from 2022-05-16 09-53-37](https://user-images.githubusercontent.com/55200060/168546301-091a4d6a-2b6c-4060-a21e-35b5a2de2701.png)
![Screenshot from 2022-05-17 14-19-28](https://user-images.githubusercontent.com/55200060/168809715-5ac423f4-6d23-46be-b1c5-17907ce047c6.png)



after:
![Screenshot from 2022-05-16 09-52-01](https://user-images.githubusercontent.com/55200060/168546293-8e1e1455-e558-4936-bb8f-758615c3116d.png)
![Screenshot from 2022-05-17 14-20-32](https://user-images.githubusercontent.com/55200060/168809633-e7cfa7cc-3fa7-44a6-807b-edcf5b2bc015.png)

