### PR TITLE
landing page: remove excessive spacing from files table

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -35,7 +35,7 @@
       <span id="preview-file-title">{{file.key}}</span>
       <i class="ui angle right icon"></i>
     </div>
-    <div id="collapsablePreview" class="active content rm-pt">
+    <div id="collapsablePreview" class="active content pt-0">
       <div>
         {{ preview_file('invenio_app_rdm_records.record_file_preview', pid_value=pid, filename=file.key, is_preview=is_preview) }}
       </div>
@@ -106,7 +106,7 @@
       <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat(binary=binary_sizes)}}){% endif %}</small>
       <i class="angle right icon"></i>
     </div>
-    <div class="active content rm-pt">
+    <div class="active content pt-0">
       {% if record.access.files == 'restricted' %}
       <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
         <i class="ui {{ record.ui.access_status.icon }} icon"></i><b>{{ record.ui.access_status.title_l10n }}</b>


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1731

- Replaced `rm-pt` with `pt-0`

## Screenshot

<img width="786" alt="Screenshot 2022-06-14 at 16 01 29" src="https://user-images.githubusercontent.com/21052053/173596094-8aafd4e8-cd64-4a03-b015-80d242408d60.png">

