### PR TITLE
url: redirects to slug not id

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/communities_items/ComputerTabletCommunitiesItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/communities_items/ComputerTabletCommunitiesItem.js
@@ -43,7 +43,7 @@ export const ComputerTabletCommunitiesItem = ({ result, index }) => {
                 </Label>
               </Item.Extra>
               <Item.Header as="h2">
-                <a href={`/communities/${result.id}`}>{result.metadata.title}</a>
+                <a href={`/communities/${result.slug}`}>{result.metadata.title}</a>
               </Item.Header>
               <Item.Meta>
                 <div

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/communities_items/MobileCommunitiesItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/communities_items/MobileCommunitiesItem.js
@@ -37,7 +37,7 @@ export const MobileCommunitiesItem = ({ result, index }) => {
           <Image wrapped src={result.links.logo} size="small" />
         </Item.Extra>
         <Item.Header as="h2" className="rel-mt-1">
-          <a href={`/communities/${result.id}`}>{result.metadata.title}</a>
+          <a href={`/communities/${result.slug}`}>{result.metadata.title}</a>
         </Item.Header>
         <Item.Meta>
           <div


### PR DESCRIPTION
* community list url now redirects to /communities/*slug* instead of /communities/*id*
* closes https://github.com/inveniosoftware/invenio-communities/issues/882