### PR TITLE
landing page: sort files alphabetically

### DIFF
--- a/invenio_app_rdm/records_ui/views/filters.py
+++ b/invenio_app_rdm/records_ui/views/filters.py
@@ -112,6 +112,9 @@ def order_entries(files):
             return files_.pop(idx)
 
         files = [get_file(key) for key in order]
+    else:
+        # sort alphabetically by filekey
+        files = sorted(files, key=lambda x: x["key"].lower())
 
     return files
 


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/360

**Note: applies also for media files for both zenodo and rdm**


No default preview - preview the first file:
![Screenshot 2023-10-16 at 11 56 27](https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/07f6da63-c935-4201-a10f-60726992a711)

Default preview is set:
![Screenshot 2023-10-16 at 11 57 14](https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/3dd7a7f8-3a3a-4149-aa47-c37b9823cdba)
