### PR TITLE
communities: added class to access-status div to set its width to fit…

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/communities_items/ComputerTabletCommunitiesItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/communities_items/ComputerTabletCommunitiesItem.js
@@ -18,7 +18,7 @@ export const ComputerTabletCommunitiesItem = ({ result, index }) => {
   const visibilityText = isPublic ? i18next.t("Public") : i18next.t("Restricted");
   const visibilityIcon = isPublic ? undefined : "ban";
   return (
-    <Item key={index} className="computer tablet only flex">
+    <Item key={index} className="computer tablet only flex community-item">
       <Image
         wrapped
         src={result.links.logo}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/communities_items/MobileCommunitiesItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/communities_items/MobileCommunitiesItem.js
@@ -18,7 +18,7 @@ export const MobileCommunitiesItem = ({ result, index }) => {
   const visibilityText = isPublic ? i18next.t("Public") : i18next.t("Restricted");
   const visibilityIcon = isPublic ? undefined : "ban";
   return (
-    <Item key={index} className="mobile only">
+    <Item key={index} className="mobile only community-item">
       <Item.Content className="centered">
         <Item.Extra className="user-communities">
           {communityType && (

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/header.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/header.overrides
@@ -39,3 +39,7 @@ aside.sidebar {
     display: none;
   }
 }
+
+.ui.header  {
+  word-break: break-word;
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
@@ -99,12 +99,15 @@
   }
 
   .item.community-item {
-
-    .header .header-link {
-      @media all and (max-width: @largestMobileScreen) {
-        margin-top: 1rem;
+    .header {
+      word-break: break-word;
+      .header-link {
+        @media all and (max-width: @largestMobileScreen) {
+          margin-top: 1rem;
+        }
       }
     }
+
   }
 }
 


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1770

- Set property `word-break: break-word` to headers. For headers with long words they were not breaking thus creating issues in the UI.
- Added a new class for `access-status` divs that enclose `span` and `icon` elements. See https://github.com/inveniosoftware/invenio-communities/pull/757  for comments about this.
 