### PR TITLE
css overrides: cancel the influence of accordion errors on its input placeholder

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/input.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/input.overrides
@@ -39,3 +39,13 @@
     }
 }
 
+.ui.accordion.invenio-accordion-field.error.secondary.inverted {
+  .content .container input{
+    &::placeholder{
+       color: @placeholderColor;
+    }
+    &:focus::placeholder{
+       color: @placeholderFocusColor;
+    }
+  }
+}


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/244

Before:
![Screenshot 2023-10-05 at 16 20 31](https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/db6f535c-e6b0-4241-928a-61c6ca6e6f11)

After:
![Screenshot 2023-10-05 at 16 22 45](https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/8f84273b-7f49-476c-9364-f9e8069cfe99)
