### PR TITLE
creatibutors: add spacing between icon and separator

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
@@ -39,7 +39,7 @@
 
 {% macro show_creatibutors(creatibutors, show_affiliations=False) %}
   {% for creatibutor in creatibutors %}
-  <dd class="creatibutor-wrap">
+  <dd class="creatibutor-wrap separated">
     <a class="ui creatibutor-link"
       {% if show_affiliations and creatibutor.affiliations %}
         data-tooltip="{{ creatibutor.affiliations|join('; ', attribute='1') }}"
@@ -59,9 +59,6 @@
       {%- endif -%}
     </a>
     {{- creatibutor_icon(creatibutor) -}}
-    {%- if not loop.last -%}
-       <span class="separator">;</span>
-    {%- endif -%}
   </dd>
   {% endfor %}
 {%- endmacro %}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
@@ -71,7 +71,7 @@ export function SearchItemCreators({ creators }) {
 
     icon = (
       <a
-         className="no-text-decoration"
+         className="no-text-decoration mr-0"
          href={ link }
          aria-label={`${name}: ${linkTitle}`}
          title={`${name}: ${linkTitle}`}
@@ -108,10 +108,9 @@ export function SearchItemCreators({ creators }) {
     return link;
   }
   return creators.map((creator, index) => (
-    <span className="creatibutor-wrap" key={index}>
+    <span className="creatibutor-wrap separated" key={index}>
       {getLink(creator)}
       {getIcons(creator)}
-      {index < creators.length - 1 && ";"}
     </span>
   ));
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
@@ -8,7 +8,8 @@
  * it under the terms of the MIT License; see LICENSE file for more details.
  */
 
-.creatibutors {
+.creatibutors,
+.ui.items > .item .meta .creatibutors {
   margin: 0 0 0.5rem 0;
   display: flex;
   flex-wrap: wrap;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -571,3 +571,10 @@ dl.details-list {
 .left-floated {
   float: left;
 }
+
+.separated:not(:last-child)::after {
+  content: @listSeparator;
+  display: inline-block;
+  font-size: 1em;
+  margin-left: .1rem;
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.variables
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.variables
@@ -130,3 +130,9 @@
 ------------------*/
 
 @userDashboardAvatarSize: 40px;
+
+
+/*------------------
+  Separators
+------------------*/
+@listSeparator: ";";


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1736

- Added separator class to creatibutors-component in `SearchItemCreators` (to keep same markup in both places).
- Had to specify `.ui.items > .item .meta .creatibutors` for the styling to be preferred over default styling in the search-results case.
- Added spacing to separator class

## Screenshots
<img width="470" alt="Screenshot 2022-06-15 at 14 54 12" src="https://user-images.githubusercontent.com/21052053/173833154-494625a7-ba32-4af4-9d6f-e4f555aa4781.png">
<img width="473" alt="Screenshot 2022-06-15 at 14 54 00" src="https://user-images.githubusercontent.com/21052053/173833159-3f6f9b1f-966d-46ac-ba68-0b10ea0166c2.png">
<img width="720" alt="Screenshot 2022-06-15 at 14 53 49" src="https://user-images.githubusercontent.com/21052053/173833162-4112ac2f-7b02-45f7-9bc0-e29609ac4760.png">

