### PR TITLE
migrate: flask_babelex replaced by invenio_i18n

### DIFF
--- a/invenio_app_rdm/__init__.py
+++ b/invenio_app_rdm/__init__.py
@@ -16,6 +16,6 @@
 #
 # See PEP 0440 for details - https://www.python.org/dev/peps/pep-0440
 
-__version__ = "12.0.0.dev1"
+__version__ = "12.0.0.dev2"
 
 __all__ = ("__version__",)

--- a/invenio_app_rdm/communities_ui/views/ui.py
+++ b/invenio_app_rdm/communities_ui/views/ui.py
@@ -3,15 +3,16 @@
 # Copyright (C) 2019-2022 CERN.
 # Copyright (C) 2019-2022 Northwestern University.
 # Copyright (C)      2022 TU Wien.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 """Communities UI blueprints module."""
 
 from flask import Blueprint, current_app, render_template
-from flask_babelex import lazy_gettext as _
 from flask_login import current_user
 from flask_menu import current_menu
+from invenio_i18n import lazy_gettext as _
 from invenio_pidstore.errors import PIDDeletedError, PIDDoesNotExistError
 from invenio_records_resources.services.errors import PermissionDeniedError
 

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2019-2021 Northwestern University.
 # Copyright (C)      2021 TU Wien.
 # Copyright (C) 2022 KTH Royal Institute of Technology
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -11,9 +12,9 @@
 """Routes for record-related pages provided by Invenio-App-RDM."""
 
 from flask import current_app, g, render_template
-from flask_babelex import lazy_gettext as _
 from flask_login import login_required
 from invenio_communities.proxies import current_communities
+from invenio_i18n import lazy_gettext as _
 from invenio_i18n.ext import current_i18n
 from invenio_rdm_records.proxies import current_rdm_records
 from invenio_rdm_records.resources.serializers import UIJSONSerializer

--- a/invenio_app_rdm/theme/views.py
+++ b/invenio_app_rdm/theme/views.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2020 CERN.
 # Copyright (C) 2019-2020 Northwestern University.
 # Copyright (C)      2021 TU Wien.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,9 +11,9 @@
 """Routes for general pages provided by Invenio-App-RDM."""
 
 from flask import Blueprint, current_app, render_template
-from flask_babelex import get_locale
-from flask_babelex import lazy_gettext as _
 from flask_menu import current_menu
+from invenio_i18n import get_locale
+from invenio_i18n import lazy_gettext as _
 
 
 #

--- a/invenio_app_rdm/users_ui/views/ui.py
+++ b/invenio_app_rdm/users_ui/views/ui.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2016-2021 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,9 +10,9 @@
 """Communities UI views."""
 
 from flask import Blueprint, current_app, render_template
-from flask_babelex import lazy_gettext as _
 from flask_login import current_user
 from flask_menu import current_menu
+from invenio_i18n import lazy_gettext as _
 
 #
 # Error handlers

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,40 +33,40 @@ install_requires =
     invenio-cache>=1.1.1,<1.2.0
     invenio-celery>=1.2.4,<1.3.0
     invenio-config>=1.0.3,<1.1.0
-    invenio-i18n>=1.3.1,<1.4.0
+    invenio-i18n>=2.0.0,<3.0.0
     invenio-db[postgresql,mysql]>=1.0.14,<1.1.0
     # Invenio base bundle
-    invenio-admin>=1.3.2,<1.4.0
+    invenio-admin>=1.4.0,<1.5.0
     invenio-assets>=2.0.0,<3.0.0
-    invenio-formatter>=1.1.3,<1.2.0
+    invenio-formatter>=1.2.0,<1.3.0
     invenio-logging[sentry-sdk]>=1.3.2,<1.4.0
     invenio-mail>=1.0.2,<1.1.0
     invenio-rest>=1.2.8,<1.3.0
-    invenio-theme>=1.4.0,<1.5.0
+    invenio-theme>=2.0.0,<3.0.0
     # Invenio auth bundle
     invenio-access>=1.4.4,<1.5.0
-    invenio-accounts>=2.0.0,<2.1.0
-    invenio-oauth2server>=1.3.6,<1.4.0
-    invenio-oauthclient>=2.1.0,<3.0.0
-    invenio-userprofiles>=2.0.2,<2.1.0
+    invenio-accounts>=2.1.0,<2.2.0
+    invenio-oauth2server>=2.0.0,<2.1.0
+    invenio-oauthclient>=2.2.0,<3.0.0
+    invenio-userprofiles>=2.1.0,<2.2.0
     # Invenio metadata bundle
     invenio-indexer>=2.1.0,<2.2.0
     invenio-jsonschemas>=1.1.4,<1.2.0
-    invenio-oaiserver>=2.1.0,<2.2.0
-    invenio-pidstore>=1.2.3,<1.3.0
-    invenio-records-rest>=2.1.0,<2.2.0
+    invenio-oaiserver>=2.2.0,<2.3.0
+    invenio-pidstore>=1.3.0,<1.4.0
+    invenio-records-rest>=2.2.0,<2.3.0
     invenio-records-ui>=1.2.0,<1.3.0
-    invenio-records>=2.0.0,<2.1.0
-    invenio-search-ui>=2.3.0,<3.0.0
+    invenio-records>=2.1.0,<2.2.0
+    invenio-search-ui>=2.4.0,<3.0.0
     # Invenio files bundle
-    invenio-files-rest>=1.4.0,<1.5.0
-    invenio-previewer>=1.3.6,<1.4.0
+    invenio-files-rest>=1.5.0,<1.6.0
+    invenio-previewer>=1.4.0,<1.5.0
     invenio-records-files>=1.2.1,<1.3.0
     # Invenio-App-RDM
-    invenio-rdm-records>=2.0.0,<3.0.0
+    invenio-rdm-records>=2.3.0,<3.0.0
     CairoSVG>=2.5.2,<3.0.0
     invenio-pages>=2.0.0,<3.0.0
-    invenio-banners>=2.0.0,<3.0.0
+    invenio-banners>=2.1.0,<3.0.0
     # Pinned due to before_first_request deprecation https://flask.palletsprojects.com/en/2.2.x/api/#flask.Flask.before_first_request
     Flask>=2.2.0,<2.3.0
 


### PR DESCRIPTION
- NOTE: Flask-Security-Invenio invenio-accounts invenio-admin invenio-administration invenio-communities invenio-drafts-resources invenio-files-rest invenio-formatter invenio-i18n invenio-oaiserver invenio-oauth2server invenio-oauthclient invenio-pidstore invenio-previewer invenio-rdm-records invenio-records invenio-records-resources invenio-records-rest invenio-requests invenio-search-ui invenio-theme invenio-userprofiles invenio-users-resources invenio-vocabularies all other packages needs to be released first