### PR TITLE
theme: remove hardcoded override of search button color

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/input.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/input.overrides
@@ -23,10 +23,6 @@
             .prompt {
                 border-radius: @defaultBorderRadius;
             }
-            .search.icon {
-                background-color: @searchButtonColor;
-                opacity: 1;
-            }
         }
 
         .results {
@@ -39,10 +35,6 @@
                     width: @activeSearchWidth;
                 }
             }
-        }
-
-        .search.icon {
-            color: white;
         }
     }
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.variables
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.variables
@@ -23,7 +23,6 @@
 @darkGray: #333;
 @green: #048622;
 @signupColor: @green;
-@searchButtonColor: @secondaryColor;
 
 @accessRightOpen: @green;
 @accessRightRestricted: @red;


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1925

- Removed hardcoded color for search icon
- Removed color-specification for search-button

The `@searchButtonColor` variable is already defined in `button.variables` and the color is set in `button.overrides`, so the removed css should not be needed (and does not seem to make any difference when testing). 

**The reason for this change is that the mentioned css made it difficult to override the colors in the local instance.**

Related to https://github.com/zenodo/zenodo-rdm/pull/54

## Screenshots (after the change)
![Screenshot 2022-10-12 at 14 50 15](https://user-images.githubusercontent.com/21052053/195347720-60b8dc4e-45d9-4090-bdaa-23d53c1ccfd0.png)
![Screenshot 2022-10-12 at 14 50 05](https://user-images.githubusercontent.com/21052053/195347728-b14682a8-e4bb-4671-a933-b090ffb766bd.png)
![Screenshot 2022-10-12 at 14 49 53](https://user-images.githubusercontent.com/21052053/195347731-b751dfc5-d698-47e9-91cb-a43dcaa649b1.png)
![Screenshot 2022-10-12 at 14 49 50](https://user-images.githubusercontent.com/21052053/195347733-5813e56f-dd0e-43b2-99c1-5abd8ef5fd78.png)
