### PR TITLE
lp references: urlize references

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/detail.html
@@ -148,7 +148,7 @@
           ' )' %}
         {% endif %}
       {% endif %}
-      <li class="item">{{ reference_string }}</li>
+      <li class="item">{{ reference_string | urlize }}</li>
     {% endfor %}
   </ul>
 {% endmacro %}


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/567

- Additional request from the BLR team: Make URLs in references clickable
- Discussed with Lars: added for all, not only BLR