### PR TITLE
ui: rework secret links tab

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/draft_not_found.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/draft_not_found.html
@@ -1,0 +1,17 @@
+{#
+  Copyright (C) 2024 CERN.
+
+  Invenio App RDM is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% extends config.THEME_ERROR_TEMPLATE %}
+
+{%- set title = _("Draft not found") + " | " + config.THEME_SITENAME -%}
+{%- set record_link = record_id %}
+
+{%- block message %}
+  <h1><i class="bolt icon"></i> {{_('Draft not found')}}</h1>
+  <p>{{_('This record has already been published. Currently, it is not being edited, so no draft is created for it.')}}</p>
+  <a href="{{ record_link }}"> {{ _('Go to published record') }}</a>
+{% endblock message %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/draft_not_found.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/draft_not_found.html
@@ -12,6 +12,6 @@
 
 {%- block message %}
   <h1><i class="bolt icon"></i> {{_('Draft not found')}}</h1>
-  <p>{{_('This record has already been published. Currently, it is not being edited, so no draft is created for it.')}}</p>
+  <p>{{_('This record has already been published and is not currently being edited, so no draft exists.')}}</p>
   <a href="{{ record_link }}"> {{ _('Go to published record') }}</a>
 {% endblock message %}

--- a/invenio_app_rdm/records_ui/views/__init__.py
+++ b/invenio_app_rdm/records_ui/views/__init__.py
@@ -10,6 +10,7 @@
 """Views related to records and deposits."""
 
 from flask import Blueprint
+from invenio_drafts_resources.resources.records.errors import DraftNotCreatedError
 from invenio_pidstore.errors import (
     PIDDeletedError,
     PIDDoesNotExistError,
@@ -43,6 +44,7 @@ from .filters import (
     truncate_number,
 )
 from .records import (
+    draft_not_found_error,
     not_found_error,
     record_detail,
     record_export,
@@ -158,6 +160,7 @@ def create_blueprint(app):
     blueprint.register_error_handler(PIDUnregistered, not_found_error)
     blueprint.register_error_handler(KeyError, not_found_error)
     blueprint.register_error_handler(FileKeyNotFoundError, not_found_error)
+    blueprint.register_error_handler(DraftNotCreatedError, draft_not_found_error)
     blueprint.register_error_handler(
         PermissionDeniedError, record_permission_denied_error
     )

--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -386,6 +386,17 @@ def not_found_error(error):
     return render_template(current_app.config["THEME_404_TEMPLATE"]), 404
 
 
+def draft_not_found_error(error):
+    """Handler for draft not found while published record exists."""
+    return (
+        render_template(
+            "invenio_app_rdm/records/draft_not_found.html",
+            record_id=error.pid_value,
+        ),
+        404,
+    )
+
+
 def record_tombstone_error(error):
     """Tombstone page."""
     # the RecordDeletedError will have the following properties,

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessLinks/CreateAccessLink.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessLinks/CreateAccessLink.js
@@ -10,21 +10,22 @@ import PropTypes from "prop-types";
 import { Table, Input, Dropdown, Button, Icon, Grid } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 import { dropdownOptions } from "./LinksSearchResultContainer";
-import { dropdownOptionsGenerator } from "react-invenio-forms";
 
 export class CreateAccessLink extends Component {
   constructor(props) {
     super(props);
+    const { record } = this.props;
+    const isDraft = record?.is_draft || record?.is_draft === null;
     this.state = {
       description: undefined,
       expiresAt: undefined,
-      permission: dropdownOptions[0].key,
+      permission: isDraft ? dropdownOptions[1].key : dropdownOptions[0].key, // "can view" option is disabled for drafts
     };
   }
 
   render() {
     const { permission, expiresAt, description } = this.state;
-    const { handleCreation, loading } = this.props;
+    const { handleCreation, loading, dropdownOptions } = this.props;
     return (
       <Table.Row>
         <Table.Cell width={16}>
@@ -64,7 +65,7 @@ export class CreateAccessLink extends Component {
                 fluid
                 selection
                 onChange={(event, data) => this.setState({ permission: data.value })}
-                options={dropdownOptionsGenerator(dropdownOptions)}
+                options={dropdownOptions}
                 defaultValue={permission}
               />
             </Grid.Column>
@@ -92,4 +93,6 @@ export class CreateAccessLink extends Component {
 CreateAccessLink.propTypes = {
   handleCreation: PropTypes.func.isRequired,
   loading: PropTypes.bool.isRequired,
+  dropdownOptions: PropTypes.array.isRequired,
+  record: PropTypes.object.isRequired,
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessLinks/LinksSearchResultContainer.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessLinks/LinksSearchResultContainer.js
@@ -14,6 +14,8 @@ import { withCancel } from "react-invenio-forms";
 import { http } from "react-invenio-forms";
 import { CreateAccessLink } from "./CreateAccessLink";
 import { LinksSearchItem } from "./LinksSearchItem";
+import { dropdownOptionsGenerator } from "react-invenio-forms";
+import _cloneDeep from "lodash/cloneDeep";
 
 export const dropdownOptions = [
   {
@@ -118,6 +120,26 @@ export class LinksSearchResultContainer extends Component {
     }
   };
 
+  generateDropdownOptions = () => {
+    const { record } = this.props;
+
+    // "can view" option is disabled for drafts
+    const dropdownOptionsCopy = _cloneDeep(dropdownOptions);
+    if (record?.is_draft || record?.is_draft === null) {
+      const viewOption = dropdownOptionsCopy.find((item) => item.key === "view");
+      viewOption.text = i18next.t(
+        "Can view (view access link can be created only after the record is published)"
+      );
+    }
+
+    const options = dropdownOptionsGenerator(dropdownOptionsCopy);
+    if (record?.is_draft || record?.is_draft === null) {
+      const viewOption = options.find((item) => item.key === "view");
+      viewOption.disabled = true;
+    }
+    return options;
+  };
+
   render() {
     const { results, record, onItemAddedOrDeleted, onPermissionChanged } = this.props;
     const { loading, error } = this.state;
@@ -154,6 +176,11 @@ export class LinksSearchResultContainer extends Component {
                   record={record}
                   onItemAddedOrDeleted={onItemAddedOrDeleted}
                   onPermissionChanged={onPermissionChanged}
+                  dropdownOptions={
+                    result.permission === "view"
+                      ? dropdownOptionsGenerator(dropdownOptions)
+                      : this.generateDropdownOptions()
+                  }
                 />
               ))
             ) : (
@@ -169,7 +196,12 @@ export class LinksSearchResultContainer extends Component {
         </Table>
 
         <Table color="green">
-          <CreateAccessLink handleCreation={this.handleCreation} loading={loading} />
+          <CreateAccessLink
+            handleCreation={this.handleCreation}
+            loading={loading}
+            record={record}
+            dropdownOptions={this.generateDropdownOptions()}
+          />
         </Table>
       </>
     );

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/ShareModal.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/ShareModal.js
@@ -96,6 +96,11 @@ export class ShareModal extends Component {
       if (grant.subject.type === "role") groups.push(grant);
     });
 
+    const links = [];
+    record.parent?.access?.links?.forEach((link) => {
+      if (link.id !== null) links.push(link);
+    });
+
     const panes = [
       {
         menuItem: (
@@ -145,7 +150,7 @@ export class ShareModal extends Component {
           <MenuItem key="accessLinks">
             <Icon name="linkify" />
             {i18next.t("Links")}
-            <Label size="tiny">{record.parent?.access?.links?.length}</Label>
+            <Label size="tiny">{links?.length}</Label>
           </MenuItem>
         ),
         render: () => (


### PR DESCRIPTION
* introduce an error handler and a jinja template for drafts not found when published record exists
* gray out "can view" permission in share drafts
* rework links that are being copied in links tab
* closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2694

Previews:

Draft not found error page:
![Screenshot 2024-06-11 at 16 07 52](https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/94544ad1-dfdd-42e3-a296-caeeb0361d6a)

Dropdown with grayed out "view" option and the explanation
![Screenshot 2024-06-11 at 16 11 11](https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/131854fd-4b87-4c59-8679-a1d1dc39954b)

Flow:
![links](https://github.com/inveniosoftware/invenio-app-rdm/assets/61321254/6abc9e59-e825-4150-9713-c88a9b469478)

