### PR TITLE
config: import affiliations vocabulary readers

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -97,6 +97,9 @@ from invenio_vocabularies.config import (
     VOCABULARIES_DATASTREAM_WRITERS,
 )
 from invenio_vocabularies.contrib.affiliations.datastreams import (
+    VOCABULARIES_DATASTREAM_READERS as AFFILIATIONS_READERS,
+)
+from invenio_vocabularies.contrib.affiliations.datastreams import (
     VOCABULARIES_DATASTREAM_TRANSFORMERS as AFFILIATIONS_TRANSFORMERS,
 )
 from invenio_vocabularies.contrib.affiliations.datastreams import (
@@ -707,6 +710,7 @@ VOCABULARIES_DATASTREAM_READERS = {
     **COMMON_ROR_READERS,
     **AWARDS_READERS,
     **FUNDERS_READERS,
+    **AFFILIATIONS_READERS,
 }
 """Data Streams readers."""
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

Partially fixes inveniosoftware/invenio-vocabularies#382

### Description

The pull request #2755 imported vocabularies readers, transformers, writers consistently.
I found that the affiliations readers was forgotten and not imported; this pull requests fills in this gap.

Currently, [`VOCABULARIES_DATASTREAM_READERS` is empty](https://github.com/ptamarit/invenio-vocabularies/blob/master/invenio_vocabularies/contrib/affiliations/datastreams.py#L49-L50), but I might define affiliations-specific readers as part of inveniosoftware/invenio-vocabularies#382.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
