### PR TITLE
UserActions: Fix wrong endpoint for drafts + UI improvements

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/SetQuotaAction.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/SetQuotaAction.js
@@ -8,9 +8,8 @@
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Button, Modal, Icon } from "semantic-ui-react";
+import { Button, Modal, Icon, Checkbox } from "semantic-ui-react";
 import { ActionModal } from "@js/invenio_administration";
-import _isEmpty from "lodash/isEmpty";
 import { SetQuotaForm } from "./SetQuotaForm";
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 
@@ -19,49 +18,36 @@ export class SetQuotaAction extends Component {
     super(props);
     this.state = {
       modalOpen: false,
-      modalHeader: undefined,
-      modalBody: undefined,
+      setQuotaInBytes: false,
     };
   }
 
   onModalTriggerClick = (e, { payloadSchema, dataName, dataActionKey }) => {
-    const { resource, apiUrl } = this.props;
-
-    this.setState({
-      modalOpen: true,
-      modalHeader: i18next.t("Set quota"),
-      modalBody: (
-        <SetQuotaForm
-          actionSuccessCallback={this.handleSuccess}
-          actionCancelCallback={this.closeModal}
-          resource={resource}
-          apiUrl={apiUrl}
-        />
-      ),
-    });
+    this.setState({ modalOpen: true });
   };
 
   closeModal = () => {
     this.setState({
       modalOpen: false,
-      modalHeader: undefined,
-      modalBody: undefined,
+      setQuotaInBytes: false,
     });
   };
 
   handleSuccess = () => {
     const { successCallback } = this.props;
-    this.setState({
-      modalOpen: false,
-      modalHeader: undefined,
-      modalBody: undefined,
-    });
+    this.setState({ modalOpen: false });
     successCallback();
   };
 
