### PR TITLE
fix: untranslatable relative path

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/theme.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/theme.less
@@ -16,7 +16,7 @@
 @import '@{themesFolder}/default/globals/site.variables';
 
 /* Packaged site.variables */
-@import '@{themesFolder}/@{siteFolder}/globals/site.variables';
+@import '@{themesFolder}/@{site}/globals/site.variables';
 
 /* Component's site.variables */
 @import (optional) '@{themesFolder}/@{theme}/globals/site.variables';


### PR DESCRIPTION
* this bug prevented the migration to webpack 5, because this line was
  translated to a relative path, which could not be converted to an
  absolute path. this is bad, because webpack 5 introduced a check about
  relative paths and removed those and printed an error.
