### PR TITLE
ci(publish): pinned babel version

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel babel
+          pip install setuptools wheel "babel<=2.9.1"
 
       - name: Build package
         run: |


### PR DESCRIPTION
with the release of `2.10.*` the compile_catalog does not actually compile.
for a quick fix, we restrict the version until `2.9.1`, until the issue is resolved.

issue created: https://github.com/inveniosoftware/invenio-app-rdm/issues/1675