### PR TITLE
access request: make accept conditions field an editor-like

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessRequests/AccessRequestsTab.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessRequests/AccessRequestsTab.js
@@ -14,7 +14,7 @@ import { i18next } from "@translations/invenio_app_rdm/i18next";
 import { SuccessIcon } from "@js/invenio_communities/members";
 import {
   RadioField,
-  TextAreaField,
+  RichInputField,
   http,
   withCancel,
   ErrorMessage,
@@ -80,6 +80,23 @@ export class AccessRequestsTab extends Component {
       settings["secret_link_expiration"] = 0;
     }
     return { ...settings };
+  };
+
+  editorConfig = {
+    toolbar: [
+      "heading",
+      "|",
+      "bold",
+      "italic",
+      "link",
+      "bulletedList",
+      "numberedList",
+      "Indent",
+      "Outdent",
+      "blockQuote",
+      "Undo",
+      "Redo",
+    ],
   };
 
   render() {
@@ -153,14 +170,17 @@ export class AccessRequestsTab extends Component {
                       </Grid.Row>
                       <Grid.Row>
                         <Grid.Column>
+                          <h5>{i18next.t("Accept conditions")}</h5>
+                          <label className="helptext mb-0 mt-10">
+                            {i18next.t(
+                              "Optional. Specify conditions under which you approve access. This message will be " +
+                                "visible for any user when requesting access to this record."
+                            )}
+                          </label>
                           <Form.Field>
-                            <TextAreaField
-                              placeholder={i18next.t(
-                                "Optional. Specify conditions under which you approve access. This message will be " +
-                                  "visible for any user when requesting access to this record."
-                              )}
+                            <RichInputField
                               fieldPath="accept_conditions_text"
-                              rows={6}
+                              editorConfig={this.editorConfig}
                             />
                           </Form.Field>
                         </Grid.Column>


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/406

Before:
<img width="1382" alt="Screenshot 2023-10-20 at 15 52 56" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/39a56885-c536-4ace-a389-722dae275044">

After:
<img width="1440" alt="Screenshot 2023-10-20 at 15 54 13" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/6a8da9a6-8b0b-4d99-8267-9cb742cbd8f3">

Editor:
<img width="1335" alt="Screenshot 2023-10-20 at 15 55 13" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/72a0f671-7b29-4c70-92bb-3f8f14322acb">

Result - saved as HTML and displayed:
<img width="1126" alt="Screenshot 2023-10-20 at 15 55 34" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/8ac5d169-1234-44ad-b4c1-706df701274c">
