### PR TITLE
Statistics integration

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -69,6 +69,7 @@ from invenio_vocabularies.contrib.names.datastreams import (
 )
 
 from .stats.event_builders import build_record_unique_id
+from .stats.permissions import default_deny_permission_factory
 
 # TODO: Remove when records-rest is out of communities and files
 RECORDS_REST_ENDPOINTS = {}
@@ -1031,3 +1032,5 @@ STATS_QUERIES = {
         },
     },
 }
+
+STATS_PERMISSION_FACTORY = default_deny_permission_factory

--- a/invenio_app_rdm/stats/__init__.py
+++ b/invenio_app_rdm/stats/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Invenio-Stats integration for InvenioRDM."""
+
+from .event_builders import (
+    build_record_unique_id,
+    check_if_via_api,
+    drop_if_via_api,
+    file_download_event_builder,
+    record_view_event_builder,
+)
+
+__all__ = (
+    "build_record_unique_id",
+    "check_if_via_api",
+    "drop_if_via_api",
+    "file_download_event_builder",
+    "record_view_event_builder",
+)

--- a/invenio_app_rdm/stats/event_builders.py
+++ b/invenio_app_rdm/stats/event_builders.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Custom event builders for the InvenioRDM statistics.
+
+Note that the arguments to these functions will be the same as passed to the
+``EventEmitter`` objects when they are called.
+Currently in InvenioRDM this is done in resources (for API) and view functions (for UI).
+As such, it is assumed that a request context is available (and thus, Flask's global
+``request`` is accessible).
+"""
+
+from datetime import datetime
+
+from flask import current_app, request
+from invenio_stats.utils import get_user
+
+
+def file_download_event_builder(event, sender_app, **kwargs):
+    """Build a file-download event.
+
+    *Note* that this function assumes a request context by accessing properties of
+    Flask's global ``request`` object.
+    """
+    assert "record" in kwargs
+    assert "obj" in kwargs
+
+    record = kwargs["record"]
+    obj = kwargs["obj"]
+    event.update(
+        {
+            # When:
+            "timestamp": datetime.utcnow().isoformat(),
+            # What:
+            "bucket_id": str(obj.bucket_id),
+            "file_id": str(obj.file_id),
+            "file_key": obj.key,
+            "size": obj.file.size,
+            "recid": record.get("id", None),
+            "parent_recid": record.parent.get("id", None),
+            # Who:
+            "referrer": request.referrer,
+            **get_user(),
+        }
+    )
+    return event
+
+
+def record_view_event_builder(event, sender_app, **kwargs):
+    """Build a record-view event.
+
+    *Note* that this function assumes a request context by accessing properties of
+    Flask's global ``request`` object.
+    """
+    assert "record" in kwargs
+
+    record = kwargs["record"]
+    event.update(
+        {
+            # When:
+            "timestamp": datetime.utcnow().isoformat(),
+            # What:
+            "recid": record.get("id", None),
+            "parent_recid": record.parent.get("id", None),
+            # Who:
+            "referrer": request.referrer,
+            **get_user(),
+            # TODO probably we can add more request context information here for
+            #      extra filtering (e.g. URL or query params for discarding the event
+            #      when it's a citation text export)
+        }
+    )
+    return event
+
+
+def check_if_via_api(event, sender_app, **kwargs):
+    """Check if the event comes from an API request.
+
+    *Note* that this function assumes a request context by accessing properties of
+    Flask's global ``request`` object.
+    """
+    via_api = None
+    if "via_api" in kwargs:
+        via_api = kwargs["via_api"]
+    else:
+        # fallback heuristic: let's check if the request was made to our API URL
+        via_api = request.url.startswith(current_app.config["SITE_API_URL"])
+
+    event.update({"via_api": via_api})
+    return event
+
+
+def drop_if_via_api(event, sender_app, **kwargs):
+    """Drop the event if it comes from the API."""
+    if "via_api" not in event or not event["via_api"]:
+        return event
+
+    return None
+
+
+def build_record_unique_id(event):
+    """Build record unique identifier."""
+    # NOTE: the 'unique_id' is used by the aggregators to know which events
+    #       should be aggregated together... since we want to distinguish between
+    #       API and UI events, this needs to be incorporated into the 'unique_id'
+    prefix = "api" if event.get("via_api") else "ui"
+    event["unique_id"] = f"{prefix}_{event['recid']}"
+    return event

