### PR TITLE
landing page: prevent iframe in preview to overflow

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -278,6 +278,10 @@ a.no-text-decoration:hover {
   margin-right: auto;
 }
 
+#collapsablePreview {
+  border: 1px solid transparent; // Prevents iframe from overflowing accordion border
+}
+
 .preview-iframe {
   display: block;
   border-style: none;


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1733

Added `overflow: hidden` to preview accordion-panel, as the `#document` in the iframe was overflowing by 2px.

## Screenshots
![Screenshot 2022-06-15 at 10 35 25](https://user-images.githubusercontent.com/21052053/173782359-e9096056-a1c1-4a92-9d38-4df8acad2987.png)
![Screenshot 2022-06-15 at 10 35 12](https://user-images.githubusercontent.com/21052053/173782378-752289d4-ce87-4d94-930e-1bbfc88368f8.png)
![Screenshot 2022-06-15 at 10 35 18](https://user-images.githubusercontent.com/21052053/173782371-11e3ce07-bf1d-488b-9560-d3e7974a69a3.png)
