### PR TITLE
burger menu: combine mobile and tablet visibility class

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -14,27 +14,37 @@ body {
   flex-direction: column;
 }
 
-.mobile.only {
-  display: none;
+:not(.ui.grid).only{
+  display: none !important;
 
-  @media all and (max-width: @largestMobileScreen) {
-    display: inline-block;
+  &.mobile{
+    @media all and (max-width: @largestMobileScreen) {
+      display: inline-block !important;
+    }
   }
-}
 
-.tablet.only {
-  display: none;
-
-  @media all and (max-width: @largestTabletScreen) {
-    display: inline-block;
+  &.mobile.tablet{
+    @media all and (max-width: @largestTabletScreen) {
+      display: inline-block !important;
+    }
   }
-}
 
-.computer.only {
-  display: inline-block;
+  &.tablet{
+    @media all and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
+      display: inline-block !important;
+    }
+  }
 
-  @media all and (max-width: @largestTabletScreen) {
-    display: none !important;
+  &.tablet.computer{
+    @media all and (min-width: @tabletBreakpoint) {
+      display: inline-block !important;
+    }
+  }
+
+  &.computer{
+    @media all and (min-width: @computerBreakpoint) {
+      display: inline-block !important;
+    }
   }
 }
 

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header.html
@@ -114,7 +114,7 @@
                     <div class="item inbox">
                       <a role="menuitem" href="{{ item.url }}">
                         <i class="fitted inbox icon inverted"></i>
-                        <span class="mobile only tablet only">{{ _("Inbox") }}</span>
+                        <span class="mobile tablet only">{{ _("Inbox") }}</span>
                       </a>
                     </div>
                   {% endfor %}

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header_login.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header_login.html
@@ -40,7 +40,7 @@
               </div>
           </div>
 
-          <div class="sub-menu mobile only tablet only">
+          <div class="sub-menu mobile tablet only">
             <h2 class="ui small header">{{ _("Actions") }}</h2>
 
             {%- for item in plus_menu_items if item.visible %}
@@ -87,7 +87,7 @@
             </div>
           </div>
 
-          <div class="sub-menu mobile only tablet only">
+          <div class="sub-menu mobile tablet only">
             <h2 class="ui small header">{{ _("My account") }}</h2>
 
             {%- for item in current_menu.submenu('settings').children if item.visible %}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1726


- Added breakpoint rule to the tablet-class
- Added `.mobile.tablet.only`-classes as `.mobile.only` and `.tablet.only` was causing conflicts when combined. 
- Updated visibility classes on the global menu.