### PR TITLE
error messages: align home- and search page

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/frontpage/RecordsList.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/frontpage/RecordsList.js
@@ -48,7 +48,7 @@ class RecordsList extends Component {
       this.setState({ data: response.data.hits, isLoading: false });
     } catch (error) {
       console.error(error);
-      this.setState({ error: i18next.t("Unable to load records"), isLoading: false });
+      this.setState({ error: error.response.data.message, isLoading: false });
     }
   };
 
@@ -77,7 +77,7 @@ class RecordsList extends Component {
             </>
           )}
 
-          {error && <Message content={error} error icon="info" />}
+          {error && <Message content={error} error icon="warning sign" />}
         </Container>
       </Overridable>
     );

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -244,14 +244,7 @@ RDMEmptyResults.defaultProps = {
 };
 
 export const RDMErrorComponent = ({ error }) => {
-  return (
-    <Message warning>
-      <Message.Header>
-        <Icon name="warning sign" />
-        {error.response.data.message}
-      </Message.Header>
-    </Message>
-  );
+  return <Message error content={error.response.data.message} icon="warning sign" />;
 };
 
 RDMErrorComponent.propTypes = {


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/163

## Screenshots

### Search page
<img width="1367" alt="Screenshot 2023-01-09 at 16 45 15" src="https://user-images.githubusercontent.com/21052053/211349639-94d7c0c8-1bbd-4cbb-9495-d05edaa9099e.png">

### Home page
<img width="1207" alt="Screenshot 2023-01-09 at 16 45 06" src="https://user-images.githubusercontent.com/21052053/211349651-3d5c63ef-6a0b-42e6-bd4d-c6cfa0c627a9.png">
