### PR TITLE
Record landing pages: access request forms

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -1,7 +1,7 @@
 {#
   Copyright (C) 2020-2021 CERN.
   Copyright (C) 2020-2021 Northwestern University.
-  Copyright (C) 2021 TU Wien.
+  Copyright (C) 2021-2023 TU Wien.
   Copyright (C) 2021 Graz University of Technology.
   Copyright (C) 2021 New York University.
 
@@ -23,6 +23,10 @@
 <!-- preview_submission_request is set to true when coming from a community submission request -->
 {%- set is_preview_submission_request = preview_submission_request or false %}
 {%- set show_record_management_menu = can_manage_record and (not is_preview or is_preview_submission_request) %}
+
+{#- TODO check if the record allows requests for users/guests #}
+{%- set user_request_enabled = not current_user.is_anonymous %}
+{%- set guest_request_enabled = current_user.is_anonymous %}
 
 {%- block page_body %}
   <section id="banners" class="banners" aria-label="{{ _('Information banner') }}">
@@ -251,6 +255,20 @@
                             {% if record.access.embargo.reason %}
                               <p>{{ _("Reason") }}: {{ record.access.embargo.reason }}</p>
                             {% endif %}
+
+                            {%- if user_request_enabled or guest_request_enabled  %}
+                              <hr style="border-color: darkred;">
+                              <p>
+                                <p>
+                                  <strong>Request access</strong>
+                                </p>
+                                <p>
+                                  <!-- TODO: Once implemented in the backend display the access description provided nad use this as fallback -->
+                                  If you would like to request access to these files, please fill out the form below.
+                                </p>
+                                {%- include "invenio_app_rdm/records/details/access-form.html" %}
+                              </p>
+                            {%- endif %}
 
                           </div>
                         </div>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/access-form.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/access-form.html
@@ -1,0 +1,99 @@
+{#
+Copyright (C) 2023 CERN.
+
+Invenio RDM Records is free software; you can redistribute it and/or modify
+it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% set user_access_request_url = "{api}/records/{pid_value}/access/request".format(
+    api=config.SITE_API_URL, pid_value=record.id
+    )
+%}
+{% set guest_access_request_url = "{api}/records/{pid_value}/access/request/guest".format(
+    api=config.SITE_API_URL, pid_value=record.id
+    )
+%}
+
+{% set endpoint = guest_access_request_url if current_user.is_anonymous else user_access_request_url %}
+
+<div id="access-request-form container">
+    <form id="access-request-form" action="{{ endpoint }}" method="post" class="ui form">
+        <input type="hidden" id="is-guest" value="{{current_user.is_anonymous}}">
+        {%- if current_user.is_anonymous %}
+            <div class="ui segment">
+                <i aria-hidden="true" class="user secret icon"></i>You are currently <strong>not logged in</strong>. Do you have an account?
+                <a href="/login/">Log in</a>
+            </div>
+
+            <div class="equal width fields">
+                <div class="field">
+                    <div class="required field">
+                        <label for="access-request-email-address">Your email address</label>
+                        <div class="ui left icon input">
+                            <input placeholder="Email address" required=""
+                                id="access-request-email-address" type="email">
+                                <i aria-hidden="true" class="at icon"></i>
+                        </div>
+                    </div>
+                </div>
+                <div class="field">
+                    <div class="required field"><label for="access-request-full-name">Your full name</label>
+                        <div class="ui left icon input"><input placeholder="Full name" required=""
+                                id="access-request-full-name" type="text"><i aria-hidden="true"
+                                class="address card icon"></i></div>
+                    </div>
+                </div>
+            </div>
+            {% else %}
+            <div class="ui segment">
+                <i aria-hidden="true" class="user icon"></i>You are logged in as <strong>{{current_user.email}}</strong>. Not you?
+                <a href="{{ url_for('security.login') }}">Log out</a>
+                <input type="hidden" id="access-request-email-address" value="{{current_user.email}}">
+                <input type="hidden" id="access-request-full-name" value="{{current_user.user_profile.full_name}}">
+            </div>
+        {%- endif %}
+        <div class="field">
+            <div class="required field"><label for="access-request-message">Request message</label><textarea
+                    placeholder="Please describe why you need access here" required="" id="access-request-message"
+                    rows="3"></textarea></div>
+        </div>
+        <div class="field">
+
+            <div class="field">
+                <div class="ui checkbox">
+                <input type="checkbox" id="access-request-checkbox">
+                <label>I agree to that my full name and email address is shared with the owner of the record.</label>
+                </div>
+            </div>
+        </div>
+        <div class="field text-align-center">
+            <button class="ui primary button" type="submit" disabled>
+                <i class="edit outline icon"></i>
+                Request access
+            </button>
+        </div>
+        <div class="ui error message"></div>
+    </form>
+    <div class="ui modal">
+        <i class="close icon"></i>
+        <div class="header">
+          Email confirmation needed
+        </div>
+        <div class="image content">
+          <div class="description">
+            <p>We have sent you an email to verify your address. Please check the email and follow the instructions to complete the access request.</p>
+          </div>
+        </div>
+        <div class="actions">
+          <div class="ui primary deny button">
+            <i class="x icon"></i>
+            Dismiss
+          </div>
+        </div>
+      </div>
+</div>
+
+
+{%- block javascript %}
+    {{ webpack['invenio-app-rdm-landing-page-access-form.js']}}
+{%- endblock %}

--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/guest-access-request/index.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/guest-access-request/index.html
@@ -1,0 +1,60 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2023 TU Wien.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+{% set title = invenio_request.title %}
+{% extends "invenio_requests/details/index.html" %}
+{% from "invenio_requests/macros/request_header.html" import inclusion_request_header %}
+
+{% block request_header %}
+  {%- if current_user and current_user.is_authenticated %}
+    {# only display the header for the receiver #}
+    {%- set back_button_url = url_for("invenio_app_rdm_users.requests") %}
+    {{
+      inclusion_request_header(
+        back_button_url=back_button_url,
+        back_button_text=_("Back to requests"),
+        request=invenio_request,
+        accepted=request_is_accepted
+      )
+    }}
+  {%- else %}
+    <div class="computer-flex-header rel-mt-2">
+      <div id="request-actions" class="flex align-items-start ml-auto mb-10">
+        {% if request_is_accepted %}
+          <div class="ui success message">
+            <p>{{ _("Check your email on how to access the record") }}</p>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  {%- endif %}
+
+  <div>
+    <p>
+      <strong>Requester:</strong>
+      {{ invenio_request.payload.full_name }} ({{ invenio_request.payload.email }})
+    </p>
+    <p>
+      <strong>Access level:</strong>
+      {{ invenio_request.payload.permission }}
+    </p>
+    <p>
+      <strong>Record:</strong>
+      <a href="{{ url_for('invenio_app_rdm_records.record_detail', pid_value=invenio_request.topic.record) }}"
+          rel="noopener noreferrer" target="_blank"
+          title="{{ _('Opens in new tab') }}"
+      >
+        {{ invenio_request.topic.record }}
+      </a>
+    </p>
+  <div class="ui container rel-mt-2">
+    {%- block user_dashboard_body %}
+    {%- endblock user_dashboard_body %}
+  </div>
+  </div>
+{% endblock %}

--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/user-access-request/index.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/user-access-request/index.html
@@ -1,0 +1,42 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2023 TU Wien.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+{% set title = invenio_request.title %}
+{% extends "invenio_requests/details/index.html" %}
+{% from "invenio_requests/macros/request_header.html" import inclusion_request_header %}
+
+
+{% block request_header %}
+  {% set back_button_url = url_for("invenio_app_rdm_users.requests") %}
+  {{
+    inclusion_request_header(
+      back_button_url=back_button_url,
+      back_button_text=_("Back to requests"),
+      request=invenio_request,
+      accepted=request_is_accepted
+    )
+  }}
+
+  <div>
+    <p>
+      <strong>Access level:</strong>
+      {{ invenio_request.payload.permission }}
+    </p>
+    <p>
+      <strong>Record:</strong>
+      <a href="{{ url_for('invenio_app_rdm_records.record_detail', pid_value=invenio_request.topic.record) }}"
+          rel="noopener noreferrer" target="_blank"
+          title="{{ _('Opens in new tab') }}"
+      >
+        {{ invenio_request.topic.record }}
+      </a>
+    </p>
+  </div>
+{% endblock %}
+
+{% set active_dashboard_menu_item = 'requests' %}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/accessForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/accessForm.js
@@ -1,0 +1,66 @@
+import { http } from "react-invenio-forms";
+import $ from "jquery";
+
+$(function () {
+  var form = $("#access-request-form");
+  var submitButton = $('button[type="submit"]');
+  var emailInput = $("#access-request-email-address");
+  var fullNameInput = $("#access-request-full-name");
+  var messageInput = $("#access-request-message");
+  var checkbox = $("#access-request-checkbox");
+  var isGuest = $("#is-guest").val().toLowerCase() === "true";
+  // Function to check if all fields are filled
+  function checkFormValidity() {
+    const guestValidation =
+      isGuest && emailInput.val() !== "" && fullNameInput.val() !== "";
+
+    if (
+      (guestValidation || !isGuest) &&
+      messageInput.val() !== "" &&
+      checkbox.prop("checked")
+    ) {
+      submitButton.prop("disabled", false);
+    } else {
+      submitButton.prop("disabled", true);
+    }
+  }
+
+  // Add event listeners to each input field and checkbox
+  emailInput.on("input", checkFormValidity);
+  fullNameInput.on("input", checkFormValidity);
+  messageInput.on("input", checkFormValidity);
+  checkbox.on("change", checkFormValidity);
+
+  // Override form submission behavior
+  form.on("submit", async function (event) {
+    event.preventDefault(); // Prevent default form submission
+
+    const payload = {
+      email: emailInput.val(),
+      full_name: fullNameInput.val(),
+      message: messageInput.val(),
+    };
+    var url = form.attr("action");
+    try {
+      let res = await http.post(url, payload);
+      if (!isGuest) {
+        const redirectUrl = res.data.links.self_html;
+        window.location.href = redirectUrl;
+      } else {
+        $(".ui.modal").modal("show");
+      }
+      // Reset form
+      emailInput.val("");
+      fullNameInput.val("");
+      messageInput.val("");
+      checkbox.prop("checked", false);
+      submitButton.prop("disabled", true);
+    } catch (error) {
+      if (error.response.data.status === 409 && error.response.data.duplicates) {
+        // If request already created redirect to details page
+        window.location.href = `/me/requests/${error.response.data.duplicates[0]}`;
+      }
+      console.error(error);
+    }
+  });
+});

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
@@ -2,6 +2,7 @@
 // Copyright (C) 2020-2021 CERN.
 // Copyright (C) 2020-2021 Northwestern University.
 // Copyright (C) 2021 Graz University of Technology.
+// Copyright (C) 2023 TU Wien.
 //
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_app_rdm/theme/webpack.py
+++ b/invenio_app_rdm/theme/webpack.py
@@ -20,6 +20,7 @@ theme = WebpackThemeBundle(
         "semantic-ui": dict(
             entry={
                 "invenio-app-rdm-landing-page": "./js/invenio_app_rdm/landing_page/index.js",
+                "invenio-app-rdm-landing-page-access-form": "./js/invenio_app_rdm/landing_page/accessForm.js",
                 "invenio-app-rdm-landing-page-theme": "./js/invenio_app_rdm/landing_page/theme.js",
                 "invenio-app-rdm-deposit": "./js/invenio_app_rdm/deposit/index.js",
                 "invenio-app-rdm-search": "./js/invenio_app_rdm/search/index.js",


### PR DESCRIPTION
This PR provides the front-end part for the [access requests](https://github.com/inveniosoftware/invenio-rdm-records/pull/1306).

It introduces a form on the landing pages of records with restricted files that can be used by users or guests to request access.

# Screenshots
## User access request form
https://github.com/inveniosoftware/invenio-app-rdm/assets/15194802/47bd8d90-8baa-4b0a-b1d5-e80ff4830fe6

## User access request details
![image](https://github.com/inveniosoftware/invenio-app-rdm/assets/6437519/7e59e4dd-6dc0-4ab5-8383-d1acbb8d4b74)

## Guest access request form
https://github.com/inveniosoftware/invenio-app-rdm/assets/15194802/9e9bf71d-bd52-4f6a-9134-0ccadf09622e


## Guest access request details
Note that the guest is, per definition, not logged in.
As such, there _is no_ dashboard for the guest, and the usual tabbed header of the request detail page is missing.
![image](https://github.com/inveniosoftware/invenio-app-rdm/assets/6437519/84bc35bc-5e54-48ae-affa-bf52ccd5520e)