### PR TITLE
move inline-computer class to site.overrides

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -434,6 +434,13 @@ dl.details-list {
   }
 }
 
+.inline-computer {
+  display: inline-block;
+
+  @media all and (max-width: @largestMobileScreen) {
+    display: block;
+  }
+}
 
 .flex {
   display: flex;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
@@ -92,17 +92,6 @@
         margin-top: 1rem;
       }
     }
-
-    .meta {
-
-      .inline-computer {
-        display: inline-block;
-
-        @media all and (max-width: @largestMobileScreen) {
-          display: block;
-        }
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Moved the `.inline-computer`-class to `site.overrides` as this can be useful for other elements than `.item.meta` only.

Needed for https://github.com/inveniosoftware/invenio-communities/pull/663