### PR TITLE
dashboard uploads: change buttons to dropdown on mobile

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
@@ -39,10 +39,7 @@ export const ComputerTabletUploadsItem = ({
   );
 
   return (
-    <Item
-      key={result.id}
-      className="deposits-list-item mb-20 computer tablet only flex"
-    >
+    <Item key={result.id} className="deposits-list-item computer tablet only flex">
       <div className="status-icon mr-10">
         <Item.Content verticalAlign="top">
           <Item.Extra>{icon}</Item.Extra>
@@ -65,15 +62,25 @@ export const ComputerTabletUploadsItem = ({
             <i className={`icon ${accessStatusIcon}`} />
             {accessStatus}
           </Label>
-          <Button compact size="small" floated="right" onClick={() => editRecord()}>
-            <Icon name="edit" />
-            {i18next.t("Edit")}
-          </Button>
+          <Button
+            compact
+            size="small"
+            floated="right"
+            onClick={() => editRecord()}
+            labelPosition="left"
+            icon="edit"
+            content={i18next.t("Edit")}
+          />
           {isPublished && (
-            <Button compact size="small" floated="right" href={viewLink}>
-              <Icon name="eye" />
-              {i18next.t("View")}
-            </Button>
+            <Button
+              compact
+              size="small"
+              floated="right"
+              href={viewLink}
+              labelPosition="left"
+              icon="eye"
+              content={i18next.t("View")}
+            />
           )}
         </Item.Extra>
         <Item.Header as="h2">

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/MobileUploadsItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/MobileUploadsItem.js
@@ -7,7 +7,7 @@
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 import _truncate from "lodash/truncate";
 import React from "react";
-import { Button, Icon, Item, Label } from "semantic-ui-react";
+import { Dropdown, Icon, Item, Label } from "semantic-ui-react";
 import { SearchItemCreators } from "../../utils";
 import PropTypes from "prop-types";
 
@@ -33,13 +33,13 @@ export const MobileUploadsItem = ({
   } = uiMetadata;
 
   const icon = isPublished ? (
-    <Icon name="check" className="positive" />
+    <Icon name="check" className="positive mr-10" />
   ) : (
-    <Icon name="upload" className="negative" />
+    <Icon name="upload" className="negative mr-10" />
   );
 
   return (
-    <Item key={result.id} className="deposits-list-item mb-20 mobile only flex">
+    <Item key={result.id} className="deposits-list-item mobile only flex">
       <Item.Content className="centered">
         <Item.Extra className="labels-actions">
           {result.status in statuses && result.status !== "published" && (
@@ -66,7 +66,7 @@ export const MobileUploadsItem = ({
         </Item.Header>
         <Item.Meta>
           <div className="creatibutors">
-            <SearchItemCreators creators={creators} className="ml-auto mr-auto" />
+            <SearchItemCreators creators={creators} />
           </div>
         </Item.Meta>
         <Item.Description>
@@ -96,28 +96,25 @@ export const MobileUploadsItem = ({
           </Item.Extra>
         </Item.Extra>
         <Item.Extra>
-          <Button
-            compact
-            size="small"
-            floated="right"
-            onClick={() => editRecord()}
-            className="fluid-responsive"
-          >
-            <Icon name="edit" />
-            {i18next.t("Edit")}
-          </Button>
-          {isPublished && (
-            <Button
-              compact
-              size="small"
-              floated="right"
-              href={viewLink}
-              className="fluid-responsive"
-            >
-              <Icon name="eye" />
-              {i18next.t("View")}
-            </Button>
-          )}
+          <Dropdown button text={i18next.t("Actions")} labeled className="icon">
+            <Dropdown.Menu>
+              <Dropdown.Item
+                onClick={() => editRecord()}
+                labelPosition="left"
+                icon="edit"
+                content={i18next.t("Edit")}
+              />
+
+              {isPublished && (
+                <Dropdown.Item
+                  labelPosition="left"
+                  href={viewLink}
+                  icon="eye"
+                  content={i18next.t("View")}
+                />
+              )}
+            </Dropdown.Menu>
+          </Dropdown>
         </Item.Extra>
       </Item.Content>
     </Item>

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
@@ -11,8 +11,7 @@
 .creatibutors,
 .ui.items > .item .meta .creatibutors {
   margin: 0 0 0.5rem 0;
-  display: flex;
-  flex-wrap: wrap;
+  display: block;
 
   &:last-child {
     margin-bottom: 0;
@@ -29,8 +28,8 @@
 
   .creatibutor-wrap {
     color: @mutedTextColor;
-    display: flex;
-    flex-wrap: wrap;
+    display: inline-flex;
+    margin-bottom: .5rem;
 
     &:nth-child(n):not(:last-child) {
       margin-right: 1rem;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/dropdown.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/dropdown.overrides
@@ -77,6 +77,10 @@
       }
     }
   }
+
+  a.item:hover {
+    text-decoration: none;
+  }
 }
 
 @minWidthSmallerScreens: calc(100% + 5rem);

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
@@ -19,6 +19,10 @@
   color: @mutedTextColor;
 }
 
+.ui.items > .item .content.centered .extra > *:last-child {
+  margin-right: 0;
+}
+
 .ui.items > .item .meta * {
   margin-right: 0.1em;
 }


### PR DESCRIPTION
- Added labeled button to tablet/desktop
- Moved buttons to dropdown on mobile
- Cleaned up some inconsistent spacing
    - Removed excess right-spacing on last items on centered content causing the content to not be completely centered
    - Removed excess bottom spacing on the item
    - Added spacing below creatibutors to separate the content slightly, and to make sure the creatibutors are not squished together when stacked on the smallest screens
    - Removed `margin-auto` on each creatibutor item, changed the creatibutor-wrap to be `inline-flex` and removed `flex` from the container to make sure the content follows the text-alignment.
    - Added spacing between the icon and the headline
   

## Old version mobile
<img width="469" alt="Screenshot 2022-07-29 at 16 11 40" src="https://user-images.githubusercontent.com/21052053/181778664-6ac04989-9b5a-4631-ab23-4959d957ca19.png">

## Old version  tablet/desktop
<img width="744" alt="Screenshot 2022-07-29 at 16 11 23" src="https://user-images.githubusercontent.com/21052053/181778670-bec56822-519d-44ed-b3f1-8027de93db79.png">


## New version tablet/desktop
<img width="762" alt="Screenshot 2022-07-29 at 15 52 02" src="https://user-images.githubusercontent.com/21052053/181778844-9d3abb14-dc62-46bc-abb7-a37d31fbcd1e.png">

## New version mobile
<img width="468" alt="Screenshot 2022-07-29 at 16 14 47" src="https://user-images.githubusercontent.com/21052053/181779289-7250438a-98b3-4e3c-92fa-4d92feecc5ca.png">
<img width="477" alt="Screenshot 2022-07-29 at 16 14 59" src="https://user-images.githubusercontent.com/21052053/181779281-389d9e70-15a0-44c0-83c5-f31bb8a7469e.png">
<img width="471" alt="Screenshot 2022-07-29 at 16 14 52" src="https://user-images.githubusercontent.com/21052053/181779287-b86e84d6-655f-4ddf-8e1f-2e9f5d7ace7d.png">

