### PR TITLE
jump to top button: move event to button only

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -366,13 +366,11 @@
             {# Jump up button #}
             {%- block jump -%}
               <div class="ui grid">
-                <div class="jump-to-top centered row rel-mt-1" id="jump-btn">
-                  <a style="cursor: pointer;">
-                    <button class="ui button labeled icon" aria-label="{{ _('Jump to top of page') }}">
-                      <i class="arrow alternate circle up outline icon"></i>
-                      {{ _("Jump up") }}
-                    </button>
-                  </a>
+                <div class="centered row rel-mt-1">
+                  <button id="jump-btn" class="jump-to-top ui button labeled icon" aria-label="{{ _('Jump to top of page') }}">
+                    <i class="arrow alternate circle up outline icon"></i>
+                    {{ _("Jump up") }}
+                  </button>
                 </div>
               </div>
             {%- endblock jump -%}


### PR DESCRIPTION
Landing page jump to top button: 
- Fixes a small but annoying bug where clicking the entire button container (full width) triggers the jump-to-top event. Moves the trigger class to the actual button.