### PR TITLE
theme: adjust padding for community logo on record landing page

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/container.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/container.overrides
@@ -9,7 +9,6 @@
   margin-bottom: @defaultMargin;
 
   &.with-submenu {
-    padding-bottom: 0;
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> The behavior described in this issue can also be observed on Zenodo. An example is the following record: https://zenodo.org/records/11170937

The `.with-submenu` class includes a `padding-bottom` that, depending on the logo, can bring it closer to the bottom of the gray box:

![community-logo-issue](https://github.com/user-attachments/assets/c175738b-65b1-4e33-acd3-7b68256747a0)

The default community logo is also affected by this issue:

![community-logo-issue-example](https://github.com/user-attachments/assets/af7154ac-d658-4a1b-b95f-8ad0feab9653)

This PR addresses the issue by removing the `padding-bottom` from the `.with-submenu` class. The figure below shows the behavior after the proposed change.

![community-logo-issue-fixed](https://github.com/user-attachments/assets/05c940b2-c6f7-4c8e-be41-4ce510d98622)

Also, the GIF below presents the modified version on multiple devices:

![example](https://github.com/user-attachments/assets/44863d12-f674-4d3e-810c-4e74fd780cd4)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [X] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