--- a/invenio_app_rdm/stats/permissions.py
+++ b/invenio_app_rdm/stats/permissions.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Permission factories for Invenio-Stats.
+
+In contrast to the very liberal defaults provided by Invenio-Stats, these permission
+factories deny access unless otherwise specified.
+"""
+
+from invenio_stats import current_stats
+
+DenyAllPermission = type(
+    "Deny",
+    (),
+    {"can": lambda self: False, "allows": lambda *args: False},
+)()
+"""The permission factory that denies without even blinking."""
+
+
+def default_deny_permission_factory(query_name, params):
+    """Default deny permission factory.
+
+    It disables the statistics by default, unless the queries have a dedicated
+    configured permission factory.
+    """
+    if current_stats.queries[query_name].permission_factory is None:
+        return DenyAllPermission
+    else:
+        return current_stats.queries[query_name].permission_factory(query_name, params)

--- a/invenio_app_rdm/stats/templates/aggregations/__init__.py
+++ b/invenio_app_rdm/stats/templates/aggregations/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Aggregations search index templates."""

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/__init__.py
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""File download aggregations search index templates."""

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/os-v1/__init__.py
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/os-v1/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""File download aggregations OpenSearch index templates."""

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/os-v1/aggr-file-download-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/os-v1/aggr-file-download-v1.0.0.json
@@ -1,0 +1,69 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__stats-file-download-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "1m"
+    }
+  },
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "date_fields": {
+          "match_mapping_type": "date",
+          "mapping": {
+            "type": "date",
+            "format": "date_optional_time"
+          }
+        }
+      }
+    ],
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "date_optional_time"
+      },
+      "count": {
+        "type": "integer"
+      },
+      "unique_count": {
+        "type": "integer"
+      },
+      "file_id": {
+        "type": "keyword"
+      },
+      "file_key": {
+        "type": "keyword"
+      },
+      "bucket_id": {
+        "type": "keyword"
+      },
+      "volume": {
+        "type": "double"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__stats-file-download": {}
+  }
+}

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/os-v2/__init__.py
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/os-v2/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""File download aggregations OpenSearch index templates."""

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/os-v2/aggr-file-download-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/os-v2/aggr-file-download-v1.0.0.json
@@ -1,0 +1,69 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__stats-file-download-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "1m"
+    }
+  },
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "date_fields": {
+          "match_mapping_type": "date",
+          "mapping": {
+            "type": "date",
+            "format": "date_optional_time"
+          }
+        }
+      }
+    ],
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "date_optional_time"
+      },
+      "count": {
+        "type": "integer"
+      },
+      "unique_count": {
+        "type": "integer"
+      },
+      "file_id": {
+        "type": "keyword"
+      },
+      "file_key": {
+        "type": "keyword"
+      },
+      "bucket_id": {
+        "type": "keyword"
+      },
+      "volume": {
+        "type": "double"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__stats-file-download": {}
+  }
+}

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/v7/__init__.py
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/v7/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""File download aggregations Elasticsearch index templates."""

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/v7/aggr-file-download-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_file_download/v7/aggr-file-download-v1.0.0.json
@@ -1,0 +1,69 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__stats-file-download-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "1m"
+    }
+  },
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "date_fields": {
+          "match_mapping_type": "date",
+          "mapping": {
+            "type": "date",
+            "format": "date_optional_time"
+          }
+        }
+      }
+    ],
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "date_optional_time"
+      },
+      "count": {
+        "type": "integer"
+      },
+      "unique_count": {
+        "type": "integer"
+      },
+      "file_id": {
+        "type": "keyword"
+      },
+      "file_key": {
+        "type": "keyword"
+      },
+      "bucket_id": {
+        "type": "keyword"
+      },
+      "volume": {
+        "type": "double"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__stats-file-download": {}
+  }
+}

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/__init__.py
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record views aggregations search index templates."""

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/os-v1/__init__.py
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/os-v1/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record view aggregations OpenSearch index templates."""

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/os-v1/aggr-record-view-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/os-v1/aggr-record-view-v1.0.0.json
@@ -1,0 +1,46 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__stats-record-view-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "1m"
+    }
+  },
+  "mappings": {
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "date_optional_time"
+      },
+      "count": {
+        "type": "integer"
+      },
+      "unique_count": {
+        "type": "integer"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__stats-record-view": {}
+  }
+}

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/os-v2/__init__.py
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/os-v2/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record view aggregations OpenSearch index templates."""

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/os-v2/aggr-record-view-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/os-v2/aggr-record-view-v1.0.0.json
@@ -1,0 +1,46 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__stats-record-view-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "1m"
+    }
+  },
+  "mappings": {
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "date_optional_time"
+      },
+      "count": {
+        "type": "integer"
+      },
+      "unique_count": {
+        "type": "integer"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__stats-record-view": {}
+  }
+}

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/v7/__init__.py
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/v7/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 CERN.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record view aggregations Elasticsearch index templates."""

