### PR TITLE
link to subject id search from landing page (fix)

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/subjects.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/subjects.html
@@ -1,6 +1,6 @@
 {#
   Copyright (C) 2020 CERN.
-  Copyright (C) 2020 Northwestern University.
+  Copyright (C) 2020-2022 Northwestern University.
   Copyright (C) 2021 New York University.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
@@ -15,14 +15,15 @@
   <h3 class="hidden">{{ _('Keywords') }}</h3>
   <ul class="ui horizontal list no-bullets subjects">
     {%- for subject in keywords %}
-      <li class="item">
-        <a href='/search?q=metadata.subjects.subject:"{{ subject.subject }}"'
-           class="subject"
-           title="{{ _('Search results for ') + subject.subject }}"
-        >
-          {{ subject.subject }}
-        </a>
-      </li>
+    <li class="item">
+      {%- set q = 'metadata.subjects.subject:"' + subject.subject + '"' %}
+      <a href="{{ url_for('invenio_search_ui.search', q=q) }}"
+          class="subject"
+          title="{{ _('Search results for ') + subject.subject }}"
+      >
+        {{ subject.subject }}
+      </a>
+    </li>
     {%- endfor %}
   </ul>
   {% endif %}
@@ -32,7 +33,8 @@
   <ul class="ui horizontal list no-bullets subjects">
     {%- for subject in subjects %}
     <li class="item">
-      <a href='/search?q=metadata.subjects.subject:"{{ subject.subject }}"'
+      {%- set q = 'metadata.subjects.id:"' + subject.id + '"' %}
+      <a href="{{ url_for('invenio_search_ui.search', q=q) }}"
          class="subject"
          title="{{ _('Search results for ') + subject.subject }}"
       >


### PR DESCRIPTION
The subject links a record landing page weren't scoped to the scheme. This resulted in being redirected to a search that wasn't specific to the subject clicked on e.g., clicking on LCNAF subject "Saguenay River (Québec)" would lead to a search picking up records that have "Saguenay River (Québec)" as a keyword. Really we encounter the issue when 2 vocabularies have same subjects (e.g., MeSH and LCSH crossovers).

Here we fix the scoping issue by using the `id` in the search. We could have used `<scheme> AND <subject>` :shrug: . 