### PR TITLE
theme: move accordion init function to invenio-theme

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -232,7 +232,7 @@
                     {# record has files BUT user cannot see files #}
                     <div class="pt-0 pb-20">
                       <div class="ui accordion panel mb-10 {{ record.ui.access_status.id }}" id="preview" href="#collapsablePreview">
-                        <div class="active title panel-heading {{ record.ui.access_status.id }}">
+                        <div class="active title trigger panel-heading {{ record.ui.access_status.id }}">
                           {{ _("Files") }}
                           <i class="angle down icon"></i>
                         </div>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
@@ -69,8 +69,14 @@
 
 {% macro affiliations_accordion(group, affiliations) %}
 <div class="ui sixteen wide tablet three wide computer column title right aligned bottom aligned">
-    <button class="ui affiliations-button button mini up mr-0" aria-controls="{{ group }}-affiliations">{{ _("Show affiliations") }}</button>
-    <button class="ui affiliations-button button mini down mr-0" aria-controls="{{ group }}-affiliations">{{ _("Hide affiliations") }}</button>
+  <button class="ui affiliations-button trigger button mini mr-0"
+          aria-controls="{{ group }}-affiliations"
+          data-open-text="{{_('Show affiliations')}}"
+          data-close-text="{{ _('Hide affiliations') }}"
+          aria-expanded="false"
+  >
+    {{ _("Show affiliations") }}
+  </button>
 </div>
 
 <section class="ui sixteen wide column content" id="{{ group }}-affiliations" aria-label="{{ _('Affiliations for') }} {{ group }}">

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -31,9 +31,9 @@
 {% macro preview_file_box(file, pid, is_preview, record) %}
 <div class="">
   <div class="ui accordion panel mb-10 {{record.ui.access_status.id}}" id="preview" href="#collapsablePreview">
-    <div class="active title panel-heading {{record.ui.access_status.id}} truncated" tabindex="0" aria-label="{{ _('File preview') }}">
+    <div class="active title trigger panel-heading {{record.ui.access_status.id}} truncated" tabindex="0" aria-label="{{ _('File preview') }}">
       <span id="preview-file-title">{{file.key}}</span>
-      <i class="ui angle down icon"></i>
+      <i class="ui angle right icon"></i>
     </div>
     <div id="collapsablePreview" class="active content rm-pt">
       <div>
@@ -101,10 +101,10 @@
 {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
 <div class="">
   <div class="ui accordion panel mb-10 {{record.ui.access_status.id}}" id="preview" href="#collapsablePreview">
-    <div class="active title panel-heading {{record.ui.access_status.id}}" tabindex="0">
+    <div class="active title trigger panel-heading {{record.ui.access_status.id}}" tabindex="0">
       {{ _("Files") }}
       <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat(binary=binary_sizes)}}){% endif %}</small>
-      <i class="angle down icon"></i>
+      <i class="angle right icon"></i>
     </div>
     <div class="active content rm-pt">
       {% if record.access.files == 'restricted' %}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/theme.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/theme.js
@@ -37,28 +37,6 @@ $tabElement.on("keydown", function (event) {
   }
 });
 
-
-$(".ui.accordion.affiliations").accordion({
-  selector: {
-    trigger: ".title .affiliations-button",
-  },
-});
-
-
-$(".ui.accordion .title").on("keydown", function (event) {
-  const $target = $(event.target);
-  if ($target.is(".title") && event.key === "Enter") {
-    let classList = Array.from(event.target.classList);
-
-    if (classList.indexOf("active") > -1) {
-      $target.accordion("close");
-    } else {
-      $target.accordion("open");
-    }
-  }
-});
-
-
 /* User profile dropdown */
 $('#user-profile-dropdown.ui.dropdown')
   .dropdown({


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-theme/issues/286
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1577

- Add `.trigger` to all accordion panels.
- Removed accordion init function -> moved to invenio-theme https://github.com/inveniosoftware/invenio-theme/pull/284
- Changed the carret to be left pointing when closed, down when open

## Screenshots of carret bug fix
<img width="721" alt="Screenshot 2022-05-18 at 14 18 54" src="https://user-images.githubusercontent.com/21052053/169037564-a4762d8e-fbac-40d3-9371-8b9b278ed440.png">
<img width="739" alt="Screenshot 2022-05-18 at 14 18 50" src="https://user-images.githubusercontent.com/21052053/169037582-03cd5150-cb95-49f3-8dcd-22384f147d20.png">

