### PR TITLE
OpenSearch 1.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,13 +37,16 @@ jobs:
           python-version: [3.7, 3.8, 3.9]
           requirements-level: [pypi]
           db-service: [postgresql10, postgresql13]
-          search-service: [elasticsearch7]
+          search-service: [opensearch1,elasticsearch7]
           include:
           - db-service: postgresql10
             DB_EXTRAS: "postgresql"
 
           - db-service: postgresql13
             DB_EXTRAS: "postgresql"
+
+          - search-service: opensearch1
+            SEARCH_EXTRAS: "opensearch1"
 
           - search-service: elasticsearch7
             SEARCH_EXTRAS: "elasticsearch7"

--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -435,7 +435,7 @@ OAISERVER_RECORD_SETS_FETCHER = "invenio_oaiserver.utils:record_sets_fetcher"
 """Record's OAI sets function."""
 
 OAISERVER_RECORD_INDEX = "rdmrecords-records"
-"""Specify an Elastic index with records that should be exposed via OAI-PMH."""
+"""Specify a search index with records that should be exposed via OAI-PMH."""
 
 OAISERVER_GETRECORD_FETCHER = "invenio_rdm_records.oai:getrecord_fetcher"
 """Record data fetcher for serialization."""
@@ -466,8 +466,8 @@ ACCESS_CACHE = "invenio_cache:current_cache"
 # ==============
 # See https://invenio-search.readthedocs.io/en/latest/configuration.html
 
-SEARCH_ELASTIC_HOSTS = [{"host": "localhost", "port": 9200}]
-"""Elasticsearch hosts."""
+SEARCH_HOSTS = [{"host": "localhost", "port": 9200}]
+"""Search hosts."""
 
 # Invenio-Indexer
 # ===============

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -9,7 +9,6 @@
 
 """Routes for record-related pages provided by Invenio-App-RDM."""
 
-from elasticsearch_dsl import Q
 from flask import current_app, g, render_template
 from flask_babelex import lazy_gettext as _
 from flask_login import login_required
@@ -18,6 +17,7 @@ from invenio_rdm_records.proxies import current_rdm_records
 from invenio_rdm_records.resources.serializers import UIJSONSerializer
 from invenio_rdm_records.services.schemas import RDMRecordSchema
 from invenio_rdm_records.services.schemas.utils import dump_empty
+from invenio_search.engine import dsl
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 from invenio_vocabularies.records.models import VocabularyScheme
 from invenio_vocabularies.services.custom_fields import VocabularyCF
@@ -157,7 +157,7 @@ class VocabulariesOptions:
     def depositable_resource_types(self):
         """Return depositable resource type options (value, label) pairs."""
         self._vocabularies["resource_type"] = self._resource_types(
-            Q("term", tags="depositable")
+            dsl.Q("term", tags="depositable")
         )
         return self._vocabularies["resource_type"]
 
@@ -216,7 +216,7 @@ class VocabulariesOptions:
 
     def linkable_resource_types(self):
         """Dump linkable resource type vocabulary."""
-        return self._resource_types(Q("term", tags="linkable"))
+        return self._resource_types(dsl.Q("term", tags="linkable"))
 
     def identifier_schemes(self):
         """Dump identifiers scheme (fake) vocabulary.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,7 +14,7 @@
 #
 # Note: the DB, SEARCH and CACHE services to use are determined by corresponding environment
 #       variables if they are set -- otherwise, the following defaults are used:
-#       DB=postgresql, SEARCH=elasticsearch and CACHE=redis
+#       DB=postgresql, SEARCH=opensearch and CACHE=redis
 #
 # Example for using mysql instead of postgresql:
 #    DB=mysql ./run-tests.sh
@@ -54,7 +54,7 @@ fi
 
 python -m check_manifest
 python -m sphinx.cmd.build -qnN docs docs/_build/html
-eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --cache ${CACHE:-redis} --env)"
+eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch} --cache ${CACHE:-redis} --env)"
 # Note: expansion of pytest_args looks like below to not cause an unbound
 # variable error when 1) "nounset" and 2) the array is empty.
 python -m pytest ${pytest_args[@]+"${pytest_args[@]}"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     invenio-celery>=1.2.4,<1.3.0
     invenio-config>=1.0.3,<1.1.0
     invenio-i18n>=1.3.1,<1.4.0
-    invenio-db[postgresql,mysql,versioning]>=1.0.14,<1.1.0
+    invenio-db[postgresql,mysql]>=1.0.14,<1.1.0
     # Invenio base bundle
     invenio-admin>=1.3.2,<1.4.0
     invenio-assets>=1.3.0,<1.4.0
@@ -50,32 +50,31 @@ install_requires =
     invenio-oauthclient>=2.0.1,<2.1.0
     invenio-userprofiles>=2.0.2,<2.1.0
     # Invenio metdata bundle
-    invenio-indexer>=1.2.7,<1.3.0
+    invenio-indexer>=2.0.0,<2.1.0
     invenio-jsonschemas>=1.1.4,<1.2.0
-    invenio-oaiserver>=1.5.0,<1.6.0
+    invenio-oaiserver>=2.0.0,<2.1.0
     invenio-pidstore>=1.2.3,<1.3.0
-    invenio-records-rest>=1.9.0,<1.10.0
+    invenio-records-rest>=2.0.0,<2.1.0
     invenio-records-ui>=1.2.0,<1.3.0
-    invenio-records>=1.7.3,<1.8.0
+    invenio-records>=2.0.0,<2.1.0
     invenio-search-ui>=2.1.2,<2.2.0
     # Invenio files bundle
     invenio-files-rest>=1.3.3,<1.4.0
     invenio-previewer>=1.3.6,<1.4.0
     invenio-records-files>=1.2.1,<1.3.0
     # Invenio-App-RDM
-    invenio-rdm-records>=0.37.0,<0.38.0
+    invenio-rdm-records>=0.38.0,<0.39.0
     CairoSVG>=2.5.2,<3.0.0
-
 
 [options.extras_require]
 tests =
-    pytest-black>=0.3.0,<0.3.10
-    pytest-invenio~=1.4.7
-    Sphinx>=4.2.0
+    pytest-black>=0.3.0
+    pytest-invenio~=2.0.0
+    Sphinx>=4.5.0
 elasticsearch7 =
-    invenio-search[elasticsearch7]>=1.4.3,<1.5.0
+    invenio-search[elasticsearch7]>=2.0.0,<3.0.0
 opensearch1 =
-    invenio-search[opensearch1]>=1.4.3,<1.5.0
+    invenio-search[opensearch1]>=2.0.0,<3.0.0
 s3 =
     invenio-s3~=1.0.5
 

--- a/tests/ui/test_deposits.py
+++ b/tests/ui/test_deposits.py
@@ -8,8 +8,8 @@
 """Test deposit views."""
 
 import pytest
-from elasticsearch_dsl import Q
 from invenio_access.permissions import system_identity
+from invenio_search.engine import dsl
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 from invenio_vocabularies.records.api import Vocabulary
 
@@ -95,7 +95,7 @@ def test_resource_types(app, client_with_login, additional_resource_types):
     ]
 
     # the choice of this filter isn't important for the test
-    result = options._resource_types(Q("term", tags="depositable"))
+    result = options._resource_types(dsl.Q("term", tags="depositable"))
 
     sorted_result = sorted(result, key=lambda e: e["id"])
     assert expected == sorted_result


### PR DESCRIPTION
This PR enables the use of OpenSearch 1.x as an alternative to Elasticsearch 7.x

Requires https://github.com/inveniosoftware/invenio-search/pull/216 (and a new 1.4.3 release)