### PR TITLE
Views: Add Static Pages dynamic Routing

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -2,9 +2,9 @@
 #
 # Copyright (C) 2019-2024 CERN.
 # Copyright (C) 2019-2020 Northwestern University.
-# Copyright (C) 2021 Graz University of Technology.
-# Copyright (C) 2022 KTH Royal Institute of Technology
-# Copyright (C) 2023 TU Wien
+# Copyright (C) 2021      Graz University of Technology.
+# Copyright (C) 2022-2024 KTH Royal Institute of Technology.
+# Copyright (C) 2023      TU Wien
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -1037,6 +1037,17 @@ PAGES_TEMPLATES = [
     ("invenio_app_rdm/default_static_page.html", "Default"),
 ]
 """List of available templates for pages."""
+
+APP_RDM_PAGES = {}
+"""Register static pages with predefined initial content from 'pages.yaml' file.
+
+Example:
+{
+    "about": "/about",
+    "terms": "/terms",
+    "privacy-policy": "/privacy-policy",
+}
+"""
 
 # Invenio-Stats
 # =============

--- a/invenio_app_rdm/theme/views.py
+++ b/invenio_app_rdm/theme/views.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2019-2020 Northwestern University.
 # Copyright (C)      2021 TU Wien.
 # Copyright (C) 2023-2024 Graz University of Technology.
+# Copyright (C)      2024 KTH Royal Institute of Technology.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -15,6 +16,7 @@ from flask_login import current_user
 from invenio_db import db
 from invenio_i18n import get_locale
 from invenio_i18n import lazy_gettext as _
+from invenio_pages.views import create_page_view
 from invenio_users_resources.forms import NotificationsForm
 
 
@@ -55,6 +57,7 @@ def create_blueprint(app):
     blueprint.add_url_rule(
         **create_url_rule(routes["help_versioning"], default_view_func=help_versioning)
     )
+    add_static_page_routes(blueprint, app)
 
     return blueprint
 
@@ -139,3 +142,11 @@ def handle_notifications_form(form):
     form.populate_obj(current_user)
     db.session.add(current_user)
     current_app.extensions["security"].datastore.commit()
+
+
+def add_static_page_routes(blueprint, app):
+    """Add custom page routes to the blueprint from the app configuration."""
+    for endpoint, path in app.config["APP_RDM_PAGES"].items():
+        blueprint.add_url_rule(
+            path, endpoint=endpoint, view_func=create_page_view(path)
+        )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
+#
+# Invenio-RDM is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from invenio_app_rdm.theme.views import add_static_page_routes
+
+
+def test_add_static_page_routes():
+    """Test add_static_page_routes function."""
+
+    # Mocking the blueprint and app objects
+    mock_blueprint = Mock()
+    mock_app = Mock()
+    mock_app.config = {"APP_RDM_PAGES": {"endpoint1": "/path1", "endpoint2": "/path2"}}
+
+    # Mocking the create_page_view function
+    with patch("invenio_app_rdm.theme.views.create_page_view") as mock_create_page_view:
+        mock_create_page_view.side_effect = lambda x: f"view_func_{x}"
+
+        add_static_page_routes(mock_blueprint, mock_app)
+
+    mock_blueprint.add_url_rule.assert_any_call(
+        "/path1", endpoint="endpoint1", view_func="view_func_/path1"
+    )
+    mock_blueprint.add_url_rule.assert_any_call(
+        "/path2", endpoint="endpoint2", view_func="view_func_/path2"
+    )
+
+    # Check if was called with the right arguments
+    mock_create_page_view.assert_any_call("/path1")
+    mock_create_page_view.assert_any_call("/path2")
+
+    # Check if was called the right number of times
+    assert mock_blueprint.add_url_rule.call_count == 2


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Introduced `APP_RDM_PAGES` dict in `config.py` to register static pages that can be overridden on the instance level.
* Added `add_static_page_routes` in `views.py` to dynamically add page routes based on the `APP_RDM_PAGES` configuration.
* Created unit tests in `test_views.py`.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
