### PR TITLE
Remove whitespaces as default text

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -230,7 +230,7 @@
 
             {# Files #}
             {%- block record_files -%}
-              {# record has files BUT passed files are empty. This happens when we display are request. #}
+              {# record has files BUT passed files are empty. This happens when we display a request. #}
               {%- if record.files.enabled -%}
                 <section id="record-files" class="rel-mt-2" aria-label="{{ _('Files') }}">
                   <h2 id="files-heading">{{ _('Files') }}</h2>
@@ -296,7 +296,7 @@
 
             {# Files #}
             {%- block record_media_files -%}
-              {# record has files BUT passed files are empty. This happens when we display are request. #}
+              {# record has files BUT passed files are empty. This happens when we display a request. #}
               {%- if record.media_files.enabled -%}
                 <section id="record-media-files" class="rel-mt-2" aria-label="{{ _('Media files') }}">
                   <h2 id="files-heading">{{ _('Media files') }}</h2>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/access-form.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/access-form.html
@@ -71,8 +71,7 @@ current_user.is_anonymous else user_access_request_url %}
           required=""
           id="access-request-message"
           rows="3"
-        >
-        </textarea>
+        ></textarea>
       </div>
     </div>
     <div class="field">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,7 +295,7 @@ def invalid_file_instance(db, dummy_location):
     file_id = obj.file_id
 
     # Get FileInstance from file ID
-    f = FileInstance.query.get(file_id)
+    f = db.session.get(FileInstance, file_id)
 
     # Force an invalid checksum
     f.checksum = "invalid"
@@ -303,6 +303,6 @@ def invalid_file_instance(db, dummy_location):
     db.session.commit()
 
     # Retrieve the file instance (with updated last_check)
-    f = FileInstance.query.get(file_id)
+    f = db.session.get(FileInstance, file_id)
 
     return f


### PR DESCRIPTION
The line break after the `<textarea>` opening tag in the HTML seems to introduce the indent before the closing tag as default text for the request message.

Before:

![image](https://github.com/inveniosoftware/invenio-app-rdm/assets/6437519/8cb9daa9-3fc6-4fa9-99d4-a0e2376d7fac)


After:

![image](https://github.com/inveniosoftware/invenio-app-rdm/assets/6437519/e1a15393-a4bd-4b37-9937-6ce5a720959b)
