### PR TITLE
menu: increase z of menu, prevent flash message overlap

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/menu.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/menu.overrides
@@ -219,7 +219,7 @@
       box-shadow: 0px 0px 7px rgba(0,0,0,0.2);
       background-color: rgb(255,255,255);
       height: 100vh;
-      z-index: 3;
+      z-index: 100;
       padding: 2rem 1.5rem 1.5rem 1.5rem;
       overflow-y: scroll;
 


### PR DESCRIPTION
Increase z-index of burger-menu to prevent flash messages from overlapping the menu.