### PR TITLE
landing page: move divider within conditional

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
@@ -348,6 +348,6 @@ show_alternate_identifiers, show_related_identifiers, show_funding, show_dates %
         </div>
       </div>
     {% endif %}
+    <div class="ui divider"></div>
   {% endif %}
-  <div class="ui divider"></div>
 {% endif %}


### PR DESCRIPTION
Fixes the following issue:
<img width="913" alt="Screenshot 2023-09-18 at 15 18 12" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/eed90453-57da-43d7-8408-76e34d318c42">

The divider for `metadata.references` was not within the related conditional.

After fix: 
<img width="877" alt="Screenshot 2023-09-18 at 15 19 35" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/5034bf28-99ac-4f89-a62b-5f0746bae3d6">