+  setQuotaValueInBytes = (event, data) => {
+    const { checked } = data;
+    this.setState({ setQuotaInBytes: checked });
+  };
+
   render() {
-    const { resource } = this.props;
-    const { modalOpen, modalHeader, modalBody } = this.state;
+    const { resource, apiUrl, headerText, isRecord } = this.props;
+    const { modalOpen, setQuotaInBytes } = this.state;
+
     return (
       <>
         <Button
@@ -73,12 +59,37 @@ export class SetQuotaAction extends Component {
           labelPosition="left"
         >
           <Icon name="disk" />
-          Set Quota
+          {i18next.t("Set Quota")}
         </Button>
 
         <ActionModal modalOpen={modalOpen} resource={resource}>
-          {modalHeader && <Modal.Header>{modalHeader}</Modal.Header>}
-          {!_isEmpty(modalBody) && modalBody}
+          <Modal.Header className="flex justify-space-between">
+            <div>{headerText}</div>
+            <div>
+              <Checkbox
+                toggle
+                label={i18next.t("Set quota in bytes")}
+                onChange={this.setQuotaValueInBytes}
+              />
+            </div>
+          </Modal.Header>
+          {!isRecord && (
+            <Modal.Content>
+              <p>
+                <strong>{i18next.t("Note")}:</strong>{" "}
+                {i18next.t(
+                  "This is the default quota that will be applied to any NEW buckets created by this user – it will NOT update existing buckets."
+                )}
+              </p>
+            </Modal.Content>
+          )}
+          <SetQuotaForm
+            actionSuccessCallback={this.handleSuccess}
+            actionCancelCallback={this.closeModal}
+            resource={resource}
+            apiUrl={apiUrl}
+            setQuotaInBytes={setQuotaInBytes}
+          />
         </ActionModal>
       </>
     );
@@ -89,6 +100,10 @@ SetQuotaAction.propTypes = {
   resource: PropTypes.object.isRequired,
   successCallback: PropTypes.func.isRequired,
   apiUrl: PropTypes.string.isRequired,
+  headerText: PropTypes.string.isRequired,
+  isRecord: PropTypes.bool,
 };
 
-SetQuotaAction.defaultProps = {};
+SetQuotaAction.defaultProps = {
+  isRecord: false,
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/SetQuotaForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/SetQuotaForm.js
@@ -44,17 +44,34 @@ export class SetQuotaForm extends Component {
   handleSubmit = async (values) => {
     this.setState({ loading: true });
     const { addNotification } = this.context;
-    const { resource, actionSuccessCallback, apiUrl } = this.props;
-    const payload = { ...values };
-    this.cancellableAction = withCancel(http.post(apiUrl, payload));
+    const { resource, actionSuccessCallback, setQuotaInBytes, apiUrl } = this.props;
+    let { notes, quota_size: quotaSize, max_file_size: maxFileSize } = values;
+
+    const quotaInGb = !setQuotaInBytes && quotaSize;
+
+    if (!setQuotaInBytes) {
+      quotaSize *= 10 ** 9;
+      maxFileSize *= 10 ** 9;
+    }
+
+    this.cancellableAction = withCancel(
+      http.post(apiUrl, {
+        notes,
+        quota_size: quotaSize,
+        max_file_size: maxFileSize,
+      })
+    );
+
     try {
       await this.cancellableAction.promise;
       this.setState({ loading: false, error: undefined });
+
       addNotification({
         title: i18next.t("Success"),
-        content: i18next.t("Quota of {{id}} was set to {{quota}}", {
+        content: i18next.t("Quota of {{id}} was set to {{quota}} {{unit}}", {
           id: resource.id,
-          quota: payload.quota_size,
+          quota: quotaInGb || quotaSize,
+          unit: quotaInGb ? "GB" : "bytes",
         }),
         type: "success",
       });
@@ -86,6 +103,8 @@ export class SetQuotaForm extends Component {
 
   render() {
     const { error, loading } = this.state;
+    const { setQuotaInBytes } = this.props;
+
     return (
       <Formik
         onSubmit={this.handleSubmit}
@@ -99,13 +118,15 @@ export class SetQuotaForm extends Component {
           return (
             <>
               {error && (
-                <ErrorMessage
-                  header={i18next.t("Unable to set quota.")}
-                  content={i18next.t(error)}
-                  icon="exclamation"
-                  className="text-align-left"
-                  negative
-                />
+                <Modal.Content>
+                  <ErrorMessage
+                    header={i18next.t("Unable to set quota.")}
+                    content={i18next.t(error)}
+                    icon="exclamation"
+                    className="text-align-left"
+                    negative
+                  />
+                </Modal.Content>
               )}
               <Modal.Content>
                 <Form className="full-width">
@@ -113,14 +134,18 @@ export class SetQuotaForm extends Component {
                     <TextField
                       required
                       fieldPath="quota_size"
-                      label={i18next.t("Quota size")}
+                      label={i18next.t("Quota size ({{unit}})", {
+                        unit: setQuotaInBytes ? "bytes" : "GB",
+                      })}
                       placeholder={i18next.t("Enter quota size...")}
                       type="number"
                     />
                     <TextField
                       required
                       fieldPath="max_file_size"
-                      label={i18next.t("Max file size")}
+                      label={i18next.t("Max file size ({{unit}})", {
+                        unit: setQuotaInBytes ? "bytes" : "GB",
+                      })}
                       placeholder={i18next.t("Enter max file size...")}
                       type="number"
                     />
@@ -132,7 +157,7 @@ export class SetQuotaForm extends Component {
               </Modal.Content>
               <Modal.Actions>
                 <Button onClick={this.handleModalClose} floated="left">
-                  Close
+                  {i18next.t("Close")}
                 </Button>
                 <Button
                   size="small"
@@ -158,4 +183,9 @@ SetQuotaForm.propTypes = {
   actionSuccessCallback: PropTypes.func.isRequired,
   actionCancelCallback: PropTypes.func.isRequired,
   apiUrl: PropTypes.string.isRequired,
+  setQuotaInBytes: PropTypes.bool,
+};
+
+SetQuotaForm.defaultProps = {
+  setQuotaInBytes: false,
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/records/RecordActions.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/records/RecordActions.js
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2023 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { i18next } from "@translations/invenio_app_rdm/i18next";
+import { Actions } from "@js/invenio_administration";
+import { SetQuotaAction } from "../components/SetQuotaAction";
+
+export const RecordActions = ({
+  title,
+  resourceName,
+  record,
+  displayEdit,
+  displayDelete,
+  actions,
+  idKeyPath,
+  listUIEndpoint,
+  successCallback,
+  displayQuota,
+  editUrl,
+}) => {
+  return (
+    <>
+      <Actions
+        title={title}
+        resourceName={resourceName}
+        editUrl={editUrl}
+        displayEdit={displayEdit}
+        displayDelete={displayDelete}
+        actions={actions}
+        resource={record}
+        idKeyPath={idKeyPath}
+        successCallback={successCallback}
+        listUIEndpoint={listUIEndpoint}
+      />
+      {displayQuota && (
+        <SetQuotaAction
+          headerText={i18next.t("Set quota for record {{recordId}}", {
+            recordId: record.id,
+          })}
+          successCallback={successCallback}
+          apiUrl={`/api/records/${record.id}/quota`}
+          resource={record}
+          isRecord
+        />
+      )}
+    </>
+  );
+};
+
+RecordActions.propTypes = {
+  successCallback: PropTypes.func.isRequired,
+  record: PropTypes.string.isRequired,
+  idKeyPath: PropTypes.string.isRequired,
+  listUIEndpoint: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  resourceName: PropTypes.string.isRequired,
+  actions: PropTypes.object.isRequired,
+  editUrl: PropTypes.string.isRequired,
+  displayQuota: PropTypes.bool,
+  displayEdit: PropTypes.bool,
+  displayDelete: PropTypes.bool,
+};
+
+RecordActions.defaultProps = {
+  displayQuota: false,
+  displayEdit: false,
+  displayDelete: false,
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/records/search/SearchResultItemLayout.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/records/search/SearchResultItemLayout.js
@@ -6,8 +6,9 @@
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
-import { BoolFormatter, Actions } from "@js/invenio_administration";
+import { BoolFormatter } from "@js/invenio_administration";
 import { UserActions } from "../../users/UserActions";
+import { RecordActions } from "../RecordActions";
 import _truncate from "lodash/truncate";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
@@ -100,14 +101,15 @@ class SearchResultItemComponent extends Component {
 
         <Table.Cell collapsing>
           <Button.Group basic widths={5} compact className="margined">
-            <Actions
+            <RecordActions
+              record={result}
+              displayQuota={!result.is_published}
               title={title}
               resourceName={resourceName}
               editUrl={AdminUIRoutes.editView(listUIEndpoint, result, idKeyPath)}
               displayEdit={displayEdit}
               displayDelete={displayDelete}
               actions={actions}
-              resource={result}
               idKeyPath={idKeyPath}
               successCallback={this.refreshAfterAction}
               listUIEndpoint={listUIEndpoint}
@@ -116,7 +118,6 @@ class SearchResultItemComponent extends Component {
               user={{ id: result.parent.access.owned_by.user }}
               displaySuspend
               displayBlock
-              displayQuota={!result.is_published}
               successCallback={this.refreshAfterAction}
             />
           </Button.Group>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/UserActions.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/UserActions.js
@@ -129,6 +129,9 @@ export class UserActions extends Component {
         <>
           {displayQuota && (
             <SetQuotaAction
+              headerText={i18next.t("Set default quota for {{email}}", {
+                email: user.email,
+              })}
               successCallback={successCallback}
               apiUrl={`/api/users/${user.id}/quota`}
               resource={user}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/modal.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/modal.overrides
@@ -123,6 +123,11 @@
     line-height: @contentLineHeight;
     padding: @contentPadding;
     background: @contentBackground;
+
+    .ui.message .content {
+      background: transparent;
+      padding: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/500 

- UI improvements (default input in GB, toggle to use bytes), more info displayed in modals.
- Updating apiUrl for record drafts.


<img width="802" alt="Screenshot 2023-11-08 at 2 30 51 PM" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/add72271-f5d0-4871-8d98-93b75528b59d">
<img width="797" alt="Screenshot 2023-11-08 at 2 31 01 PM" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/a7e21448-2477-40f1-ac31-f83b1295b72a">
<img width="790" alt="Screenshot 2023-11-08 at 2 30 40 PM" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/3bd0cd33-d8ec-4a5a-8ae3-17f969f79a53">



<img width="845" alt="Screenshot 2023-11-08 at 3 09 17 PM" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/e12f058a-1f80-4007-b0c3-05d4144c00f3">
<img width="855" alt="Screenshot 2023-11-08 at 3 09 23 PM" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/71230c30-0823-4b9e-8c30-c8e45502a3aa">
<img width="853" alt="Screenshot 2023-11-08 at 3 09 35 PM" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/21052053/6c3bb32e-c6ed-4f3a-96c9-086963ea4b97">
