### PR TITLE
members: reserves space for success/error icon

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/icon.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/icon.overrides
@@ -20,3 +20,8 @@
     color: @errorTextColor;
   }
 }
+
+.members-icon-container {
+  width: 1em;
+  height: 1em;
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/icon.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/icon.overrides
@@ -20,8 +20,3 @@
     color: @errorTextColor;
   }
 }
-
-.members-icon-container {
-  width: 1em;
-  height: 1em;
-}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/dropdown.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/dropdown.overrides
@@ -80,12 +80,10 @@
 }
 
 @minWidthSmallerScreens: calc(100% + 5rem);
-
 .members-dropdown-container {
   .ui.dropdown {
     border: @selectionBorder;
-    padding: @selectionPadding;
-    padding-right: @defaultPadding;
+    padding: @selectionVerticalPadding @selectionHorizontalPadding;
     border-radius: @selectionBorderRadius;
 
     .menu {
@@ -97,7 +95,17 @@
       font-weight: normal;
 
     }
+
+    .dropdown.icon {
+      padding-top: 0.25em;
+    }
   }
+
+.action-status-container {
+  width: 1em;
+  padding: @selectionVerticalPadding @selectionHorizontalPadding;
+  border-radius: @selectionBorderRadius;
+}
 
   @media screen and (max-width: @largestTabletScreen) {
     .ui.dropdown {


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1714

The issue was that the dropdown container width was adjusting when the icon rendered. E.g. when the icon was rendered, the dropdown container shrinked.

This fix reserves space for the success/error icon by creating a `div`. Does not reduce the dropdown size a lot and it's enough to make the whole cell static when changing the selection.