### PR TITLE
migrate to v12: emit non-zero exit code on error

### DIFF
--- a/invenio_app_rdm/upgrade_scripts/migrate_11_0_to_12_0.py
+++ b/invenio_app_rdm/upgrade_scripts/migrate_11_0_to_12_0.py
@@ -38,6 +38,7 @@ This script has been tested with following data:
   - drafts visible
   - records visible
 """
+import sys
 
 from click import secho
 from flask import current_app
@@ -183,6 +184,8 @@ def execute_upgrade():
             "Please fix the above listed errors and try the upgrade again",
         )
         secho(msg, fg="yellow", err=True)
+
+        sys.exit(1)
 
 
 # if the script is executed on its own, perform the upgrade


### PR DESCRIPTION
This is a convenience for automated upgrades to be able to detect
errored command from the outside.
