### PR TITLE
landing page: improve a11y for accordions, change add details view

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -232,7 +232,7 @@
             {%- block record_files -%}
               {# record has files BUT passed files are empty. This happens when we display are request. #}
               {%- if record.files.enabled -%}
-                <section id="record-files" class="rel-mt-2" aria-label="{{ _('Files') }}">
+                <section id="record-files" class="rel-mt-2 rel-mb-3" aria-label="{{ _('Files') }}">
                   <h2 id="files-heading">{{ _('Files') }}</h2>
                   {%- if permissions.can_read_files -%}
                     {# record has files AND user can see files #}
@@ -244,48 +244,47 @@
                     {%- endif -%}
                     {{ file_list_box(files, record.id, is_preview, record) }}
                   {% else %}
-                    {# record has files BUT user cannot see files #}
-                    <div class="pt-0 pb-20">
-                      <div class="ui accordion panel mb-10 {{ record.ui.access_status.id }}"
-                           href="#collapsablePreview">
-                        <div class="active title trigger panel-heading {{ record.ui.access_status.id }}">
+                    {# record has files BUT user does not have permission to see files #}
+                    <div class="ui accordion panel mb-10 {{ record.ui.access_status.id }}"
+                          href="#files-preview-accordion-panel">
+                      <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
+                        <div role="button" id="files-preview-accordion-trigger" tabindex="0" class="trigger" aria-controls="files-preview-accordion-panel">
                           {{ _("Files") }}
-                          <i class="angle right icon"></i>
+                          <i class="angle right icon" aria-hidden="true"></i>
                         </div>
-                        <div id="collapsablePreview" class="active content pt-0">
-                          <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
-                            <i
-                              class="ui {{ record.ui.access_status.icon }} icon"></i><b>{{ record.ui.access_status.title_l10n }}</b>
-                            <p>{{ record.ui.access_status.description_l10n }}</p>
+                      </h3>
+                      <div role="region" id="files-preview-accordion-panel" aria-labelledby="files-preview-accordion-trigger" class="active content preview-container pt-0">
+                        <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
+                          <i class="ui {{ record.ui.access_status.icon }} icon"></i><b>{{ record.ui.access_status.title_l10n }}</b>
+                          <p>{{ record.ui.access_status.description_l10n }}</p>
 
-                            {% if record.access.embargo.reason %}
-                              <p>{{ _("Reason") }}: {{ record.access.embargo.reason }}</p>
-                            {% endif %}
+                          {% if record.access.embargo.reason %}
+                            <p>{{ _("Reason") }}: {{ record.access.embargo.reason }}</p>
+                          {% endif %}
 
-                            {% block record_files_access_request %}
-                              {%- if allow_user_requests or allow_guest_requests %}
-                                <div class="ui divider"></div>
+                          {% block record_files_access_request %}
+                            {%- if allow_user_requests or allow_guest_requests %}
+                              <div class="ui divider"></div>
+                              <p>
                                 <p>
-                                  <p>
-                                    <strong>{{ _("Request access") }}</strong>
-                                  </p>
-                                  <p>
-                                    {{ _("If you would like to request access to these files, please fill out the form below.") }}
-                                  </p>
-                                  <div>
-                                    {%- if record.parent.access.settings %}{%- set accept_conditions_text = record.parent.access.settings.accept_conditions_text %}{%- endif %}
-                                    {%- if accept_conditions_text %}
-                                      <p>
-                                        <h5>{{ _("You need to satisfy these conditions in order for this request to be accepted:") }}</h5>
-                                        {{ accept_conditions_text | safe }}
-                                      </p>
-                                    {%- endif %}
-                                  </div>
-                                  {%- include "invenio_app_rdm/records/details/access-form.html" %}
+                                  <strong>{{ _("Request access") }}</strong>
                                 </p>
-                              {%- endif %}
-                            {% endblock record_files_access_request %}
-                          </div>
+                                <p>
+                                  {{ _("If you would like to request access to these files, please fill out the form below.") }}
+                                </p>
+                                <div>
+                                  {%- if record.parent.access.settings %}{%- set accept_conditions_text = record.parent.access.settings.accept_conditions_text %}{%- endif %}
+                                  {%- if accept_conditions_text %}
+                                  <p class="ui small header">{{ _("You need to satisfy these conditions in order for this request to be accepted:") }}</p>
+                                  <p>
+                                      {{ accept_conditions_text | safe }}
+                                    </p>
+                                  {%- endif %}
+                                </div>
+                                {%- include "invenio_app_rdm/records/details/access-form.html" %}
+                              </p>
+                            {%- endif %}
+                          {% endblock record_files_access_request %}
                         </div>
                       </div>
                     </div>
@@ -294,7 +293,7 @@
               {%- endif %}
             {%- endblock record_files -%}
 
-            {# Files #}
+            {# Media files #}
             {%- block record_media_files -%}
               {# record has media files AND user can see files #}
               {# can_media_read_files is false when record is fully restricted and users can't see the landing page at all #}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
@@ -12,7 +12,7 @@
 <div class="ui grid">
   {% if record.ui.creators and record.ui.creators.creators %}
     <div class="row ui accordion affiliations">
-      <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column mb-10">
+      <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
           <dl class="creatibutors" aria-label="{{ _('Creators list') }}">
             <dt class="hidden">{{ _('Creators') }}</dt>
               {{ show_creatibutors(record.ui.creators.creators, show_affiliations=True) }}
@@ -30,7 +30,7 @@
 
   {% if record.ui.contributors and record.ui.contributors.contributors %}
     <div class="row ui accordion affiliations">
-      <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column mb-10">
+      <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
 
           {%- for group in record.ui.contributors.contributors|groupby('role.title')%}
           <dl class="creatibutors" aria-label="{{ _('Contributors list') }}">

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
@@ -12,7 +12,7 @@
 {% set description = metadata.get('description') %}
 {% if description %}
   <section id="description" class="rel-mt-2" aria-label="{{ _('Record description') }}">
-    <h2 id="description-heading">{{ _('Description') }}</h2>
+    <h2 id="description-heading" class="sr-only">{{ _('Description') }}</h2>
     {# description data is being sanitized by marshmallow in the backend #}
     <p>{{ description | safe }}</p>
   </section>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
@@ -33,256 +33,321 @@ show_alternate_identifiers, show_related_identifiers, show_funding, show_dates %
 
 {% set rights = record.ui.get('rights') %}
 {% set funding = record.ui.get('funding') %}
-{% set active = true %}
-{% set active_cf_sections = namespace(items=[]) %}
 
 {% if hasContent.value %}
   <h2 id="record-details-heading">{{ _('Additional details') }}</h2>
 
-  <div class="rdm-tab-container ml-0-mobile mr-0-mobile">
-    {# Tabs #}
-    <div role="tablist" class="ui top attached tabs menu rdm-tab-menu">
-      {% if record.ui.additional_titles %}
-        <a
-          role="tab"
-          aria-selected="{{ active }}"
-          aria-controls="additional-titles-tab-panel"
-          data-tab="additional-titles"
-          tabindex="0"
-          class="{{ 'active' if active }} item"
-          id="additional-titles-tab"
-        >
-          {{ _('Additional titles') }}
-        </a>
-        {% set active = false %}
-      {% endif %}
+  <div class="ui divider"></div>
 
-
-      {% if metadata.identifiers %}
-        <a
-          role="tab"
-          aria-selected="{{ active }}"
-          aria-controls="identifiers-tab-panel"
-          data-tab="identifiers"
-          tabindex="0"
-          class="{{ 'active' if active }} item"
-          id="identifiers-tab"
-        >
-          {{ _('Identifiers') }}
-        </a>
-        {% set active = false %}
-      {% endif %}
-
-      {% if record.ui.related_identifiers %}
-        <a
-          role="tab"
-          aria-selected="{{ active }}"
-          aria-controls="related-works-tab-panel"
-          data-tab="related-works"
-          tabindex="0"
-          class="{{ 'active' if active }} item"
-          id="related-works-tab"
-        >
-          {{ _('Related works') }}
-        </a>
-        {% set active = false %}
-      {% endif %}
-
-      {% if metadata.funding %}
-        <a
-          role="tab"
-          aria-selected="{{ active }}"
-          aria-controls="funding-tab-panel"
-          data-tab="funding"
-          tabindex="0"
-          class="{{ 'active' if active }} item"
-          id="funding-tab"
-        >
-          {{ _('Funding') }}
-        </a>
-        {% set active = false %}
-      {% endif %}
-
-      {% if record.ui.dates %}
-        <a
-          role="tab"
-          aria-selected="{{ active }}"
-          aria-controls="dates-tab-panel"
-          data-tab="dates"
-          tabindex="0"
-          class="{{ 'active' if active }} item"
-          id="dates-tab"
-        >
-          {{ _('Dates') }}
-        </a>
-        {% set active = false %}
-      {% endif %}
-
-      {% if metadata.references %}
-        <a
-          role="tab"
-          aria-selected="{{ active }}"
-          aria-controls="references-tab-panel"
-          data-tab="references"
-          tabindex="0"
-          class="{{ 'active' if active }} item"
-          id="references-tab"
-        >
-          {{ _('References') }}
-        </a>
-        {% set active = false %}
-      {% endif %}
-      {% if record.custom_fields %}
-        {# Needed to use namespace as variable assignments are cleared in the end of
-           for loops i.e cannot set active = false #}
-        {% set active_cf = namespace(value=active) %}
-        {%- for section_cfg in custom_fields_ui %}
-          {% set section_has_fields = namespace(value=false) %}
-          {% set section_format = section_cfg.section | replace(" ", "-") %}
-          {# Show the section if at least one of its fields is in record #}
-          {% for field_cfg in section_cfg.fields %}
-            {% if record.custom_fields.get(field_cfg.field) %}
-              {% set section_has_fields.value = true %}
-            {% endif %}
-          {% endfor %}
-          {% if section_has_fields.value %}
-            {% set active_cf_sections.items = active_cf_sections.items + [section_cfg.section] %}
-            <a
-            role="tab"
-            aria-selected="{{ active_cf.value }}"
-            aria-controls="{{section_format}}-tab-panel"
-            data-tab="{{section_format}}"
-            tabindex="0"
-            class="{{ 'active' if active_cf.value }} item"
-            id="{{section_format}}-tab"
+  {% if record.ui.additional_titles %}
+    {% if record.ui.additional_titles|length > 5 %}
+      <div class="ui fluid accordion padded grid rel-mb-1">
+        <div class="active title sixteen wide mobile four wide tablet three wide computer column">
+          <h3 class="ui header">
+            <div
+              id="additional-titles-accordion-trigger"
+              role="button"
+              tabindex="0"
+              aria-expanded="true"
+              aria-controls="additional-titles-panel"
+              class="trigger"
             >
-            {{ section_cfg.section }}
-            </a>
-            {% set active_cf.value = false %}
-          {% endif %}
-        {%- endfor %}
-      {% endif %}
-    </div>
-
-    {# Content #}
-    {% set active = true %}
-
-    {% if record.ui.additional_titles %}
-      <div
-          role="tabpanel"
-          class="ui bottom attached {{ 'active' if active }} tab segment"
-          data-tab="additional-titles"
-          aria-labelledby="additional-titles-tab"
-          id="additional-titles-tab-panel"
-          hidden="{{ not active }}"
-
-      >
-        <dl class="details-list">
-          {{ show_add_titles(record.ui.additional_titles) }}
-        </dl>
+              <i class="caret right icon" aria-hidden="true"></i>{{ _('Additional titles') }}
+            </div>
+          </h3>
+        </div>
+        <div
+          id="additional-titles-panel"
+          role="region"
+          aria-labelledby="additional-titles-accordion-trigger"
+          class="active content sixteen wide mobile twelve wide tablet thirteen wide computer column"
+        >
+          <dl class="details-list">
+            {{ show_add_titles(record.ui.additional_titles) }}
+          </dl>
+        </div>
       </div>
-      {% set active = false %}
-    {% endif %}
-
-    {% if metadata.identifiers %}
-      <div
-          role="tabpanel"
-          class="ui bottom attached {{ 'active' if active }} tab segment"
-          data-tab="identifiers"
-          aria-labelledby="identifiers-tab"
-          id="identifiers-tab-panel"
-          hidden="{{ not active }}"
-      >
-        <dl class="details-list">
-          {{ show_alternate_identifiers(metadata.identifiers) }}
-        </dl>
+    {% else %}
+      <div class="ui grid">
+        <div class="sixteen wide mobile four wide tablet three wide computer column">
+          <h3 class="ui header">{{ _('Additional titles') }}</h3>
+        </div>
+        <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
+          <dl class="details-list">
+            {{ show_add_titles(record.ui.additional_titles) }}
+          </dl>
+        </div>
       </div>
-      {% set active = false %}
     {% endif %}
+    <div class="ui divider"></div>
+  {% endif %}
 
-    {% if record.ui.related_identifiers %}
-      <div
-          role="tabpanel"
-          class="ui bottom attached {{ 'active' if active }} tab segment"
-          data-tab="related-works"
-          aria-labelledby="related-works-tab"
-          id="related-works-tab-panel"
-          hidden="{{ not active }}"
-      >
-        <dl class="details-list">
+  {% if metadata.identifiers %}
+    {% if metadata.identifiers|length > 5 %}
+      <div class="ui fluid accordion padded grid rel-mb-1">
+        <div class="active title sixteen wide mobile four wide tablet three wide computer column">
+          <h3 class="ui header">
+            <div
+              id="identifiers-accordion-trigger"
+              role="button"
+              tabindex="0"
+              aria-expanded="true"
+              aria-controls="identifiers-panel"
+              class="trigger"
+            >
+              <i class="caret right icon" aria-hidden="true"></i>{{ _('Identifiers') }}
+            </div>
+          </h3>
+        </div>
+        <div
+          id="identifiers-panel"
+          role="region"
+          aria-labelledby="identifiers-accordion-trigger"
+          class="active content sixteen wide mobile twelve wide tablet thirteen wide computer column"
+        >
+          <dl class="details-list">
+            {{ show_alternate_identifiers(metadata.identifiers) }}
+          </dl>
+        </div>
+      </div>
+    {% else %}
+      <div class="ui grid">
+        <div class="sixteen wide mobile four wide tablet three wide computer column">
+          <h3 class="ui header">{{ _('Identifiers') }}</h3>
+        </div>
+        <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
+          <dl class="details-list">
+            {{ show_alternate_identifiers(metadata.identifiers) }}
+          </dl>
+        </div>
+      </div>
+    {% endif %}
+    <div class="ui divider"></div>
+  {% endif %}
+
+  {% if record.ui.related_identifiers %}
+    {% if record.ui.related_identifiers|length > 5 %}
+      <div class="ui fluid accordion padded grid rel-mb-1">
+        <div class="active title sixteen wide mobile four wide tablet three wide computer column">
+          <h3 class="ui header">
+            <div
+              id="related-works-accordion-trigger"
+              role="button"
+              tabindex="0"
+              aria-expanded="true"
+              aria-controls="related-works-panel"
+              class="trigger"
+            >
+              <i class="caret right icon" aria-hidden="true"></i>{{ _('Related works') }}
+            </div>
+          </h3>
+        </div>
+        <div
+          id="related-works-panel"
+          role="region"
+          aria-labelledby="related-works-accordion-trigger"
+          class="active content sixteen wide mobile twelve wide tablet thirteen wide computer column"
+        >
           {{ show_related_identifiers(record.ui.related_identifiers) }}
-        </dl>
+        </div>
       </div>
-      {% set active = false %}
+    {% else %}
+      <div class="ui grid">
+        <div class="sixteen wide mobile four wide tablet three wide computer column">
+          <h3 class="ui header">{{ _('Related works') }}</h3>
+        </div>
+        <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
+          {{ show_related_identifiers(record.ui.related_identifiers) }}
+        </div>
+      </div>
     {% endif %}
+    <div class="ui divider"></div>
+  {% endif %}
 
-    {% if funding %}
+  {% if funding %}
+   {% if funding|length > 5 %}
+    <div class="ui fluid accordion padded grid rel-mb-1">
+      <div class="active title sixteen wide mobile four wide tablet three wide computer column">
+        <h3 class="ui header">
+          <div
+            id="funding-accordion-trigger"
+            role="button"
+            tabindex="0"
+            aria-expanded="true"
+            aria-controls="funding-panel"
+            class="trigger"
+          >
+            <i class="caret right icon" aria-hidden="true"></i>{{ _('Funding') }}
+          </div>
+        </h3>
+      </div>
       <div
-          role="tabpanel"
-          class="ui bottom attached {{ 'active' if active }} tab segment"
-          data-tab="funding"
-          aria-labelledby="funding-tab"
-          id="funding-tab-panel"
-          hidden="{{ not active }}"
+        id="funding-panel"
+        role="region"
+        aria-labelledby="funding-accordion-trigger"
+        class="active content sixteen wide mobile twelve wide tablet thirteen wide computer column"
       >
         <dl class="details-list">
           {{ show_funding(funding) }}
         </dl>
       </div>
-      {% set active = false %}
-    {% endif %}
-
-    {% if record.ui.dates %}
-      <div
-          role="tabpanel"
-          class="ui bottom attached {{ 'active' if active }} tab segment"
-          data-tab="dates"
-          aria-labelledby="dates-tab"
-          id="dates-tab-panel"
-          hidden="{{ not active }}"
-      >
-        <dl class="details-list">
-          {{ show_dates(record.ui.dates) }}
-        </dl>
-      </div>
-      {% set active = false %}
-    {% endif %}
-
-    {% if metadata.references %}
-      <div
-          role="tabpanel"
-          class="ui bottom attached {{ 'active' if active }} tab segment"
-          data-tab="references"
-          aria-labelledby="references-tab"
-          id="references-tab-panel"
-          hidden="{{ not active }}"
-      >
-        <dl class="details-list">
-          {{ show_references(metadata.references) }}
-        </dl>
-      </div>
-    {% endif %}
-
-    {% if record.custom_fields %}
-      {# Needed to use namespace as variable assignments are cleared in the end of for
-         loops i.e cannot set active = false #}
-      {% set active_cf = namespace(value=active) %}
-      {%- for section_cfg in custom_fields_ui if section_cfg.section in active_cf_sections.items %}
-        {% set section_format = section_cfg.section | replace(" ", "-") %}
-        <div
-          role="tabpanel"
-          class="ui bottom attached {{ 'active' if active_cf.value }} tab segment"
-          data-tab="{{section_format}}"
-          aria-labelledby="{{section_format}}-tab"
-          id="{{section_format}}-tab-panel"
-          hidden="{{ not active_cf.value }}"
-        >
+    </div>
+    {% else %}
+      <div class="ui grid">
+        <div class="sixteen wide mobile four wide tablet three wide computer column">
+          <h3 class="ui header">{{ _('Funding') }}</h3>
+        </div>
+        <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
           <dl class="details-list">
-            {{ show_section_custom_fields(record.ui.custom_fields, section_cfg.fields) }}
+            {{ show_funding(funding) }}
           </dl>
         </div>
-        {% set active_cf.value = false %}
-      {%- endfor %}
+      </div>
     {% endif %}
-  </div>
+    <div class="ui divider"></div>
+  {% endif %}
+
+  {% if record.ui.dates %}
+    {% if record.ui.dates|length > 5 %}
+      <div class="ui fluid accordion padded grid rel-mb-1">
+        <div class="active title sixteen wide mobile four wide tablet three wide computer column">
+          <h3 class="ui header">
+            <div
+              id="dates-accordion-trigger"
+              role="button"
+              tabindex="0"
+              aria-expanded="true"
+              aria-controls="dates-panel"
+              class="trigger"
+            >
+              <i class="caret right icon" aria-hidden="true"></i>{{ _('Dates') }}
+            </div>
+          </h3>
+        </div>
+        <div
+          id="dates-panel"
+          role="region"
+          aria-labelledby="dates-accordion-trigger"
+          class="active content sixteen wide mobile twelve wide tablet thirteen wide computer column"
+        >
+          <dl class="details-list">
+            {{ show_dates(record.ui.dates) }}
+          </dl>
+        </div>
+      </div>
+    {% else %}
+      <div class="ui grid">
+        <div class="sixteen wide mobile four wide tablet three wide computer column">
+          <h3 class="ui header">{{ _('Dates') }}</h3>
+        </div>
+        <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
+          <dl class="details-list">
+            {{ show_dates(record.ui.dates) }}
+          </dl>
+        </div>
+      </div>
+    {% endif %}
+    <div class="ui divider"></div>
+  {% endif %}
+
+  {% if record.custom_fields %}
+    {%- for section_cfg in custom_fields_ui %}
+      {% set section_has_fields = namespace(value=false) %}
+      {% set section_format = section_cfg.section | replace(" ", "-") %}
+      {# Show the section if at least one of its fields is in record #}
+      {% for field_cfg in section_cfg.fields %}
+        {% if record.custom_fields.get(field_cfg.field) %}
+          {% set section_has_fields.value = true %}
+        {% endif %}
+      {% endfor %}
+
+      {% if section_has_fields.value %}
+        {% if section_cfg.fields|length > 5 %}
+          <div class="ui fluid accordion padded grid rel-mb-1">
+            <div class="active title sixteen wide mobile four wide tablet three wide computer column">
+              <h3 class="ui header">
+                <div
+                  id="custom-fields-accordion-trigger"
+                  role="button"
+                  tabindex="0"
+                  aria-expanded="true"
+                  aria-controls="custom-fields-panel"
+                  class="trigger"
+                >
+                  <i class="caret right icon" aria-hidden="true"></i>{{ section_cfg.section }}
+                </div>
+              </h3>
+            </div>
+            <div
+              id="custom-fields-panel"
+              role="region"
+              aria-labelledby="custom-fields-accordion-trigger"
+              class="active content sixteen wide mobile twelve wide tablet thirteen wide computer column"
+            >
+              {%- for section_cfg in custom_fields_ui if section_cfg.section %}
+                {% set section_format = section_cfg.section | replace(" ", "-") %}
+                <dl class="details-list">
+                  {{ show_section_custom_fields(record.ui.custom_fields, section_cfg.fields) }}
+                </dl>
+              {%- endfor %}
+            </div>
+          </div>
+        {% else %}
+          <div class="ui grid">
+            <div class="sixteen wide mobile four wide tablet three wide computer column">
+              <h3 class="ui header">{{ section_cfg.section }}</h3>
+            </div>
+            <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
+              {%- for section_cfg in custom_fields_ui if section_cfg.section %}
+                {% set section_format = section_cfg.section | replace(" ", "-") %}
+                <dl class="details-list">
+                  {{ show_section_custom_fields(record.ui.custom_fields, section_cfg.fields) }}
+                </dl>
+              {%- endfor %}
+            </div>
+          </div>
+        {% endif %}
+        <div class="ui divider"></div>
+      {% endif %}
+    {%- endfor %}
+  {% endif %}
+
+  {% if metadata.references %}
+    {% if metadata.references|length > 5 %}
+      <div class="ui fluid accordion padded grid rel-mb-1">
+        <div class="active title sixteen wide mobile four wide tablet three wide computer column">
+          <h3 class="ui header">
+            <div
+              id="references-accordion-trigger"
+              role="button"
+              tabindex="0"
+              aria-expanded="true"
+              aria-controls="references-panel"
+              class="trigger"
+            >
+              <i class="caret right icon" aria-hidden="true"></i>{{ _('References') }}
+            </div>
+          </h3>
+        </div>
+        <div
+          id="references-panel"
+          role="region"
+          aria-labelledby="references-accordion-trigger"
+          class="active content sixteen wide mobile twelve wide tablet thirteen wide computer column"
+        >
+          {{ show_references(metadata.references) }}
+        </div>
+      </div>
+    {% else %}
+      <div class="ui grid">
+        <div class="sixteen wide mobile four wide tablet three wide computer column">
+          <h3 class="ui header">{{ _('References') }}</h3>
+        </div>
+        <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
+          {{ show_references(metadata.references) }}
+        </div>
+      </div>
+    {% endif %}
+  {% endif %}
+  <div class="ui divider"></div>
 {% endif %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/detail.html
@@ -31,9 +31,15 @@
 {%- endmacro %}
 
 
-{% macro list_string_values(values) %}
+{% macro list_string_values(field, values) %}
   {% for value in values %}
-    {{ value }}{{ ", " if not loop.last }}
+    {% set search_url = field | custom_fields_search(value) %}
+    {% if search_url %}
+      <a href="{{ search_url }}">{{ value }}</a> {{ ", " if not loop.last }}
+    {% else %}
+      {{ value }}{{ ", " if not loop.last }}
+    {% endif %}
+
   {% endfor %}
 {% endmacro %}
 
@@ -60,7 +66,14 @@
   {% for add_description in add_descriptions %}
   <section id="additional-description-{{loop.index}}" class="rel-mt-2" aria-label="{{ _( add_description.type.title_l10n ) }}">
     <h2>{{add_description.type.title_l10n }} <span class="text-muted language">{{ '(' + add_description.lang.title_l10n + ')' if add_description.lang }}</span></h2>
-    <p>{{ add_description.description | sanitize_html() | safe}}</p>
+
+    {% if add_description.type.id == "notes" %}
+      <div class="ui message warning">
+        {{ add_description.description | sanitize_html() | safe }}
+      </div>
+    {% else %}
+      {{ add_description.description | sanitize_html() | safe }}
+    {% endif %}
   </section>
   {% endfor %}
 {% endmacro %}
@@ -88,6 +101,10 @@
     {%- if item.award.title_l10n -%}
       <dt class="ui tiny header">
         <span class="mr-5">
+          {% if item.award.acronym %}
+            {{ item.award.acronym }} –
+          {% endif %}
+
           {{ item.award.title_l10n }}
         </span>
 
@@ -114,21 +131,22 @@
 
 
 {% macro show_references(references) %}
-    <dt class="hidden">{{ _('References') }}</dt>
-  {% for reference in references %}
-    {% set reference_string = reference.reference %}
-    {% if 'identifier' in reference %}
-      {% if 'scheme' in reference %}
-        {% set reference_scheme = reference.scheme | get_scheme_label %}
-        {% set reference_string = reference_string + ' ( ' + reference_scheme +
-        ' - ' + reference.identifier + ' )' %}
-      {% else %}
-        {% set reference_string = reference_string + ' ( ' + reference.identifier +
-         ' )' %}
+  <ul class="ui bulleted list details-list">
+    {% for reference in references %}
+      {% set reference_string = reference.reference %}
+      {% if 'identifier' in reference %}
+        {% if 'scheme' in reference %}
+          {% set reference_scheme = reference.scheme | get_scheme_label %}
+          {% set reference_string = reference_string + ' ( ' + reference_scheme +
+          ' - ' + reference.identifier + ' )' %}
+        {% else %}
+          {% set reference_string = reference_string + ' ( ' + reference.identifier +
+          ' )' %}
+        {% endif %}
       {% endif %}
-    {% endif %}
-    <dd>{{ reference_string }}</dd>
-  {% endfor %}
+      <li class="item">{{ reference_string }}</li>
+    {% endfor %}
+  </ul>
 {% endmacro %}
 
 
@@ -155,10 +173,12 @@
 
 
 {% macro show_related_identifiers(related_identifiers) %}
-  {%- for group in related_identifiers | groupby('relation_type.title_l10n')%}
-  <dt class="ui tiny header">{{ group.grouper }}</dt>
-  {{ _identifiers_for_group(group.list) }}
-  {%- endfor %}
+<dl class="details-list">
+    {%- for group in related_identifiers | groupby('relation_type.title_l10n')%}
+    <dt class="ui tiny header">{{ group.grouper }}</dt>
+    {{ _identifiers_for_group(group.list) }}
+    {%- endfor %}
+  </dl>
 {% endmacro %}
 
 
@@ -202,9 +222,24 @@
       {% if field_cfg.template %}
         {% include field_cfg.template %}
       {% else %}
-        <dt class="ui tiny header">{{ field_cfg.props.label }}</dt>
+        <dt class="ui tiny header">
+          {{ field_cfg.props.label }}
+          {% set namespace_url = field_cfg.field | namespace_url %}
+          {% if namespace_url %}
+          <a href="{{ namespace_url }}" aria-label="{{ namespace_url }}">
+            <i class="icon external" aria-hidden="true"></i>
+          </a>
+          {% endif %}
+        </dt>
         {% if field_value is string %}
-          <dd>{{ field_value | safe }}</dd>
+          <dd>
+            {% set search_url = field_cfg.field | custom_fields_search(field_value|safe) %}
+            {% if search_url %}
+              <a href="{{ search_url }}">{{ field_value | safe }}</a>
+            {% else %}
+              {{ field_value | safe }}
+            {% endif %}
+          </dd>
         {% elif field_value is boolean %}
           <dd>
             {% if field_value %}
@@ -216,7 +251,7 @@
         {% elif field_cfg.is_vocabulary %}
           <dd>{{ list_vocabulary_values(field_value) }}</dd>
         {% elif field_value is iterable and field_value|length > 0 and field_value[0] is string %}
-          <dd>{{ list_string_values(field_value) }}</dd>
+          <dd>{{ list_string_values(field_cfg.field, field_value) }}</dd>
         {% else %}
           <dd>{{ field_value }}</dd>
         {% endif %}
@@ -226,17 +261,17 @@
 {% endmacro %}
 
 {% macro show_detail_conference(conference) %}
-     <dd>
-       {%- if conference.url %}
-        <a href="{{conference.url}}"><i class="fa fa-external-link"></i> {{conference.title}}</a>
-       {%- else %}
-        {{conference.title}}
-       {%- endif%}
-       {%- if conference.place %}, {{conference.place}} {%- endif %}
-       {%- if conference.dates %}, {{conference.dates}} {%- endif %}
-       {% if conference.session %}(Session {{conference.session}}{% if conference.session_part %}, Part {{conference.session_part}}{%- endif %}){%- endif %}
-     </dd>
-     {%- if conference.url and not conference.title %}
-       <dd><a href="{{conference.url}}"><i class="fa fa-external-link"></i> {{_('Conference website')}}</a></dd>
-     {%- endif %}
+    <dd>
+      {%- if conference.url %}
+      <a href="{{conference.url}}"><i class="fa fa-external-link"></i> {{conference.title}}</a>
+      {%- else %}
+      {{conference.title}}
+      {%- endif%}
+      {%- if conference.place %}, {{conference.place}} {%- endif %}
+      {%- if conference.dates %}, {{conference.dates}} {%- endif %}
+      {% if conference.session %}(Session {{conference.session}}{% if conference.session_part %}, Part {{conference.session_part}}{%- endif %}){%- endif %}
+    </dd>
+    {%- if conference.url and not conference.title %}
+      <dd><a href="{{conference.url}}"><i class="fa fa-external-link"></i> {{_('Conference website')}}</a></dd>
+    {%- endif %}
 {% endmacro %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -29,19 +29,28 @@
 
 
 {% macro preview_file_box(file, pid, is_preview, record) %}
-<div class="">
-  <div class="ui accordion panel mb-10 {{record.ui.access_status.id}}" href="#collapsablePreview">
-    <div class="active title trigger panel-heading {{record.ui.access_status.id}} truncated" tabindex="0" aria-label="{{ _('File preview') }}">
-      <span id="preview-file-title">{{file.key}}</span>
-      <i class="ui angle right icon"></i>
-    </div>
-    <div id="collapsablePreview" class="active content pt-0">
+  <div class="ui accordion panel mb-10 {{record.ui.access_status.id}}" href="#files-preview-accordion-panel">
+    <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
+      <div
+        role="button"
+        id="files-preview-accordion-trigger"
+        aria-controls="files-preview-accordion-panel"
+        aria-expanded="true"
+        tabindex="0"
+        class="trigger"
+        aria-label="{{ _('File preview') }}"
+      >
+        <span id="preview-file-title">{{ file.key }}</span>
+        <i class="angle right icon" aria-hidden="true"></i>
+      </div>
+    </h3>
+
+    <div role="region" id="files-preview-accordion-panel" aria-labelledby="files-preview-accordion-trigger" class="active content preview-container pt-0">
       <div>
         {{ preview_file('invenio_app_rdm_records.record_file_preview', pid_value=pid, filename=file.key, is_preview=is_preview) }}
       </div>
     </div>
   </div>
-</div>
 {%- endmacro %}
 
 
@@ -60,10 +69,10 @@
         <th>{{_('Size')}}</th>
         <th class>
           {%- if config.RDM_ARCHIVE_DOWNLOAD_ENABLED %}
-          {% set archive_download_url = record.links.archive_media if is_media else record.links.archive %}
-          <a role="button" class="ui compact mini button right floated archive-link" href="{{ archive_download_url }}">
-            <i class="file archive icon button"></i> {{_("Download all")}}
-          </a>
+            {% set archive_download_url = record.links.archive_media if is_media else record.links.archive %}
+            <a role="button" class="ui compact mini button right floated archive-link" href="{{ archive_download_url }}">
+              <i class="file archive icon button" aria-hidden="true"></i> {{_("Download all")}}
+            </a>
           {%- endif %}
         </th>
       </tr>
@@ -78,6 +87,7 @@
         {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1) %}
         {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=file.key) %}
       {% endif %}
+
       {%- set file_type = file.key.split('.')[-1] %}
       <tr>
         <td class="ten wide" >
@@ -94,13 +104,12 @@
         <td class="right aligned">
           <span>
             {% if with_preview and file_type|lower is previewable %}
-            <a role="button" class="ui compact mini button preview-link" href="{{ file_url_preview }}" target="preview-iframe" data-file-key="{{file.key}}">
-              <i class="eye icon"></i> {{_("Preview")}}
-            </a>
+              <a role="button" class="ui compact mini button preview-link" href="{{ file_url_preview }}" target="preview-iframe" data-file-key="{{file.key}}">
+                <i class="eye icon" aria-hidden="true"></i>{{_("Preview")}}
+              </a>
             {% endif %}
             <a role="button" class="ui compact mini button" href="{{ file_url_download }}">
-              <i class="download icon"></i>
-              {{_('Download')}}
+              <i class="download icon" aria-hidden="true"></i>{{_('Download')}}
             </a>
           </span>
         </td>
@@ -112,55 +121,57 @@
 
 
 {% macro file_list_box(files, pid, is_preview, record) %}
-{%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
-<div class="">
-  <div class="ui accordion panel mb-10 {{record.ui.access_status.id}}" href="#collapsablePreview">
-    <div class="active title trigger panel-heading {{record.ui.access_status.id}}" tabindex="0">
-      {{ _("Files") }}
-      <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat(binary=binary_sizes)}}){% endif %}</small>
-      <i class="angle right icon"></i>
-    </div>
-    <div class="active content pt-0">
-      {% if record.access.files == 'restricted' %}
-      <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
-        <i class="ui {{ record.ui.access_status.icon }} icon"></i><b>{{ record.ui.access_status.title_l10n }}</b>
-        <p>{{ record.ui.access_status.description_l10n }}</p>
-        {% if record.access.embargo.reason %}
-          <p>{{_("Reason")}}: {{record.access.embargo.reason}}</p>
-        {% endif%}
+  {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
+  <div class="ui accordion panel mb-10 {{ record.ui.access_status.id }}" href="#files-list-accordion-panel">
+    <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
+      <div role="button" id="files-list-accordion-trigger" aria-controls="files-list-accordion-panel" aria-expanded="true" tabindex="0" class="trigger">
+        {{ _("Files") }}
+        <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat(binary=binary_sizes)}}){% endif %}</small>
+        <i class="angle right icon" aria-hidden="true"></i>
       </div>
+    </h3>
+
+    <div role="region" id="files-list-accordion-panel" aria-labelledby="files-list-accordion-trigger" class="active content pt-0">
+      {% if record.access.files == 'restricted' %}
+        <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
+          <i class="ui {{ record.ui.access_status.icon }} icon" aria-hidden="true"></i><b>{{ record.ui.access_status.title_l10n }}</b>
+          <p>{{ record.ui.access_status.description_l10n }}</p>
+          {% if record.access.embargo.reason %}
+            <p>{{_("Reason")}}: {{record.access.embargo.reason}}</p>
+          {% endif%}
+        </div>
       {% endif %}
-      <div id="collapsableFiles">
+      <div>
         {{ file_list(files, pid, is_preview, record=record, download_endpoint="invenio_app_rdm_records.record_file_download") }}
       </div>
     </div>
   </div>
-</div>
 {%- endmacro %}
 
 {% macro media_file_list_box(files, pid, is_preview, record) %}
-{%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
-<div class="">
-  <div class="ui accordion panel mb-10 {{record.access.record}}" id="preview" href="#collapsablePreview">
-    <div class="active title trigger panel-heading {{record.access.record}}" tabindex="0">
-      {{ _("System files") }}
-      <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat(binary=binary_sizes)}}){% endif %}</small>
-      <i class="angle right icon"></i>
-    </div>
-    <div class="active content pt-0">
-      {% if record.access.record == 'restricted'%}
-      <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
-        <i class="ui {{ record.ui.access_status.icon }} icon"></i><b>{{ record.ui.access_status.title_l10n }}</b>
-        <p>{{ record.ui.access_status.description_l10n }}</p>
-        {% if record.access.embargo.reason %}
-          <p>{{_("Reason")}}: {{record.access.embargo.reason}}</p>
-        {% endif%}
+  {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
+  <div class="ui accordion panel mb-10 {{ record.access.record }}" href="#media-files-preview-accordion-panel">
+    <h3 class="active title panel-heading {{ record.access.record }} m-0">
+      <div role="button" id="media-files-preview-accordion-trigger" aria-controls="media-files-preview-accordion-panel" aria-expanded="true" tabindex="0" class="trigger">
+        {{ _("System files") }}
+        <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat(binary=binary_sizes)}}){% endif %}</small>
+        <i class="angle right icon" aria-hidden="true"></i>
       </div>
+    </h3>
+
+    <div role="region" id="media-files-preview-accordion-panel" aria-labelledby="media-files-preview-accordion-trigger" class="active content pt-0">
+      {% if record.access.record == 'restricted'%}
+        <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
+          <i class="ui {{ record.ui.access_status.icon }} icon"></i><b>{{ record.ui.access_status.title_l10n }}</b>
+          <p>{{ record.ui.access_status.description_l10n }}</p>
+          {% if record.access.embargo.reason %}
+            <p>{{_("Reason")}}: {{record.access.embargo.reason}}</p>
+          {% endif%}
+        </div>
       {% endif %}
-      <div id="collapsableFiles">
+      <div>
         {{ file_list(files, pid, is_preview, record=record, with_preview=false, download_endpoint="invenio_app_rdm_records.record_media_file_download", is_media=true) }}
       </div>
     </div>
   </div>
-</div>
 {%- endmacro %}

--- a/invenio_app_rdm/records_ui/views/__init__.py
+++ b/invenio_app_rdm/records_ui/views/__init__.py
@@ -27,11 +27,13 @@ from .deposits import deposit_create, deposit_edit
 from .filters import (
     can_list_files,
     compact_number,
+    custom_fields_search,
     get_scheme_label,
     has_images,
     has_previewable_files,
     localize_number,
     make_files_preview_compatible,
+    namespace_url,
     order_entries,
     pid_url,
     select_preview_file,
@@ -157,6 +159,8 @@ def create_blueprint(app):
     blueprint.add_app_template_filter(localize_number)
     blueprint.add_app_template_filter(compact_number)
     blueprint.add_app_template_filter(truncate_number)
+    blueprint.add_app_template_filter(namespace_url)
+    blueprint.add_app_template_filter(custom_fields_search)
 
     # Register context processor
     blueprint.app_context_processor(search_app_context)

--- a/invenio_app_rdm/records_ui/views/filters.py
+++ b/invenio_app_rdm/records_ui/views/filters.py
@@ -13,7 +13,7 @@ from os.path import splitext
 
 import idutils
 from babel.numbers import format_compact_decimal, format_decimal
-from flask import current_app
+from flask import current_app, url_for
 from invenio_previewer.views import is_previewable
 from invenio_records_files.api import FileObject
 from invenio_records_permissions.policies import get_record_permission_policy
@@ -148,3 +148,31 @@ def truncate_number(value, max_value):
     if int(value) > max_value:
         number = compact_number(value, max_value=1_000_000)
     return number
+
+
+def namespace_url(field):
+    """Get custom field namespace url."""
+    namespace_array = field.split(":")
+    namespace = namespace_array[0]
+    namespace_value = namespace_array[1]
+    namespaces = current_app.config.get("RDM_NAMESPACES")
+
+    if not namespaces.get(namespace):
+        return None
+
+    return namespaces[namespace] + namespace_value
+
+
+def custom_fields_search(field, field_value):
+    """Get custom field search url."""
+    namespace_array = field.split(":")
+    namespace = namespace_array[0]
+    namespaces = current_app.config.get("RDM_NAMESPACES")
+
+    if not namespaces.get(namespace):
+        return None
+
+    namespace_string = "\:".join(namespace_array)
+    return url_for(
+        "invenio_search_ui.search", q=f"custom_fields.{namespace_string}:{field_value}"
+    )

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/header.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/header.overrides
@@ -11,12 +11,14 @@
 
 .main-record-content {
   h1,
-  h1.ui.header {
+  h1.ui.header,
+  .ui.huge.header {
     font-size: 2rem;
   }
 
   h2,
-  h2.ui.header {
+  h2.ui.header,
+  .ui.large.header {
     font-size: 1.5rem;
 
     &:not(:first-child) {
@@ -25,12 +27,14 @@
   }
 
   h3,
-  h3.ui.header {
+  h3.ui.header,
+  .ui.medium.header {
     font-size: 1.2rem;
   }
 
   h4,
-  h4.ui.header {
+  h4.ui.header,
+  .ui.small.header {
     font-size: 1rem;
   }
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -276,7 +276,7 @@ a.no-text-decoration:hover {
   text-decoration: none;
 }
 
-#collapsablePreview {
+.preview-container {
   border: 1px solid transparent; // Prevents iframe from overflowing accordion border
 }
 
@@ -290,8 +290,18 @@ dd {
   margin-inline-start: 0;
 }
 
+ul.details-list {
+  li {
+    padding-left: 0 !important;
+
+    &:not(:last-child) {
+      margin-bottom: 1rem;
+    }
+  }
+}
+
 dl.details-list {
-  margin-top: .5rem;
+  margin-top: 0;
 
   &:last-child {
     margin-bottom: 0;
@@ -424,4 +434,15 @@ dl.details-list {
   &::first-letter {
     text-transform: capitalize;
   }
+}
+
+.sr-only { // Hide element in the UI, but keep it available for screen readers
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  word-wrap: normal;
+  border: 0;
 }


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/229

- Removes "Description" header from the UI (the element remains in the DOM but with a new `sr-only` class, to keep it available for screen readers.
- Changes Additional Details view from tabs to list (accordion if sub content longer than 5 items)
    - The accordion is open by default
- Improves accessibility for all files accordions
- Custom fields are linked to search for namespace terms
- External url added for namespace docs
- Added "Notes" description to warning message box
- Added acronym to awards

<img width="919" alt="Screenshot 2023-09-12 at 10 19 50" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/1a4d96c6-5a39-44e0-9cf3-b711dbadf99c">

![127 0 0 1_5000_records_wp2dk-aqj34](https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/4b1d4155-80d7-47dc-ada4-c4e577b4960e)
![127 0 0 1_5000_records_kmevf-50k32](https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/5c37fca1-5ff0-45b6-857d-b253afb3d54d)
![127 0 0 1_5000_records_kmevf-50k32_expanded](https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/e7840208-5724-4d6c-a4d7-0f749d4498dc)


