### PR TITLE
dashboard: respect flask-menu items' visibility

### DIFF
--- a/invenio_app_rdm/users_ui/templates/semantic-ui/invenio_app_rdm/users/header.html
+++ b/invenio_app_rdm/users_ui/templates/semantic-ui/invenio_app_rdm/users/header.html
@@ -37,7 +37,7 @@
     {% endif %}
   </div>
   <div class="ui container secondary pointing menu page-subheader pl-0">
-  {% for item in current_menu.submenu('dashboard').children %}
+  {% for item in current_menu.submenu('dashboard').children if item.visible %}
   <a
     class="item {{ 'active' if active_dashboard_menu_item == item.name }} {{ 'disabled' if not item.url }}"
     href="{{ item.url }}">{{ item.text }}</a>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Currently, submenus on the user dashboard are *always* shown, ignoring submenus' `.visible` setting.
In all other invenio templates that make use of `flask_menu`, this setting is honored, e.g. [here](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/header.html#L83) and [here](https://github.com/inveniosoftware/invenio-communities/blob/master/invenio_communities/templates/semantic-ui/invenio_communities/details/header.html#L132) (note the `if item.visible` part in those).
With this PR, submenus on the user dashboard will respect this setting too.

This change won't affect behavior of the default-configuration, as the user dashboard's submenus [are registered without passing `visible_when` kwarg](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/users_ui/views/ui.py#L70), leaving it at its default, which [always shows the submenu](https://github.com/inveniosoftware/flask-menu/blob/master/flask_menu/menu.py#L48).

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