--- a/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/v7/aggr-record-view-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/aggregations/aggr_record_view/v7/aggr-record-view-v1.0.0.json
@@ -1,0 +1,46 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__stats-record-view-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "1m"
+    }
+  },
+  "mappings": {
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "date_optional_time"
+      },
+      "count": {
+        "type": "integer"
+      },
+      "unique_count": {
+        "type": "integer"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__stats-record-view": {}
+  }
+}

--- a/invenio_app_rdm/stats/templates/events/__init__.py
+++ b/invenio_app_rdm/stats/templates/events/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Statistics events search index templates."""

--- a/invenio_app_rdm/stats/templates/events/file_download/__init__.py
+++ b/invenio_app_rdm/stats/templates/events/file_download/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""File download event search index templates."""

--- a/invenio_app_rdm/stats/templates/events/file_download/os-v1/__init__.py
+++ b/invenio_app_rdm/stats/templates/events/file_download/os-v1/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""File download event OpenSearch index templates."""

--- a/invenio_app_rdm/stats/templates/events/file_download/os-v1/file-download-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/events/file_download/os-v1/file-download-v1.0.0.json
@@ -1,0 +1,93 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__events-stats-file-download-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "date_fields": {
+          "match_mapping_type": "date",
+          "mapping": {
+            "type": "date",
+            "format": "strict_date_hour_minute_second"
+          }
+        }
+      }
+    ],
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "strict_date_hour_minute_second"
+      },
+      "bucket_id": {
+        "type": "keyword"
+      },
+      "file_id": {
+        "type": "keyword"
+      },
+      "file_key": {
+        "type": "keyword"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "country": {
+        "type": "keyword"
+      },
+      "visitor_id": {
+        "type": "keyword"
+      },
+      "is_machine": {
+        "type": "boolean"
+      },
+      "is_robot": {
+        "type": "boolean"
+      },
+      "unique_session_id": {
+        "type": "keyword"
+      },
+      "size": {
+        "type": "double"
+      },
+      "referrer": {
+        "type": "keyword"
+      },
+      "ip_address": {
+        "type": "keyword"
+      },
+      "user_agent": {
+        "type": "keyword"
+      },
+      "user_id": {
+        "type": "keyword"
+      },
+      "session_id": {
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__events-stats-file-download": {}
+  }
+}

--- a/invenio_app_rdm/stats/templates/events/file_download/os-v2/__init__.py
+++ b/invenio_app_rdm/stats/templates/events/file_download/os-v2/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""File download event OpenSearch index templates."""

