### PR TITLE
dependencies: bump invenio-cache minimum for v12+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     # Invenio core modules
     invenio-app>=1.4.0,<2.0.0
     invenio-base>=1.3.0,<2.0.0
-    invenio-cache>=1.1.1,<2.0.0
+    invenio-cache>=1.3.0,<2.0.0
     invenio-celery>=1.2.4,<2.0.0
     invenio-config>=1.0.3,<2.0.0
     invenio-i18n>=2.0.0,<3.0.0


### PR DESCRIPTION
invenio-cache >= 1.3.0 is needed in InvenioRDM v12+ for invenio-vocabularies for example (see https://github.com/inveniosoftware/invenio-vocabularies/blob/master/invenio_vocabularies/services/facets.py#L12 ) .

This should be backported to maint-v12 when accepted. I can do that then or wait for more patches to come in since the workaround is to specify invenio-cache >= 1.3.0 in instance's Pipfile. 