### PR TITLE
config: vocabularies Datastream common ROR readers

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -101,6 +101,9 @@ from invenio_vocabularies.contrib.awards.datastreams import (
 from invenio_vocabularies.contrib.awards.datastreams import (
     VOCABULARIES_DATASTREAM_WRITERS as AWARDS_WRITERS,
 )
+from invenio_vocabularies.contrib.common.ror.datastreams import (
+    VOCABULARIES_DATASTREAM_READERS as COMMON_ROR_READERS,
+)
 from invenio_vocabularies.contrib.funders.datastreams import (
     VOCABULARIES_DATASTREAM_TRANSFORMERS as FUNDERS_TRANSFORMERS,
 )
@@ -658,6 +661,7 @@ REST_CSRF_ENABLED = True
 VOCABULARIES_DATASTREAM_READERS = {
     **VOCABULARIES_DATASTREAM_READERS,
     **NAMES_READERS,
+    **COMMON_ROR_READERS,
 }
 """Data Streams readers."""
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,8 +63,8 @@ install_requires =
     invenio-previewer>=2.2.0,<3.0.0
     invenio-records-files>=1.2.1,<2.0.0
     # Invenio-App-RDM
-    invenio-communities>=13.0.0,<14.0.0
-    invenio-rdm-records>=10.0.0,<11.0.0
+    invenio-communities>=14.0.0,<15.0.0
+    invenio-rdm-records>=11.0.0,<12.0.0
     CairoSVG>=2.5.2,<3.0.0
     invenio-banners>=3.0.0,<4.0.0
     invenio-pages>=4.0.0,<5.0.0


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Fixes inveniosoftware/invenio-vocabularies#311
* Fixes inveniosoftware/invenio-vocabularies#333
* Configures the common ROR readers defined in inveniosoftware/invenio-vocabularies#315
    * **Needs the aforementioned pull request in `invenio-vocabularies` to be released** for the CI to be green.
    * ~~Once merged, the changes in inveniosoftware/invenio-vocabularies#320 should work.~~
    * Once merged, the changes in inveniosoftware/invenio-vocabularies#331 should work.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