--- a/invenio_app_rdm/stats/templates/events/file_download/os-v2/file-download-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/events/file_download/os-v2/file-download-v1.0.0.json
@@ -1,0 +1,93 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__events-stats-file-download-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "date_fields": {
+          "match_mapping_type": "date",
+          "mapping": {
+            "type": "date",
+            "format": "strict_date_hour_minute_second"
+          }
+        }
+      }
+    ],
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "strict_date_hour_minute_second"
+      },
+      "bucket_id": {
+        "type": "keyword"
+      },
+      "file_id": {
+        "type": "keyword"
+      },
+      "file_key": {
+        "type": "keyword"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "country": {
+        "type": "keyword"
+      },
+      "visitor_id": {
+        "type": "keyword"
+      },
+      "is_machine": {
+        "type": "boolean"
+      },
+      "is_robot": {
+        "type": "boolean"
+      },
+      "unique_session_id": {
+        "type": "keyword"
+      },
+      "size": {
+        "type": "double"
+      },
+      "referrer": {
+        "type": "keyword"
+      },
+      "ip_address": {
+        "type": "keyword"
+      },
+      "user_agent": {
+        "type": "keyword"
+      },
+      "user_id": {
+        "type": "keyword"
+      },
+      "session_id": {
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__events-stats-file-download": {}
+  }
+}

--- a/invenio_app_rdm/stats/templates/events/file_download/v7/__init__.py
+++ b/invenio_app_rdm/stats/templates/events/file_download/v7/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 CERN.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""File download event Elasticsearch index templates."""

--- a/invenio_app_rdm/stats/templates/events/file_download/v7/file-download-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/events/file_download/v7/file-download-v1.0.0.json
@@ -1,0 +1,93 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__events-stats-file-download-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "date_fields": {
+          "match_mapping_type": "date",
+          "mapping": {
+            "type": "date",
+            "format": "strict_date_hour_minute_second"
+          }
+        }
+      }
+    ],
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "strict_date_hour_minute_second"
+      },
+      "bucket_id": {
+        "type": "keyword"
+      },
+      "file_id": {
+        "type": "keyword"
+      },
+      "file_key": {
+        "type": "keyword"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "country": {
+        "type": "keyword"
+      },
+      "visitor_id": {
+        "type": "keyword"
+      },
+      "is_machine": {
+        "type": "boolean"
+      },
+      "is_robot": {
+        "type": "boolean"
+      },
+      "unique_session_id": {
+        "type": "keyword"
+      },
+      "size": {
+        "type": "double"
+      },
+      "referrer": {
+        "type": "keyword"
+      },
+      "ip_address": {
+        "type": "keyword"
+      },
+      "user_agent": {
+        "type": "keyword"
+      },
+      "user_id": {
+        "type": "keyword"
+      },
+      "session_id": {
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__events-stats-file-download": {}
+  }
+}

--- a/invenio_app_rdm/stats/templates/events/record_view/__init__.py
+++ b/invenio_app_rdm/stats/templates/events/record_view/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record views search index templates."""

--- a/invenio_app_rdm/stats/templates/events/record_view/os-v1/__init__.py
+++ b/invenio_app_rdm/stats/templates/events/record_view/os-v1/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record view event OpenSearch index templates."""

--- a/invenio_app_rdm/stats/templates/events/record_view/os-v1/record-view-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/events/record_view/os-v1/record-view-v1.0.0.json
@@ -1,0 +1,70 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__events-stats-record-view-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "strict_date_hour_minute_second"
+      },
+      "labels": {
+        "type": "keyword"
+      },
+      "country": {
+        "type": "keyword"
+      },
+      "visitor_id": {
+        "type": "keyword"
+      },
+      "is_robot": {
+        "type": "boolean"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "unique_session_id": {
+        "type": "keyword"
+      },
+      "referrer": {
+        "type": "keyword"
+      },
+      "ip_address": {
+        "type": "keyword"
+      },
+      "user_agent": {
+        "type": "keyword"
+      },
+      "user_id": {
+        "type": "keyword"
+      },
+      "session_id":{
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__events-stats-record-view": {}
+  }
+}

--- a/invenio_app_rdm/stats/templates/events/record_view/os-v2/__init__.py
+++ b/invenio_app_rdm/stats/templates/events/record_view/os-v2/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record view event OpenSearch index templates."""

