### PR TITLE
theme menu: fit  more than two items in horizonttal mobile version

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/menu.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/menu.overrides
@@ -50,6 +50,16 @@
 
         > .item {
           flex: 1 0 0;
+          min-width: 0;
+          text-align: center;
+
+          &::before {
+            content: none;
+          }
+
+          &:not(:first-child) {
+            border-left: 1px solid @borderColor;
+          }
 
           &:first-child {
             border-radius: @borderRadius 0px 0px @borderRadius;
@@ -67,12 +77,23 @@
     }
 
     &.tablet {
-      @media screen and (max-width: @largestTabletScreen) {
+      @media screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
         display: flex;
         flex-direction: row;
+        width: max-content;
 
         > .item {
           flex: 1 0 0;
+          min-width: 9rem;
+          text-align: center;
+
+          &::before {
+            content: none;
+          }
+
+          &:not(:first-child) {
+            border-left: 1px solid @borderColor;
+          }
 
           &:first-child {
             border-radius: @borderRadius 0px 0px @borderRadius;


### PR DESCRIPTION
Needed in https://github.com/inveniosoftware/invenio-communities/pull/884

The vertical SUI menu is currently only good for two elements (`width: 15em`). Instead I set a min-width on the item itself (so it can still expand), and added `width: max-content` to the menu.

Also fixed some excess/missing borders for the smaller screens version.

## Screenshots of changes:

### Two items desktop
![Screenshot 2023-02-03 at 17 25 36](https://user-images.githubusercontent.com/21052053/216655720-b85722c2-908d-452f-acdf-add8a591a50e.png)

### Two items tablet 
![Screenshot 2023-02-03 at 17 39 37](https://user-images.githubusercontent.com/21052053/216658159-512778a6-8446-41f6-9574-e1dc49388187.png)


### Two items mobile
![Screenshot 2023-02-03 at 17 39 47](https://user-images.githubusercontent.com/21052053/216658136-fc6fa06a-329c-4bcc-a9c6-4d3a4d0b0695.png)



### Three items desktop
![Screenshot 2023-02-03 at 17 25 53](https://user-images.githubusercontent.com/21052053/216655715-cc475659-7a70-4dc7-b0ba-5c3b02dfff5b.png)

### Three items tablet
![Screenshot 2023-02-03 at 17 39 29](https://user-images.githubusercontent.com/21052053/216658063-f52b4edd-eac4-434f-8f06-a7d8ec628f6d.png)


### Three items mobile
![Screenshot 2023-02-03 at 17 39 21](https://user-images.githubusercontent.com/21052053/216658098-7f0bc8a8-2bd3-4958-9f1c-f89044183e3f.png)




