### PR TITLE
menu: make horizontal menu full width on tablet

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/form.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/form.overrides
@@ -142,3 +142,15 @@
     }
   }
 }
+
+/* due to complex config interface of CKEditor 5 */
+.generate-ck-editor-heights(@max, @i: 0) when (@i =< @max) {
+  .ck-height-@{i} {
+    .ck-editor__editable {
+      height: unit(@i, em) !important;
+    }
+  }
+  .generate-ck-editor-heights(@max, (@i + 1));
+}
+
+.generate-ck-editor-heights(30);

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/menu.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/menu.overrides
@@ -80,7 +80,7 @@
       @media screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
         display: flex;
         flex-direction: row;
-        width: max-content;
+        width: 100%;
 
         > .item {
           flex: 1 0 0;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/image.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/image.overrides
@@ -64,6 +64,17 @@
 
 }
 
+.ui.items{
+  .ui.image.community-logo {
+    img {
+      height: @communityItemLogoWidth !important; // needs to override height set for images in items by SUI
+      width: @communityItemLogoWidth !important; // needs to override height set for images in items by SUI
+      object-fit: contain;
+    }
+  }
+}
+
+
 .ui.image.community-header-logo {
   height: inherit;
   object-fit: contain;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/card.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/card.overrides
@@ -72,8 +72,9 @@
     display: flex;
     background: transparent;
 
+
     img {
-      object-fit: scale-down;
+      object-fit: contain;
     }
 
     &.fallback_image, &.placeholder {


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-communities/issues/907

This PR makes the horizontal tablet menu (e.g. in community settings) span the full width.

## Screenshot
<img width="793" alt="Screenshot 2023-03-09 at 16 07 57" src="https://user-images.githubusercontent.com/21052053/224072007-6cd111d7-aa51-46ea-8c13-b1c004aba4d1.png">
