### PR TITLE
ui: landing_page: access form: make full name not required

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/AccessRequestForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/AccessRequestForm.js
@@ -28,7 +28,7 @@ export class AccessRequestForm extends Component {
     // nullable().required() is needed to avoid ``null`` type message errors.
     this.accessRequestSchema = Yup.object({
       email: Yup.string().email().nullable().required(),
-      full_name: Yup.string().nullable().required(),
+      full_name: Yup.string().nullable(),
       message: Yup.string().nullable(),
       consent_to_share_personal_data: Yup.bool().required(),
     });


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/373

Yup's object validation: [string.required](https://github.com/jquense/yup#stringrequiredmessage-string--function-schema) doesn't allow empty strings 

Full names can be null or empty strings. We added a check in place in https://github.com/inveniosoftware/invenio-app-rdm/pull/2490 to convert any null values to empty strings which made this validation fail always and the form stopped working.