### PR TITLE
Exporters: make serializer parameters configurable

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -640,12 +640,14 @@ APP_RDM_RECORD_EXPORTERS = {
     "json": {
         "name": _("JSON"),
         "serializer": ("flask_resources.serializers:JSONSerializer"),
+        "params": {"options": {"indent": 2, "sort_keys": True}},
         "content-type": "application/json",
         "filename": "{id}.json",
     },
     "csl": {
         "name": _("CSL"),
         "serializer": ("invenio_rdm_records.resources.serializers:CSLJSONSerializer"),
+        "params": {"options": {"indent": 2, "sort_keys": True}},
         "content-type": "application/vnd.citationstyles.csl+json",
         "filename": "{id}.json",
     },
@@ -654,6 +656,7 @@ APP_RDM_RECORD_EXPORTERS = {
         "serializer": (
             "invenio_rdm_records.resources.serializers:DataCite43JSONSerializer"
         ),
+        "params": {"options": {"indent": 2, "sort_keys": True}},
         "content-type": "application/vnd.datacite.datacite+json",
         "filename": "{id}.json",
     },
@@ -662,6 +665,7 @@ APP_RDM_RECORD_EXPORTERS = {
         "serializer": (
             "invenio_rdm_records.resources.serializers:DataCite43XMLSerializer"
         ),
+        "params": {},
         "content-type": "application/vnd.datacite.datacite+xml",
         "filename": "{id}.xml",
     },
@@ -670,30 +674,35 @@ APP_RDM_RECORD_EXPORTERS = {
         "serializer": (
             "invenio_rdm_records.resources.serializers:DublinCoreXMLSerializer"
         ),
+        "params": {},
         "content-type": "application/x-dc+xml",
         "filename": "{id}.xml",
     },
     "marcxml": {
         "name": _("MARCXML"),
         "serializer": ("invenio_rdm_records.resources.serializers:MARCXMLSerializer"),
+        "params": {},
         "content-type": "application/marcxml+xml",
         "filename": "{id}.xml",
     },
     "bibtex": {
         "name": _("BibTeX"),
         "serializer": ("invenio_rdm_records.resources.serializers:" "BibtexSerializer"),
+        "params": {},
         "content-type": "application/x-bibtex",
         "filename": "{id}.bib",
     },
     "GeoJSON": {
         "name": _("GeoJSON"),
         "serializer": ("invenio_rdm_records.resources.serializers:GeoJSONSerializer"),
+        "params": {"options": {"indent": 2, "sort_keys": True}},
         "content-type": "application/vnd.geojson+json",
         "filename": "{id}.geojson",
     },
     "DCAT-AP": {
         "name": _("DCAT"),
         "serializer": "invenio_rdm_records.resources.serializers:DCATSerializer",
+        "params": {},
         "content-type": "application/dcat+xml",
         "filename": "{id}.xml",
     },

--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -218,10 +218,7 @@ def record_export(
         abort(404)
 
     serializer = obj_or_import_string(exporter["serializer"])(
-        options={
-            "indent": 2,
-            "sort_keys": True,
-        }
+        **exporter.get("params", {})
     )
     exported_record = serializer.serialize_object(record.to_dict())
     contentType = exporter.get("content-type", export_format)


### PR DESCRIPTION
This PR fixes the tests on the master branch, here's the details:

The problem is caused by the export page [simply passing hard-coded JSON formatting arguments](https://github.com/inveniosoftware/invenio-rdm-records/pull/1266) to all serializers, no matter which arguments they accept.
This isn't accepted by the code path along the Dublin Core XML serializer and causes a failure (more details in the RDM-Records PR linked below).

In this PR, I make the arguments to be used configurable per serializer.
This obviously makes the export serialization more flexible (e.g. it enables users to set custom indentation for JSON, ...) and is actually required to enable configuration of the DC XML export (UI) to behave like before its update.

I've opened up a complementary PR in RDM-Records, which focuses on limiting the accepted arguments in the serializer: https://github.com/inveniosoftware/invenio-rdm-records/pull/1266
Either of these PRs should fix the problem at hand, but I suggest both of them, because arguably both spots were a bit off.