### PR TITLE
creatibutors: fix semantic html

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
@@ -13,10 +13,10 @@
   {% if record.ui.creators and record.ui.creators.creators %}
     <div class="row ui accordion affiliations">
       <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
-          <dl class="creatibutors" aria-label="{{ _('Creators list') }}">
-            <dt class="hidden">{{ _('Creators') }}</dt>
-              {{ show_creatibutors(record.ui.creators.creators, show_affiliations=True) }}
-          </dl>
+          <h2 class="sr-only">{{ _('Creators') }}</h2>
+          <ul class="creatibutors">
+            {{ show_creatibutors(record.ui.creators.creators, show_affiliations=True) }}
+          </ul>
       </div>
 
         {# Todo: get full list of all affiliations (both creators & contributors) e.g.
@@ -31,12 +31,14 @@
   {% if record.ui.contributors and record.ui.contributors.contributors %}
     <div class="row ui accordion affiliations">
       <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
-
+          <h2 class="sr-only">{{ _('Contributors') }}</h2>
           {%- for group in record.ui.contributors.contributors|groupby('role.title')%}
-          <dl class="creatibutors" aria-label="{{ _('Contributors list') }}">
-              <dt class="text-muted">{{group.grouper}}{%- if group.list|length > 1 -%}s{%- endif -%}:</dt>
+          <div>
+            <h3 class="creatibutors-header ui small header">{{group.grouper}}{%- if group.list|length > 1 -%}s{%- endif -%}:</h3>
+            <ul class="creatibutors">
               {{ show_creatibutors(group.list, show_affiliations=True) }}
-          </dl>
+            </ul>
+          </div>
           {%- endfor %}
       </div>
 

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
@@ -39,7 +39,7 @@
 
 {% macro show_creatibutors(creatibutors, show_affiliations=False) %}
   {% for creatibutor in creatibutors %}
-  <dd class="creatibutor-wrap separated">
+  <li class="creatibutor-wrap separated">
     <a class="ui creatibutor-link"
       {% if show_affiliations and creatibutor.affiliations %}
         data-tooltip="{{ creatibutor.affiliations|join('; ', attribute='1') }}"
@@ -59,7 +59,7 @@
       {%- endif -%}
     </a>
     {{- creatibutor_icon(creatibutor) -}}
-  </dd>
+  </li>
   {% endfor %}
 {%- endmacro %}
 

--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/macros/request_header.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/macros/request_header.html
@@ -70,9 +70,9 @@
     <h2 class="ui header request-header">{{ request.title }}</h2>
     <p class="ui header">{{ request.description|safe }}</p>
     {% if record %}
-      <dl class="creatibutors" aria-label="{{ _('Creators list') }}">
+      <ul class="creatibutors" aria-label="{{ _('Creators') }}">
         {{ show_creatibutors(record.metadata.creators) }}
-      </dl>
+      </ul>
     {% endif %}
   </div>
 {% endmacro %}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
@@ -8,18 +8,29 @@
  * it under the terms of the MIT License; see LICENSE file for more details.
  */
 
+h3.ui.small.header.creatibutors-header {
+  display: inline-block;
+  color: @mutedTextColor;
+  margin-bottom: .5rem;
+  margin-right: .5rem;
+  font-weight: bold !important;
+}
+
+h3.ui.small.header.creatibutors-header + ul.creatibutors {
+  display: inline-block;
+}
+
 .creatibutors,
 .ui.items > .item .meta .creatibutors {
   margin: 0 0 0.5rem 0;
-  display: block;
+  padding: 0;
 
   &:last-child {
     margin-bottom: 0;
   }
 
-  dt {
+  li {
     display: inline-block;
-    font-weight: bold;
     margin: 0 0.25rem 0 0;
 
     &.hidden {
@@ -33,7 +44,7 @@
     margin-bottom: .5rem;
 
     &:nth-child(n):not(:last-child) {
-      margin-right: 1rem;
+      margin-right: .5rem;
     }
 
     .identifier-link, .group.icon {


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-requests/issues/362

- Converts creatibutors list to `ul` instead of `dl` due to accessibility errors.
- Adds `sr-only` headlines to creators and contributors on the landing page
- Reduces whitespace on creatibutors, otherwise the UI remains the same.

<img width="743" alt="Screenshot 2023-09-19 at 10 48 58" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/11fe0d2a-9317-42db-9e87-6c231fbc1c1d">
<img width="710" alt="Screenshot 2023-09-19 at 10 50 43" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/442cd763-013a-4781-9350-bafd10b599ea">
<img width="959" alt="Screenshot 2023-09-19 at 10 51 49" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/9f6a221c-c996-4c80-a1d3-6f227e48c3a6">
