### PR TITLE
enable audio/video previewer [+]

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -990,6 +990,8 @@ PREVIEWER_PREFERENCE = [
     "xml_prismjs",
     "mistune",
     "pdfjs",
+    "video_videojs",
+    "audio_videojs",
     "ipynb",
     "zip",
     "txt",

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ install_requires =
     invenio-search-ui>=2.4.0,<3.0.0
     # Invenio files bundle
     invenio-files-rest>=2.0.0,<3.0.0
-    invenio-previewer>=2.0.0,<3.0.0
+    invenio-previewer>=2.2.0,<3.0.0
     invenio-records-files>=1.2.1,<2.0.0
     # Invenio-App-RDM
     invenio-communities>=12.0.0,<13.0.0


### PR DESCRIPTION
This makes them available by default in any invenio-app-rdm backed instance.

:warning: depends on https://github.com/inveniosoftware/invenio-previewer/pull/194
being merged and released (i.e. wait for that to confirm dependency versioning too)
