### PR TITLE
Logo: avoid logo image overflowing

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -107,6 +107,7 @@ pre.export.result {
 
 .rdm-logo {
   width: 250px;
+  max-height: @75px;
 }
 
 .borderless {


### PR DESCRIPTION
Before:
![Screenshot from 2022-05-25 11-34-42](https://user-images.githubusercontent.com/25476209/170231540-b47c3b4d-4d12-4594-accf-abe0cdb7cc29.png)

After:
![Screenshot from 2022-05-25 16-28-24](https://user-images.githubusercontent.com/25476209/170289250-f2ef3b5d-6af6-4bd6-b9b0-0f08e90dbc7c.png)
![Screenshot from 2022-05-25 16-28-29](https://user-images.githubusercontent.com/25476209/170289260-a591cf7d-db28-4c65-9274-1c9c6c392adf.png)
![Screenshot from 2022-05-25 16-28-34](https://user-images.githubusercontent.com/25476209/170289265-7090b292-e5d6-4f38-a303-624ed8cb042c.png)
![Screenshot from 2022-05-25 16-39-55](https://user-images.githubusercontent.com/25476209/170289401-35900b06-97bb-4915-9fea-0c04e49e2fe4.png)
![Screenshot from 2022-05-25 16-41-09](https://user-images.githubusercontent.com/25476209/170289427-5b07c425-0100-43f7-8324-57472c80079b.png)
![Screenshot from 2022-05-25 16-41-20](https://user-images.githubusercontent.com/25476209/170289430-0e94bcd1-0499-46c4-a5e7-57a5b126d042.png)
![Screenshot from 2022-05-25 17-17-27](https://user-images.githubusercontent.com/25476209/170298209-25deb6a3-51b4-48ce-b95d-b1ea53af3532.png)
![Screenshot from 2022-05-25 17-17-27](https://user-images.githubusercontent.com/25476209/170298285-1d8e2ec8-2089-487e-9966-0c7c57b84812.png)
![Screenshot from 2022-05-25 17-17-19](https://user-images.githubusercontent.com/25476209/170298195-33329d0d-356d-4f81-a6df-1fb7a7bbaf73.png)

Screenshots of portrait format.
![Screenshot from 2022-05-30 13-00-53](https://user-images.githubusercontent.com/25476209/170979033-250de283-f462-426c-a121-6d00701f097a.png)
![Screenshot from 2022-05-30 13-01-38](https://user-images.githubusercontent.com/25476209/170979045-9e6a30c1-5fde-4113-a582-1ffe11c09c4d.png)
![Screenshot from 2022-05-30 13-01-31](https://user-images.githubusercontent.com/25476209/170979048-f95753a8-0be5-4bef-a3b7-9b49fdd33bd2.png)