--- a/invenio_app_rdm/stats/templates/events/record_view/os-v2/record-view-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/events/record_view/os-v2/record-view-v1.0.0.json
@@ -1,0 +1,70 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__events-stats-record-view-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "strict_date_hour_minute_second"
+      },
+      "labels": {
+        "type": "keyword"
+      },
+      "country": {
+        "type": "keyword"
+      },
+      "visitor_id": {
+        "type": "keyword"
+      },
+      "is_robot": {
+        "type": "boolean"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "unique_session_id": {
+        "type": "keyword"
+      },
+      "referrer": {
+        "type": "keyword"
+      },
+      "ip_address": {
+        "type": "keyword"
+      },
+      "user_agent": {
+        "type": "keyword"
+      },
+      "user_id": {
+        "type": "keyword"
+      },
+      "session_id":{
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__events-stats-record-view": {}
+  }
+}

--- a/invenio_app_rdm/stats/templates/events/record_view/v7/__init__.py
+++ b/invenio_app_rdm/stats/templates/events/record_view/v7/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2023 CERN.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Record view event Elasticsearch index templates."""

--- a/invenio_app_rdm/stats/templates/events/record_view/v7/record-view-v1.0.0.json
+++ b/invenio_app_rdm/stats/templates/events/record_view/v7/record-view-v1.0.0.json
@@ -1,0 +1,70 @@
+{
+  "index_patterns": ["__SEARCH_INDEX_PREFIX__events-stats-record-view-*"],
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "date_detection": false,
+    "dynamic": false,
+    "numeric_detection": false,
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "strict_date_hour_minute_second"
+      },
+      "labels": {
+        "type": "keyword"
+      },
+      "country": {
+        "type": "keyword"
+      },
+      "visitor_id": {
+        "type": "keyword"
+      },
+      "is_robot": {
+        "type": "boolean"
+      },
+      "unique_id": {
+        "type": "keyword"
+      },
+      "unique_session_id": {
+        "type": "keyword"
+      },
+      "referrer": {
+        "type": "keyword"
+      },
+      "ip_address": {
+        "type": "keyword"
+      },
+      "user_agent": {
+        "type": "keyword"
+      },
+      "user_id": {
+        "type": "keyword"
+      },
+      "session_id":{
+        "type": "keyword"
+      },
+      "record_id": {
+        "type": "keyword"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "parent_id": {
+        "type": "keyword"
+      },
+      "parent_recid": {
+        "type": "keyword"
+      },
+      "via_api": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aliases": {
+    "__SEARCH_INDEX_PREFIX__events-stats-record-view": {}
+  }
+}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -54,7 +54,7 @@ fi
 
 python -m check_manifest
 python -m sphinx.cmd.build -qnN docs docs/_build/html
-eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch} --cache ${CACHE:-redis} --env)"
+eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch} --cache ${CACHE:-redis} --mq ${MQ:-rabbitmq} --env)"
 # Note: expansion of pytest_args looks like below to not cause an unbound
 # variable error when 1) "nounset" and 2) the array is empty.
 python -m pytest ${pytest_args[@]+"${pytest_args[@]}"}

--- a/tests/api/test_stats_api.py
+++ b/tests/api/test_stats_api.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 CERN.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test the statistics integration."""
+
+from invenio_accounts.testutils import login_user_via_session
+
+
+def test_ui_event_emission(running_app, headers, client, admin_user):
+    """It is expected that the REST API endpoint for the statistics is disabled."""
+    login_user_via_session(client, email=admin_user.email)
+
+    # NOTE: the permissions are only relevant per requested query type ("stat")
+    data = {"my-query": {"stat": "record-view", "params": {"recid": "doesnt-matter"}}}
+    result = client.post("/stats", headers=headers, json=data)
+    assert result.status_code == 403
+
+    # i.e. if no queries are requested, nothing will be denied
+    result = client.post("/stats", headers=headers, json={})
+    assert result.status_code == 200
+    assert result.json == {}

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -17,6 +17,7 @@ from flask_webpackext.manifest import (
 from invenio_access.permissions import system_identity
 from invenio_app.factory import create_ui
 from invenio_rdm_records.proxies import current_rdm_records
+from invenio_search import current_search
 
 
 #
@@ -53,6 +54,12 @@ def app_config(app_config):
 def create_app():
     """Create test app."""
     return create_ui
+
+
+@pytest.fixture()
+def index_templates(running_app):
+    """Ensure the index templates are in place."""
+    list(current_search.put_templates(ignore=[400]))
 
 
 @pytest.fixture()

--- a/tests/ui/test_stats_ui.py
+++ b/tests/ui/test_stats_ui.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023 TU Wien.
+#
+# Invenio-App-RDM is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test the statistics integration."""
+
+import time
+from datetime import datetime, timedelta
+
+import pytest
+from flask import current_app
+from invenio_search.engine import dsl
+from invenio_stats.proxies import current_stats
+from invenio_stats.tasks import process_events
+
+
+@pytest.fixture()
+def empty_event_queues(running_app):
+    """Make sure the event queues exist and are empty."""
+    for event in current_stats.events:
+        queue = current_stats.events[event].queue
+        queue.queue.declare()
+        queue.consume()
+
+
+def test_record_view_events(
+    client, running_app, index_templates, record, empty_event_queues
+):
+    """Test that landing page visits trigger events."""
+    res = client.get(f"/records/{record.id}")
+    assert res.status_code == 200
+
+    # as per current default configuration, only UI-based visits should
+    # trigger events to be sent off to the queue
+    # (API calls such as the CSL export on the landing page are ignored)
+    queue = current_stats.events["record-view"].queue
+    events = list(queue.consume())
+    event = events[0]
+    assert len(events) == 1
+    assert event["recid"] == record.id
+    assert event["via_api"] is False
+
+
+def test_record_view_statistics(
+    client, running_app, index_templates, record, empty_event_queues
+):
+    """Test that landing page visits triggers events and indexes them."""
+    event_cfg = current_stats.events["record-view"]
+    event = event_cfg.cls(**event_cfg.params, double_click_window=0)
+    agg_cfg = current_stats.aggregations["record-view-agg"]
+    agg = agg_cfg.cls(agg_cfg.name, **agg_cfg.params)
+    query_cfg = current_stats.queries["record-view"]
+    query = query_cfg.cls(name=query_cfg.name, **query_cfg.params)
+
+    for i in range(3):
+        if i != 0:
+            # we need to sleep for a little while here because invenio-stats trims
+            # the sub-second part from the events before indexing them,
+            # (and thus collapses similar events if they are too close in time)
+            time.sleep(1.25)
+
+        res = client.get(f"/records/{record.id}")
+        assert res.status_code == 200
+
+        # process the event
+        processing_result = event.run()
+        assert processing_result == (1, 0)
+
+        # refresh the index and check if the event was properly indexed
+        dsl.Index(event.index, using=event.client).refresh()
+        indexed_events = dsl.Search(using=event.client, index=event.index).execute(
+            ignore_cache=True
+        )
+        indexed_event = indexed_events.hits[0]
+        assert indexed_events.hits.total.value == (i + 1)
+        assert indexed_event["recid"] == record.id
+        assert indexed_event["parent_recid"] == record["parent"]["id"]
+        assert indexed_event["via_api"] is False
+
+        # calculate the aggregations and check if the query is correct
+        yesterday = datetime.today() - timedelta(days=1)
+        tomorrow = datetime.today() + timedelta(days=1)
+        agg.run(start_date=yesterday, end_date=tomorrow, update_bookmark=False)
+        dsl.Index(agg.index, using=agg.client).refresh()
+        query_result = query.run(recid=record.id)
+        assert query_result["recid"] == record.id
+        assert query_result["parent_recid"] == record["parent"]["id"]
+        assert query_result["views"] == (i + 1)
+        assert query_result["unique_views"] == 1


### PR DESCRIPTION
This PR introduces the following pieces in order to integrate `Invenio-Stats` into InvenioRDM:
* search index templates for **events** and **aggregations**
* custom parts of the stats pipeline (i.e. **event builders**), adjusted to the basic needs of InvenioRDM
* default configuration that makes use of these custom parts