### PR TITLE
config: update OAISERVER_RECORD_SETS_FETCHER to correct set fetcher

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -579,7 +579,7 @@ OAISERVER_CREATED_KEY = "created"
 OAISERVER_RECORD_CLS = "invenio_rdm_records.records.api:RDMRecord"
 """Record retrieval class."""
 
-OAISERVER_RECORD_SETS_FETCHER = "invenio_oaiserver.utils:record_sets_fetcher"
+OAISERVER_RECORD_SETS_FETCHER = "invenio_oaiserver.percolator:find_sets_for_record"
 """Record's OAI sets function."""
 
 OAISERVER_RECORD_INDEX = "rdmrecords-records"


### PR DESCRIPTION
Fixes https://github.com/zenodo/rdm-project/issues/565

The config set fetcher didn't evaluate the sets rather, tried to fetch it from the record.

Having same method names for [evaluation](https://github.com/inveniosoftware/invenio-oaiserver/blob/f2cfe79138b96864f393281fbbb818e08f1e9b89/invenio_oaiserver/ext.py#L42) and [fetcher/getter](https://github.com/inveniosoftware/invenio-oaiserver/blob/f2cfe79138b96864f393281fbbb818e08f1e9b89/invenio_oaiserver/utils.py#L183) might have been the cause for confusion between those.

The new config method is referred from oaiserver [config](https://github.com/inveniosoftware/invenio-oaiserver/blob/f2cfe79138b96864f393281fbbb818e08f1e9b89/invenio_oaiserver/config.py#L130)
