### PR TITLE
config: update limiter config

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -158,7 +158,7 @@ SESSION_COOKIE_SAMESITE = "Lax"
 # =============
 # https://flask-limiter.readthedocs.io/en/stable/#configuration
 
-RATELIMIT_STORAGE_URL = "redis://localhost:6379/3"
+RATELIMIT_STORAGE_URI = "redis://localhost:6379/3"
 """Storage for ratelimiter."""
 
 # Increase defaults


### PR DESCRIPTION
Update flask-limiter config according to [invenio-app](https://github.com/inveniosoftware/invenio-app/blob/master/invenio_app/ext.py#L123C25-L123C46). The change in the latter keeps backwards compatibility. This PR fixes the ability to be able to use the newly created config as currently invenio-app-rdm sets a default to a local redis storage.