### PR TITLE
WIP: deposit form: send api headers to deposit app

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -633,6 +633,16 @@ APP_RDM_DEPOSIT_FORM_QUOTA = {
 }
 """Deposit file upload quota """
 
+APP_RDM_DEPOSIT_API_HEADERS = {
+    "json": {"Content-Type": "application/json"},
+    "vnd+json": {
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.inveniordm.v1+json",
+    },
+    "octet-stream": {"Content-Type": "application/octet-stream"},
+}
+"""Deposit api headers """
+
 APP_RDM_DISPLAY_DECIMAL_FILE_SIZES = True
 """Display the file sizes in powers of 1000 (KB, ...) or 1024 (KiB, ...)."""
 

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -302,6 +302,7 @@ def get_form_config(**kwargs):
             ]
         ),
         custom_fields=load_custom_fields(),
+        apiHeaders=conf.get("APP_RDM_DEPOSIT_API_HEADERS"),
         **kwargs,
     )
 


### PR DESCRIPTION
The implementation set the configuration for the deposit api headers used in the react deposit app.

- requires: inveniosoftware/react-invenio-deposit#583
