### PR TITLE
community modals: align modal layouts

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/PendingCommunitiesModal/PendingCommunitiesModal.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/PendingCommunitiesModal/PendingCommunitiesModal.js
@@ -32,7 +32,7 @@ export class PendingCommunitiesModal extends Component {
         onOpen={handleOnOpen}
       >
         <Modal.Header>
-          <Header as="h2" id="record-communities-header">
+          <Header as="h2" size="small" id="record-communities-header" className="mt-5">
             {i18next.t("Pending communities")}
           </Header>
         </Modal.Header>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/PendingCommunitiesModal/PendingCommunitiesSearch.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/PendingCommunitiesModal/PendingCommunitiesSearch.js
@@ -65,7 +65,7 @@ export class PendingCommunitiesSearch extends Component {
               />
             </Modal.Content>
 
-            <Modal.Content scrolling>
+            <Modal.Content scrolling className="community-list-results">
               <ResultsLoader>
                 <EmptyResults />
                 <Error />

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesList.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesList.js
@@ -48,7 +48,7 @@ export class RecordCommunitiesList extends Component {
         ?.slice(0, maxDisplayedCommunities)
         .map((community) => (
           <Item key={community.id}>
-            <Image size="mini" src={community.links.logo} alt="" />
+            <Image wrapped size="mini" src={community.links.logo} alt="" />
             <Item.Content verticalAlign="middle">
               <Item.Header as={Header}>
                 <Header as="a" href={community.links.self_html} size="small">
@@ -61,7 +61,7 @@ export class RecordCommunitiesList extends Component {
 
       Element = (
         <>
-          <Item.Group>{communityItems}</Item.Group>
+          <Item.Group unstackable>{communityItems}</Item.Group>
           {error && <Message error>{error}</Message>}
         </>
       );

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesListModal/RecordCommunitiesListModal.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesListModal/RecordCommunitiesListModal.js
@@ -35,7 +35,7 @@ export class RecordCommunitiesListModal extends Component {
         trigger={trigger}
       >
         <Modal.Header>
-          <Header as="h2" id="record-communities-header">
+          <Header as="h2" size="small" id="record-communities-header" className="mt-5">
             {i18next.t("Communities")}
           </Header>
         </Modal.Header>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesListModal/RecordCommunitiesSearch.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesListModal/RecordCommunitiesSearch.js
@@ -68,7 +68,7 @@ export class RecordCommunitiesSearch extends Component {
               />
             </Modal.Content>
 
-            <Modal.Content scrolling>
+            <Modal.Content scrolling className="community-list-results">
               <ResultsLoader>
                 <EmptyResults />
                 <Error />

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/image.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/image.overrides
@@ -79,7 +79,21 @@
 
 }
 
-.ui.items{
+.ui.items {
+
+  &.unstackable > .item > .image {
+    &.mini {
+      width: @miniWidth !important;
+      min-width: @miniWidth !important;
+
+      img {
+        max-height: @miniWidth;
+        min-width: @miniWidth;
+        object-fit: contain;
+      }
+    }
+  }
+
   .ui.image.community-logo {
     img {
       height: @communityItemLogoWidth !important; // needs to override height set for images in items by SUI

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/modal.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/modal.overrides
@@ -21,11 +21,22 @@
   .community-list-results.content {
     height: calc(55vh - 10em);
 
-    .item {
-      padding: @defaultPadding;
+    .community-item {
+      padding: @defaultPadding calc(@defaultPadding/2);
+      border-bottom: 1px solid @borderColor;
 
-      &:first-child {
+      &:first-child,
+      &:first-child + .mobile {
         padding-top: @defaultPadding !important; //overriding semantic ui's !important
+        border-top: 1px solid @borderColor;
+      }
+
+      &:last-child {
+        padding-bottom: @defaultPadding !important; //overriding semantic ui's !important
+      }
+
+      @media all and (max-width: @largestMobileScreen) {
+        padding: @defaultPadding calc(@defaultPadding/4);
       }
 
       &.selected {

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
@@ -100,32 +100,6 @@
   }
 
   .item {
-    &.community-item {
-      .ui.grid {
-        margin-left: 0.5em !important;
-        width: 100% !important;
-      }
-
-      .content {
-        width: 100% !important;
-
-        &.flex.right-column{
-          flex-direction: column;
-          align-items: end;
-        };
-      }
-
-      .header {
-        word-break: break-word;
-        margin-bottom: 0;
-
-        .header-link {
-          @media all and (max-width: @largestMobileScreen) {
-            margin-top: 1rem;
-          }
-        }
-      }
-    }
 
     &.flex {
       display: flex !important;


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/171

Aligns the layout of all community modals, and fixes the community list view in the sidebar for mobile.

![Screenshot 2023-08-08 at 15 32 26](https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/65a3f500-c7cb-429b-9bfb-ef842eb44485)
![Screenshot 2023-08-08 at 14 44 59](https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/90ddf951-b168-4583-889b-daaefb776e92)
![Screenshot 2023-08-08 at 14 43 53](https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/f6ffb186-e1dc-420d-aaf6-01ec5ccc9146)

Mobile:
![Screenshot 2023-08-08 at 17 08 25](https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/67c9d1ac-7cd2-4931-a73c-df2f9b57e800)

