### PR TITLE
header: add active status to menu items

### DIFF
--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header.html
@@ -25,7 +25,7 @@
                     <a class="logo-link" href="/">
                       <img class="ui image rdm-logo"
                             src="{{ url_for('static', filename=config.THEME_LOGO) }}"
-                            alt="{{ _(config.THEME_SITENAME) }}"/>
+                            alt="{{ _(config.THEME_SITENAME) }} {{ _('home') }}"/>
                     </a>
                   {%- else %}
                     <a class="logo" href="/">{{ _(config.THEME_SITENAME) }}</a>
@@ -87,15 +87,15 @@
                     </div>
                   </div>
                 {%- else %}
-                  <div class="{{' item active' if item.active and loop.depth == 0 else ' item' }}">
+                  <div class="{{ 'item active' if item.active else 'item' }}">
                     <a href="{{ item.url }}">{{ item.text|safe }}</a>
                   </div>
                 {%- endif %}
               {%- endfor %}
 
               {% for item in current_menu.submenu('actions').children|sort(attribute='order') if item.visible recursive %}
-                <div class="item">
-                  <a  href="{{ item.url }}">{{ item.text|safe }}</a>
+                <div class="{{ 'item active' if item.active else 'item' }}">
+                  <a href="{{ item.url }}">{{ item.text|safe }}</a>
                 </div>
               {% endfor %}
             {%- endblock navbar_nav %}
@@ -104,7 +104,7 @@
               <div class="right menu item">
                 {%- if config.ACCOUNTS and current_user.is_authenticated %}
                   {% for item in current_menu.submenu('notifications').children|sort(attribute='order') if item.visible recursive %}
-                    <div class="item inbox">
+                    <div class="{{'item active' if item.active else 'item' }} inbox">
                       <a href="{{ item.url }}" aria-label="{{ _('Requests') }}">
                         <i class="fitted inbox icon inverted"></i>
                         <span class="mobile tablet only inline">{{ _("Inbox") }}</span>


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2333

Comment: I removed the `and loop.depth == 0` from the conditional, as it was preventing the active state to show. (The actual depth == 1.) I'm not sure I understand why it should be there, so if it should for some reason, please let me know.

<img width="1265" alt="Screenshot 2023-09-25 at 11 56 47" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/4acef3cc-9fd9-4908-bdec-05cc9be960e9">
<img width="1146" alt="Screenshot 2023-09-25 at 11 56 53" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/c2f8d8a7-2e04-4bb8-9045-b60a90d919fd">
<img width="829" alt="Screenshot 2023-09-25 at 11 56 59" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/63ed77c9-48bf-4c16-aade-0e279a459b54">
