### PR TITLE
settings: added logo size quota.

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -656,6 +656,12 @@ APP_RDM_DEPOSIT_FORM_QUOTA = {
 }
 """Deposit file upload quota """
 
+
+APP_RDM_COMMUNITY_LOGO_QUOTA = {
+    "maxStorage": 10**6,
+}
+"""Community logo size quota, in bytes."""
+
 APP_RDM_DISPLAY_DECIMAL_FILE_SIZES = True
 """Display the file sizes in powers of 1000 (KB, ...) or 1024 (KiB, ...)."""
 


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1716

- Added maximum size allowed for community logos.
  - By default it is set to 1 MB, can be modified per instance. 
  - The magic number 1MB was decided based on a search about image standards for web apps. For logos the recommended size was 500 KB, thus an extra 500KB were given. 


Note: this change should be documented for the instance configuration. 