### PR TITLE
ext: add records menu as first if no branded community

### DIFF
--- a/invenio_app_rdm/ext.py
+++ b/invenio_app_rdm/ext.py
@@ -62,29 +62,38 @@ def init_menu(app):
     )
 
     communities = current_menu.submenu("communities")
-    communities.submenu("home").register(
-        "invenio_app_rdm_communities.communities_home",
-        text=_("Home"),
-        order=1,
-        visible_when=_is_branded_community,
-        expected_args=["pid_value"],
-        **dict(icon="home", permissions="can_read"),
-    )
-    communities.submenu("search").register(
-        "invenio_app_rdm_communities.communities_detail",
-        text=_("Records"),
-        order=2,
-        expected_args=["pid_value"],
-        **dict(icon="search", permissions=True),
-    )
-    communities.submenu("submit").register(
-        "invenio_app_rdm_communities.community_static_page",
-        text=_("Submit"),
-        order=3,
-        visible_when=_is_branded_community,
-        endpoint_arguments_constructor=lambda: {
-            "pid_value": request.view_args["pid_value"],
-            "page_slug": "how-to-submit",
-        },
-        **dict(icon="upload", permissions="can_read"),
-    )
+    if _is_branded_community:
+        communities.submenu("home").register(
+            "invenio_app_rdm_communities.communities_home",
+            text=_("Home"),
+            order=1,
+            visible_when=_is_branded_community,
+            expected_args=["pid_value"],
+            **dict(icon="home", permissions="can_read"),
+        )
+        communities.submenu("search").register(
+            "invenio_app_rdm_communities.communities_detail",
+            text=_("Records"),
+            order=2,
+            expected_args=["pid_value"],
+            **dict(icon="search", permissions=True),
+        )
+        communities.submenu("submit").register(
+            "invenio_app_rdm_communities.community_static_page",
+            text=_("Submit"),
+            order=3,
+            visible_when=_is_branded_community,
+            endpoint_arguments_constructor=lambda: {
+                "pid_value": request.view_args["pid_value"],
+                "page_slug": "how-to-submit",
+            },
+            **dict(icon="upload", permissions="can_read"),
+        )
+    else:
+        communities.submenu("search").register(
+            "invenio_app_rdm_communities.communities_detail",
+            text=_("Records"),
+            order=1,
+            expected_args=["pid_value"],
+            **dict(icon="search", permissions=True),
+        )


### PR DESCRIPTION
If the community is not branded then the "Records" tab doesn't show up as first.

![Screenshot 2024-04-04 at 17 14 15](https://github.com/inveniosoftware/invenio-app-rdm/assets/22594783/6c8473be-fd20-4043-83dc-6ace8859bc61)
