### PR TITLE
creatibutors: align contributor title with contributors

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
@@ -18,6 +18,7 @@
   }
 
   dt {
+    display: inline-block;
     font-weight: bold;
     margin: 0 0.25rem 0 0;
 


### PR DESCRIPTION
For some reason, the title for the contributors-group is no longer aligned with the contributor names, and it looks a bit messy. See screenshot:
<img width="891" alt="Screenshot 2022-10-13 at 14 37 16" src="https://user-images.githubusercontent.com/21052053/195598777-b23184a5-9520-41c4-8f47-0a823a5b0bfa.png">


This PR makes it so that the list looks like in the following screenshot:
<img width="870" alt="Screenshot 2022-10-13 at 14 37 22" src="https://user-images.githubusercontent.com/21052053/195598522-d1472d80-868c-427b-9bb3-b10aeeef1cdb.png">
