### PR TITLE
record files: enable file modifications depending on external DOi

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -30,6 +30,9 @@
   {%- if permissions %}
   <input id="deposits-record-permissions" type="hidden" name="deposits-record-permissions" value='{{permissions | tojson }}'></input>
   {%- endif %}
+  {%- if externalDOI is not none %}
+  <input id="deposits-externalDOI" type="hidden" name="deposits-externalDOI" value='{{ externalDOI | tojson }}'></input>
+  {%- endif %}
   <div id="deposit-form"></div>
 {%- endblock page_body %}
 

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/manage_menu.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/manage_menu.html
@@ -17,6 +17,7 @@ it under the terms of the MIT License; see LICENSE file for more details.
          data-is-draft="{{ is_draft | tojson }}"
          data-is-preview-submission-request="{{ is_preview_submission_request | tojson }}"
          data-current-user-id="{{ current_user.id }}"
+         data-external-doi="{{ externalDOI | tojson }}"
     >
       <div class="ui placeholder">
         <div class="header">

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -94,7 +94,8 @@ export class RDMDepositForm extends Component {
   sidebarRef = createRef();
 
   render() {
-    const { record, files, permissions, preselectedCommunity } = this.props;
+    const { record, files, permissions, preselectedCommunity, externalDOI } =
+      this.props;
     const customFieldsUI = this.config.custom_fields.ui;
     return (
       <DepositFormApp
@@ -147,6 +148,8 @@ export class RDMDepositForm extends Component {
                       quota={this.config.quota}
                       decimalSizeDisplay={this.config.decimal_size_display}
                       showMetadataOnlyToggle={permissions?.can_manage_files}
+                      // externalDOI={permissions?.can_draft_modify_files}
+                      externalDOI={externalDOI}
                     />
                   </Overridable>
                 </AccordionField>
@@ -659,6 +662,7 @@ RDMDepositForm.propTypes = {
   preselectedCommunity: PropTypes.object,
   files: PropTypes.object,
   permissions: PropTypes.object,
+  externalDOI: PropTypes.bool, // required?
 };
 
 RDMDepositForm.defaultProps = {

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/index.js
@@ -21,6 +21,7 @@ ReactDOM.render(
       files={getInputFromDOM("deposits-record-files")}
       config={getInputFromDOM("deposits-config")}
       permissions={getInputFromDOM("deposits-record-permissions")}
+      externalDOI={getInputFromDOM("deposits-externalDOI")}
     />
   </OverridableContext.Provider>,
   document.getElementById("deposit-form")

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
@@ -25,8 +25,14 @@ export class RecordManagement extends Component {
   }
 
   render() {
-    const { record, permissions, isDraft, isPreviewSubmissionRequest, currentUserId } =
-      this.props;
+    const {
+      record,
+      permissions,
+      isDraft,
+      isPreviewSubmissionRequest,
+      currentUserId,
+      externalDOI,
+    } = this.props;
     const { error } = this.state;
     const { id: recid } = record;
 
@@ -59,16 +65,18 @@ export class RecordManagement extends Component {
         )}
         {!isPreviewSubmissionRequest && (
           <>
-            <Grid.Column className="pt-5 pb-5">
-              <NewVersionButton
-                fluid
-                size="medium"
-                record={record}
-                onError={handleError}
-                disabled={!permissions.can_new_version}
-              />
-            </Grid.Column>
-
+            {/*{!permissions?.can_draft_modify_files && (*/}
+            {!externalDOI && (
+              <Grid.Column className="pt-5 pb-5">
+                <NewVersionButton
+                  fluid
+                  size="medium"
+                  record={record}
+                  onError={handleError}
+                  disabled={!permissions.can_new_version}
+                />
+              </Grid.Column>
+            )}
             <Grid.Column className="pt-5">
               {permissions.can_manage && (
                 <ShareButton disabled={!permissions.can_update_draft} recid={recid} />
@@ -100,4 +108,5 @@ RecordManagement.propTypes = {
   isDraft: PropTypes.bool.isRequired,
   isPreviewSubmissionRequest: PropTypes.bool.isRequired,
   currentUserId: PropTypes.string.isRequired,
+  externalDOI: PropTypes.bool, // required?
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
@@ -41,6 +41,7 @@ function renderRecordManagement(element) {
           recordManagementAppDiv.dataset.isPreviewSubmissionRequest
         )}
         currentUserId={recordManagementAppDiv.dataset.currentUserId}
+        externalDOI={JSON.parse(recordManagementAppDiv.dataset.externalDoi)}
       />
     </OverridableContext.Provider>,
     element


### PR DESCRIPTION
* remove "New version" button from landing page for records with external DOI
* remove "New version" button from record edit form for records with external DOI
* closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2259

Landing page preview for record with external DOI:
<img width="1654" alt="Screenshot 2023-06-21 at 11 28 55" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/87380b6f-1304-469c-9480-485a7cd7437f">

For comparison: rec with our DOI:
<img width="1648" alt="Screenshot 2023-06-21 at 11 28 37" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/84f5474d-7b99-474a-8689-a8e2bcd04882">

