### PR TITLE
records-ui: urlize links in citation text

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCitationField.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCitationField.js
@@ -7,6 +7,7 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import _debounce from "lodash/debounce";
+import _escape from "lodash/escape";
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Placeholder, Dropdown, Message } from "semantic-ui-react";
@@ -100,10 +101,21 @@ export class RecordCitationField extends Component {
       };
     });
 
+    // convert links in text to clickable links (ignoring punctuations at the end)
+    const escapedCitation = _escape(citation); // escape html characters
+    const urlRegex = /(https?:\/\/[^\s,;]+(?=[^\s.,;]*\S))/g;
+    const urlizedCitation = escapedCitation.replace(urlRegex, (url) => {
+      return `<a href="${url}" target="_blank">${url}</a>`;
+    });
+
     return (
       <div>
         <div id="citation-text" className="wrap-overflowing-text rel-mb-2">
-          {loading ? this.placeholderLoader() : citation}
+          {loading ? (
+            this.placeholderLoader()
+          ) : (
+            <div dangerouslySetInnerHTML={{ __html: urlizedCitation }} />
+          )}
         </div>
 
         <div className="auto-column-grid no-wrap">


### PR DESCRIPTION
If there are DOI links serialized in the citation text, they should be clickable links (cc @tmorrell).

Before:

<img width="401" alt="image" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/1814661/dd66b311-0f92-48f3-9a7c-cb129c07ccf9">


After:

<img width="407" alt="image" src="https://github.com/inveniosoftware/invenio-app-rdm/assets/1814661/7b001c71-6fd2-45c5-a102-c72c9f985e7a">
