### PR TITLE
config: vocabularies Datastream awards readers

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -96,6 +96,9 @@ from invenio_vocabularies.config import (
     VOCABULARIES_DATASTREAM_WRITERS,
 )
 from invenio_vocabularies.contrib.awards.datastreams import (
+    VOCABULARIES_DATASTREAM_READERS as AWARDS_READERS,
+)
+from invenio_vocabularies.contrib.awards.datastreams import (
     VOCABULARIES_DATASTREAM_TRANSFORMERS as AWARDS_TRANSFORMERS,
 )
 from invenio_vocabularies.contrib.awards.datastreams import (
@@ -662,6 +665,7 @@ VOCABULARIES_DATASTREAM_READERS = {
     **VOCABULARIES_DATASTREAM_READERS,
     **NAMES_READERS,
     **COMMON_ROR_READERS,
+    **AWARDS_READERS,
 }
 """Data Streams readers."""
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Fixes inveniosoftware/invenio-vocabularies#324
* Configures the awards readers defined in inveniosoftware/invenio-vocabularies#326
    * :heavy_check_mark: Needs the aforementioned pull request to be released for the CI to be green.
    * ~~Once merged, the changes in inveniosoftware/invenio-vocabularies#328 should work.~~
    * Once merged, we could use it in a celery task (similar to what has been done in inveniosoftware/invenio-vocabularies#331)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
