### PR TITLE
fix(landing-page): link to contributor search

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
@@ -36,7 +36,7 @@
           <div>
             <h3 class="creatibutors-header ui small header">{{group.grouper}}{%- if group.list|length > 1 -%}s{%- endif -%}:</h3>
             <ul class="creatibutors">
-              {{ show_creatibutors(group.list, show_affiliations=True) }}
+              {{ show_creatibutors(group.list, show_affiliations=True, type="contributors") }}
             </ul>
           </div>
           {%- endfor %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
@@ -37,14 +37,14 @@
 {% endmacro %}
 
 
-{% macro show_creatibutors(creatibutors, show_affiliations=False) %}
+{% macro show_creatibutors(creatibutors, show_affiliations=False, type="creators") %}
   {% for creatibutor in creatibutors %}
   <li class="creatibutor-wrap separated">
     <a class="ui creatibutor-link"
       {% if show_affiliations and creatibutor.affiliations %}
         data-tooltip="{{ creatibutor.affiliations|join('; ', attribute='1') }}"
       {% endif %}
-      href="{{url_for('invenio_search_ui.search', q='metadata.creators.person_or_org.name:"' + creatibutor.person_or_org.name + '"')}}"
+      href="{{url_for('invenio_search_ui.search', q='metadata.' + type + '.person_or_org.name:"' + creatibutor.person_or_org.name + '"')}}"
     >
 
       <span class="creatibutor-name">


### PR DESCRIPTION
* since one macro is used for contributor and creator the link is set to
  creators.

* this has been fixed now with an additional parameter

NOTE:
fixes https://github.com/inveniosoftware/invenio-app-rdm/issues/2247
