### PR TITLE
CLI command for rebuilding the search indices

### DIFF
--- a/invenio_app_rdm/cli.py
+++ b/invenio_app_rdm/cli.py
@@ -8,6 +8,8 @@
 """Command-line tools for invenio app rdm."""
 import click
 from flask.cli import with_appcontext
+from invenio_access.permissions import system_identity
+from invenio_records_resources.proxies import current_service_registry
 
 from invenio_app_rdm.fixtures import FixturesEngine, Pages
 
@@ -51,3 +53,20 @@ def create_fixtures():
     FixturesEngine().run()
 
     click.secho("Created required fixtures!", fg="green")
+
+
+@rdm.command("rebuild-all-indices")
+@with_appcontext
+def rebuild_all_indices():
+    """Schedule reindexing of all items for search."""
+    click.secho("Scheduling bulk indexing for all items.", fg="yellow")
+    for name, service in current_service_registry._services.items():
+        if hasattr(service, "rebuild_index"):
+            click.echo(f"{name}... ", nl=False)
+            service.rebuild_index(system_identity)
+            click.secho("Done.", fg="green")
+
+    click.secho(
+        "Please start a celery worker to process the scheduled bulk indexing!",
+        fg="green",
+    )


### PR DESCRIPTION
This PR introduces a new CLI command for calling `service.rebuild_index()` for every service with this method registered in the service registry (which should include all relevant services in the latest releases).