### PR TITLE
communities: fix unhandled visibility error

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -859,7 +859,7 @@ COMMUNITIES_ERROR_HANDLERS = {
     InvalidCommunityVisibility: create_error_handler(
         lambda e: HTTPJSONException(
             code=400,
-            description=str(e),
+            description=e.reason,
         )
     ),
 }


### PR DESCRIPTION
Fixes community error when trying to restrict a community with public records

# Current 

![Screenshot 2023-09-19 at 16 01 00](https://github.com/inveniosoftware/invenio-app-rdm/assets/22594783/79e45754-6434-4ebe-b57d-8082ae22fec7)


