### PR TITLE
community-item: Fix styling bug for mobile item

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
@@ -107,20 +107,25 @@
         }
       .content{
         width: 100% !important;
+
         &.flex.right-column{
           flex-direction: column;
           align-items: end;
         };
       }
       .extra{
-        position: absolute;
-        bottom: 0.7em !important;
-        top: unset;
-        left:unset;
-        width: unset;
+        @media all and (min-width: @tabletBreakpoint) {
+          position: absolute;
+          bottom: 0.7em !important;
+          top: unset;
+          left:unset;
+          width: unset;
+        }
       }
       .header {
         word-break: break-word;
+        margin-bottom: 0;
+
         .header-link {
           @media all and (max-width: @largestMobileScreen) {
             margin-top: 1rem;


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-communities/issues/950

This PR adds a media query to the `.extra`-class to remove absolute positioning on mobile, plus removes the bottom margin from the heading to make the spacing consistent.


## Screenshots

### Desktop
<img width="957" alt="Screenshot 2023-05-05 at 17 29 01" src="https://user-images.githubusercontent.com/21052053/236508094-950371da-ae8e-4f06-b884-b8a69c058237.png">

### Tablet
<img width="735" alt="Screenshot 2023-05-05 at 17 29 08" src="https://user-images.githubusercontent.com/21052053/236508101-68e32c6e-f279-4213-a208-5d1427c5992a.png">

### Mobile
<img width="365" alt="Screenshot 2023-05-05 at 17 36 40" src="https://user-images.githubusercontent.com/21052053/236508107-92a9c2b1-ca4c-412c-8a7a-f6c89e0b7d77.png">