### PR TITLE
item: keep license item flex row on mobile

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
@@ -67,6 +67,10 @@
 .ui.items > .item.license-item {
   cursor: pointer;
 
+  @media screen and (max-width: @largestMobileScreen) {
+    flex-direction: row;
+  }
+
   .radio {
     margin-right: 0.5em;
   }


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1578

Keeps the license item a row, to be aligned with the radio button also on mobile.