### PR TITLE
theme: makes sure text on white segments is visible

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -89,6 +89,10 @@ button:focus-visible, a:focus-visible {
   background-color: @navbarBackgroundColor;
   border-color: transparent;
   color: @white;
+
+  .ui.segment:not(.basic) {
+    color: @mutedTextColor;
+  }
 }
 
 .no-dots-list {


### PR DESCRIPTION
The text on the "forgot password" page is invisible due to white text on white background due to `color: @white` on `.cover-page`, see screenshot:
<img width="442" alt="Screenshot 2022-10-13 at 16 29 55" src="https://user-images.githubusercontent.com/21052053/195625436-e19fc56d-a338-45ac-aefa-2ae1e84c3050.png">

This PR sets the text color to muted on white segments:
<img width="452" alt="Screenshot 2022-10-13 at 16 29 50" src="https://user-images.githubusercontent.com/21052053/195625448-fbc924ed-6767-457d-8e94-54e37a63a167.png">
