### PR TITLE
bump invenio-assets

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     invenio-db[postgresql,mysql,versioning]>=1.0.14,<1.1.0
     # Invenio base bundle
     invenio-admin>=1.3.2,<1.4.0
-    invenio-assets>=1.2.7,<1.3.0
+    invenio-assets>=1.3.0,<1.4.0
     invenio-formatter>=1.1.3,<1.2.0
     invenio-logging[sentry-sdk]>=1.3.2,<1.4.0
     invenio-mail>=1.0.2,<1.1.0


### PR DESCRIPTION
**Warning** this means that these 2 commits will be in:
* https://github.com/inveniosoftware/invenio-assets/commit/b89bf81c04daa09d95a368eb6cddb5bdd592a06e
* https://github.com/inveniosoftware/invenio-assets/commit/70d37ebecd46ca9cdc6e9fbe15c5dfd0b24ae6f2

I wouldn't release this in a InvenioRDM `v9.1.x`, I would go for `v9.2` or `v10`. If merged to `master`, then we need to pay attention to future releases.