### PR TITLE
versions toggle: replace id by aria label

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/search/components.js
@@ -170,9 +170,9 @@ export const RDMToggleComponent = ({
       <Card.Content>
         <Checkbox
           toggle
-          label={label}
+          label={<label aria-hidden="true">{label}</label>}
           name="versions-toggle"
-          id="versions-toggle"
+          aria-label={label}
           onClick={onToggleClicked}
           checked={isChecked}
         />


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2352

Replaces the id by aria-label so that the label gets disconnected and the aria-label is used instead. This resolves errors related to duplicate ids due to the responsive sidebar.