### PR TITLE
landing page: add extras block to additional details template

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
@@ -351,3 +351,5 @@ show_alternate_identifiers, show_related_identifiers, show_funding, show_dates %
     <div class="ui divider"></div>
   {% endif %}
 {% endif %}
+
+{% block extras %}{% endblock %}


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/446

I tested adding the subjects to the "Keywords and Subjects" block in the sidebar, as proposed in the task, but I'm not sure it makes sense due to the different types of information that can be displayed. For some of the data, it could work well to add it there (e.g. actual subject data with a URL to the term docs), but for other data, like ISSN, it doesn't really make sense? For this reason, I added it to the "Additional details" section, which is also not the best solution for all the data, but it allows for more context. 

See the screenshots below, and let me know if anything should be done differently.

<img width="894" alt="Screenshot 2023-10-26 at 9 10 16 PM" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/3a0019a4-515d-4e60-99d9-29c1525ce258">
<img width="681" alt="Screenshot 2023-10-26 at 9 09 20 PM" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/7ec9c3e5-32a9-48a1-8de7-57fb5deab7c4">
<img width="844" alt="Screenshot 2023-10-26 at 9 10 30 PM" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/b59bcd1d-0f51-46c2-b747-e8c3c9a21319">

