### PR TITLE
cli: improve rebuild indices command

### DIFF
--- a/invenio_app_rdm/cli.py
+++ b/invenio_app_rdm/cli.py
@@ -81,5 +81,14 @@ def rebuild_all_indices(order):
         service = services[service_to_reindex]
         if hasattr(service, "rebuild_index"):
             click.echo(f"Reindexing {service_to_reindex}... ", nl=False)
-            service.rebuild_index(system_identity)
-            click.secho("Done.", fg="green")
+            try:
+                service.rebuild_index(system_identity)
+            except NotImplementedError:
+                click.secho(
+                    f"{service_to_reindex} does not use the search cluster, skipping.",
+                    fg="green",
+                )
+                continue
+            else:
+                # success
+                click.secho("Done.", fg="green")


### PR DESCRIPTION
* Skips services that don't implement the rebuild_index method, often because they inherit some record service features but don't handle records
* closes #2741