### PR TITLE
migration: add migration for parent communities

### DIFF
--- a/invenio_app_rdm/upgrade_scripts/fix_migrated_records_from_8_0_to_9_0.py
+++ b/invenio_app_rdm/upgrade_scripts/fix_migrated_records_from_8_0_to_9_0.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 CERN.
+# Copyright (C) 2022 TU Wien.
+# Copyright (C) 2022 Graz University of Technology.
+#
+# Invenio-App-RDM is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record migration fix script from InvenioRDM 8.0 to 9.0."""
+
+from click import secho
+from invenio_db import db
+from invenio_rdm_records.records.api import RDMDraft, RDMRecord
+
+
+def execute_upgrade_fix():
+    """Execute the upgrade fix from InvenioRDM 8.0 to 9.0."""
+
+    def update_parent(record):
+        """Update parent schema and parent communities for older records."""
+        new_parent_schema = "local://records/parent-v2.0.0.json"
+        record.parent["$schema"] = new_parent_schema
+        record.parent.setdefault("communities", {})
+
+    def update_record(record):
+        # skipping deleted records because can't be committed
+        if record.is_deleted:
+            return
+
+        try:
+            secho(f"Updating record : {record.pid.pid_value}", fg="yellow")
+
+            update_parent(record)
+
+            record.parent.commit()
+            record.commit()
+
+            secho(f"> Updated parent: {record.parent.pid.pid_value}", fg="green")
+            secho(f"> Updated record: {record.pid.pid_value}\n", fg="green")
+        except Exception as e:
+            secho("> Error {}".format(repr(e)), fg="red")
+            error = "Record {} failed to update".format(record.pid.pid_value)
+            return error
+
+    errors = []
+    for record_metadata in RDMRecord.model_cls.query.all():
+        record = RDMRecord(record_metadata.data, model=record_metadata)
+        error = update_record(record)
+        if error:
+            errors.append(error)
+
+    for draft_metadata in RDMDraft.model_cls.query.all():
+        draft = RDMDraft(draft_metadata.data, model=draft_metadata)
+        error = update_record(draft)
+        if error:
+            errors.append(error)
+
+    success = not errors
+
+    if success:
+        secho(f"Commiting to DB", nl=True)
+        db.session.commit()
+        secho(
+            "Data migration completed, please rebuild the search indices now.",
+            fg="green",
+        )
+
+    else:
+        secho(f"Rollback", nl=True)
+        db.session.rollback()
+        secho(
+            "Upgrade aborted due to the following errors:",
+            fg="red",
+            err=True,
+        )
+
+        for error in errors:
+            secho(error, fg="red", err=True)
+
+        msg = (
+            "The changes have been rolled back. "
+            "Please fix the above listed errors and try the upgrade again",
+        )
+        secho(msg, fg="yellow", err=True)
+
+
+if __name__ == "__main__":
+    execute_upgrade_fix()

--- a/invenio_app_rdm/upgrade_scripts/fix_migrated_records_from_8_0_to_9_0.py
+++ b/invenio_app_rdm/upgrade_scripts/fix_migrated_records_from_8_0_to_9_0.py
@@ -38,6 +38,7 @@ def execute_upgrade_fix():
 
             secho(f"> Updated parent: {record.parent.pid.pid_value}", fg="green")
             secho(f"> Updated record: {record.pid.pid_value}\n", fg="green")
+            return None
         except Exception as e:
             secho("> Error {}".format(repr(e)), fg="red")
             error = "Record {} failed to update".format(record.pid.pid_value)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Adds migration for parent communities for older records.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
