### PR TITLE
views: fix redirect codes to 302

### DIFF
--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -242,13 +242,13 @@ def record_file_download(pid_value, file_item=None, is_preview=False, **kwargs):
 @pass_record_latest
 def record_latest(record=None, **kwargs):
     """Redirect to record'd latest version page."""
-    return redirect(record["links"]["self_html"], code=301)
+    return redirect(record["links"]["self_html"], code=302)
 
 
 @pass_record_from_pid
 def record_from_pid(record=None, **kwargs):
     """Redirect to record'd latest version page."""
-    return redirect(record["links"]["self_html"], code=301)
+    return redirect(record["links"]["self_html"], code=302)
 
 
 #


### PR DESCRIPTION
* Depends on https://github.com/inveniosoftware/invenio-rdm-records/pull/1370.
* Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/1282.
* Redirects for fetching latest versions or resolving DOIs should be
  using the "302 "Temporary Redirect" status, since the redirecting URL
  might change in the future.
