### PR TITLE
request header: move header below actions, add back-button to communi…

### DIFF
--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/community-submission/index.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/community-submission/index.html
@@ -15,6 +15,8 @@
 {%- block request_header %}
   {% if is_user_dashboard %}
     {% set back_button_url = url_for("invenio_app_rdm_users.requests") %}
+  {% else %}
+    {% set back_button_url = url_for("invenio_communities.communities_requests", pid_value=community.id) %}
   {% endif %}
   {{ submission_request_header(
     request=invenio_request, record=record, draft_is_accepted=draft_is_accepted, back_button_url=back_button_url) }}

--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/macros/request_header.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/macros/request_header.html
@@ -2,29 +2,27 @@
 
 {% macro invitation_request_header(back_button_url=None, back_button_text=None, request=None, accepted=False) %}
   <div class="flex wrap space-between">
-    <div class="flex wrap rel-mt-1 rel-mb-1">
-      {% if back_button_url and back_button_text %}
-        <div class="rel-mt-1 rel-mb-1">
-          <a href="{{ back_button_url }}"
-             class="ui button labeled icon  rel-mr-1">
-            <i class="ui icon left arrow" aria-hidden="true"></i>
-            {{ back_button_text }}
-          </a>
-        </div>
-      {% endif %}
-      <div class="flex align-items-center rel-mt-1 rel-mb-1">
-        <h2 class="ui header">{{ request.title }}</h2>
+    {% if back_button_url and back_button_text %}
+      <div class="mb-10">
+        <a href="{{ back_button_url }}"
+            class="ui small button labeled icon rel-mr-1">
+          <i class="ui icon left arrow" aria-hidden="true"></i>
+          {{ back_button_text }}
+        </a>
       </div>
-    </div>
-    <div id="request-actions" class="flex align-items-center ml-auto">
+    {% endif %}
+
+    <div id="request-actions" class="flex align-items-center ml-auto mb-10">
       {% if accepted %}
         <a href="{{ url_for("invenio_app_rdm_communities.communities_detail", pid_value=request.topic.community) }}"
-           class="ui button">
+           class="ui small button">
           {{ _("View Community") }}
         </a>
       {% endif %}
     </div>
   </div>
+
+  <h2 class="ui header">{{ request.title }}</h2>
 
   <div class="ui divider"></div>
 {% endmacro %}
@@ -35,33 +33,20 @@
 
 {% macro submission_request_header(back_button_url=None, request=None, record=None, draft_is_accepted=False) %}
   <div class="flex wrap space-between rel-mt-2">
-    <div class="flex wrap">
-      {% if back_button_url %}
-        <div class="rel-mt-1 rel-mb-1">
-          <a href="{{ back_button_url }}"
-             class="ui button labeled icon  rel-mr-1">
-            <i class="ui icon left arrow" aria-hidden="true"></i>
-            {{ _("Back to requests") }}
-          </a>
-        </div>
-      {% endif %}
-      <div class="flex align-items-center rel-mt-1 rel-mb-1">
-        <div>
-          <h2 class="ui header request-header">{{ request.title }}
-          </h2>
-          {% if record %}
-            <dl class="creatibutors" aria-label="{{ _('Creators list') }}">
-              {{ show_creatibutors(record.metadata.creators) }}
-            </dl>
-          {% endif %}
-        </div>
+    {% if back_button_url %}
+      <div class="mb-10">
+        <a href="{{ back_button_url }}"
+            class="ui small button labeled icon rel-mr-1">
+          <i class="ui icon left arrow" aria-hidden="true"></i>
+          {{ _("Back to requests") }}
+        </a>
       </div>
-    </div>
+    {% endif %}
 
-    <div id="request-actions" class="flex align-items-start ml-auto rel-mt-1 ">
+    <div id="request-actions" class="flex align-items-start ml-auto mb-10">
       {% if draft_is_accepted %}
         <a href="{{ url_for('invenio_app_rdm_records.record_detail', pid_value=request.topic.record) }}"
-           class="ui button"
+           class="ui small button"
            rel="noopener noreferrer" target="_blank"
            title="{{ _('Opens in new tab') }}"
         >
@@ -69,6 +54,14 @@
         </a>
       {% endif %}
     </div>
+  </div>
 
+  <div class="rel-mt-2">
+    <h2 class="ui header request-header">{{ request.title }}</h2>
+    {% if record %}
+      <dl class="creatibutors" aria-label="{{ _('Creators list') }}">
+        {{ show_creatibutors(record.metadata.creators) }}
+      </dl>
+    {% endif %}
   </div>
 {% endmacro %}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-requests/issues/268

- Moves request/invitation headline to below back-button and actions 
- Adds "Back to requests" button for community-requests
- Reduces button-sizes of back- and action-buttons from "medium" to "small" 

Mobile versions still need improvement, see https://github.com/inveniosoftware/invenio-requests/issues/267

## Screenshots
![Screenshot 2022-08-19 at 10 44 58](https://user-images.githubusercontent.com/21052053/185588699-fac166b2-74f8-416f-8422-9ba21b2092df.png)
![Screenshot 2022-08-19 at 10 44 46](https://user-images.githubusercontent.com/21052053/185588708-2a0bd25d-dbd0-4942-9fb9-103ded08eea7.png)

![Screenshot 2022-08-19 at 11 34 11](https://user-images.githubusercontent.com/21052053/185590489-25514e6a-8dc7-4c3b-8b8e-7762ccd8c7e0.png)
![Screenshot 2022-08-19 at 11 32 56](https://user-images.githubusercontent.com/21052053/185590580-001c32c4-f55e-4be3-94f6-1365360a5b72.png)


<img width="764" alt="Screenshot 2022-08-18 at 16 17 34" src="https://user-images.githubusercontent.com/21052053/185588718-de2a6e04-2cf3-41fa-ae35-8fe64df96bd2.png">
<img width="781" alt="Screenshot 2022-08-18 at 16 16 07" src="https://user-images.githubusercontent.com/21052053/185588720-289f1ebd-a9b7-4103-8a8e-80e623e01e4e.png">

