### PR TITLE
ui: render access request form based on settings

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -24,9 +24,10 @@
 {%- set is_preview_submission_request = preview_submission_request or false %}
 {%- set show_record_management_menu = can_manage_record and (not is_preview or is_preview_submission_request) %}
 
-{#- TODO check if the record allows requests for users/guests #}
-{%- set user_request_enabled = not current_user.is_anonymous %}
-{%- set guest_request_enabled = current_user.is_anonymous %}
+{%- if record.parent.access.settings %}
+  {%- set allow_user_requests = not current_user.is_anonymous and record.parent.access.settings.allow_user_requests %}
+  {%- set allow_guest_requests = current_user.is_anonymous and record.parent.access.settings.allow_guest_requests %}
+{%- endif %}
 
 {%- block page_body %}
   <section id="banners" class="banners" aria-label="{{ _('Information banner') }}">
@@ -256,16 +257,24 @@
                               <p>{{ _("Reason") }}: {{ record.access.embargo.reason }}</p>
                             {% endif %}
 
-                            {%- if user_request_enabled or guest_request_enabled  %}
+                            {%- if allow_user_requests or allow_guest_requests %}
                               <hr style="border-color: darkred;">
                               <p>
                                 <p>
-                                  <strong>Request access</strong>
+                                  <strong>{{ _("Request access") }}</strong>
                                 </p>
                                 <p>
-                                  <!-- TODO: Once implemented in the backend display the access description provided nad use this as fallback -->
-                                  If you would like to request access to these files, please fill out the form below.
+                                  {{ _("If you would like to request access to these files, please fill out the form below.") }}
                                 </p>
+                                <div>
+                                  {%- if record.parent.access.settings %}{%- set accept_conditions_text = record.parent.access.settings.accept_conditions_text %}{%- endif %}
+                                  {%- if accept_conditions_text %}
+                                    <p>
+                                      <h5>{{ _("You need to satisfy these conditions in order for this request to be accepted:") }}</h5>
+                                      {{ accept_conditions_text | safe }}
+                                    </p>
+                                  {%- endif %}
+                                </div>
                                 {%- include "invenio_app_rdm/records/details/access-form.html" %}
                               </p>
                             {%- endif %}


### PR DESCRIPTION
* closes https://github.com/inveniosoftware/invenio-rdm-records/issues/1374


Case 1: `accept_conditions_text = null` or absent
<img width="1134" alt="Screenshot 2023-07-24 at 10 42 32" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/4595a78e-b45e-4485-b39f-c04699f89ee7">

Case 2: `accept_conditions_text = "Buy me a unicorn"`
<img width="1115" alt="Screenshot 2023-07-24 at 10 42 54" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/d67ab9c3-589d-4a5c-bd2f-cb1bb4a54a7f">

Case 3: `accept_conditions_text = "<h1>Buy me a unicorn</h1>"`
<img width="1126" alt="Screenshot 2023-07-24 at 10 43 20" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/c3e5dbaf-f2fe-4b3c-ab88-831dd1504d34">

Case 4: `allow_user_requests` or `allow_guest_requests` is set to false:
<img width="1109" alt="Screenshot 2023-07-24 at 10 45 00" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/9373b493-4018-4033-ae61-71617801d916">
