### PR TITLE
config: harmonize resolvers for notifications

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -37,6 +37,7 @@ from celery.schedules import crontab
 from flask_principal import Denial
 from flask_resources import HTTPJSONException, create_error_handler
 from invenio_access.permissions import any_user
+from invenio_communities.communities.entity_resolvers import CommunityResolver
 from invenio_communities.communities.resources.config import community_error_handlers
 from invenio_communities.notifications.builders import (
     CommunityInvitationAcceptNotificationBuilder,
@@ -74,16 +75,17 @@ from invenio_rdm_records.services.github.release import RDMGithubRelease
 from invenio_rdm_records.services.permissions import RDMRequestsPermissionPolicy
 from invenio_rdm_records.services.stats import permissions_policy_lookup_factory
 from invenio_rdm_records.services.tasks import StatsRDMReindexTask
-from invenio_records_resources.references.entity_resolvers import ServiceResultResolver
 from invenio_requests.notifications.builders import (
     CommentRequestEventCreateNotificationBuilder,
 )
+from invenio_requests.resolvers.requests import RequestEventResolver, RequestResolver
 from invenio_requests.resources.requests.config import request_error_handlers
 from invenio_stats.aggregations import StatAggregator
 from invenio_stats.contrib.event_builders import build_file_unique_id
 from invenio_stats.processors import EventsIndexer, anonymize_user, flag_robots
 from invenio_stats.queries import TermsQuery
 from invenio_stats.tasks import StatsAggregationTask, StatsEventTask
+from invenio_users_resources.entity_resolvers import UserResolver
 from invenio_vocabularies.config import (
     VOCABULARIES_DATASTREAM_READERS,
     VOCABULARIES_DATASTREAM_TRANSFORMERS,
@@ -1240,10 +1242,10 @@ NOTIFICATIONS_BUILDERS = {
 NOTIFICATIONS_ENTITY_RESOLVERS = [
     EmailResolver(),
     RDMRecordServiceResultResolver(),
-    ServiceResultResolver(service_id="users", type_key="user"),
-    ServiceResultResolver(service_id="communities", type_key="community"),
-    ServiceResultResolver(service_id="requests", type_key="request"),
-    ServiceResultResolver(service_id="request_events", type_key="request_event"),
+    UserResolver(),
+    CommunityResolver(),
+    RequestResolver(),
+    RequestEventResolver(),
 ]
 """List of entity resolvers used by notification builders."""
 


### PR DESCRIPTION
* Changes resolvers to use existing resolvers build for requests instead of resolvers that use the service layer.
