### PR TITLE
Update robots.txt

### DIFF
--- a/invenio_app_rdm/theme/static/robots.txt
+++ b/invenio_app_rdm/theme/static/robots.txt
@@ -2,4 +2,11 @@ User-agent: *
 Disallow: /search
 Disallow: /api
 Disallow: /administration
+Disallow: /account
+Disallow: /uploads
+Disallow: /me
+Disallow: /login
+Disallow: /logout
+Disallow: /records/*/files
+Disallow: /records/*/preview
 Crawl-delay: 10


### PR DESCRIPTION
Update the `robots.txt` file to discourage bots from crawling some routes that aren't relevant for them, but present in all InvenioRDM deployments.
Some of the routes may be a bit overkill because they're only available to authenticated users (which should not apply to random web crawlers).