### PR TITLE
share-modal: account for system created records

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessUsersGroups/AccessUsersGroups.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessUsersGroups/AccessUsersGroups.js
@@ -91,7 +91,7 @@ export class AccessUsersGroups extends Component {
                   </Table.Row>
                 </Table.Header>
                 <Table.Body>
-                  {searchType === "user" && (
+                  {searchType === "user" && recOwner && (
                     <Table.Row>
                       <Table.Cell width={8}>
                         <Grid textAlign="left" verticalAlign="middle">

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/ShareModal.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/ShareModal.js
@@ -89,17 +89,13 @@ export class ShareModal extends Component {
     const { handleClose, groupsEnabled } = this.props;
     const { linksResults, groupsResults, usersResults } = this.state;
 
-    const users = [];
-    const groups = [];
+    let numUsers = 0;
+    let numGroups = 0;
     record.parent?.access?.grants?.forEach((grant) => {
-      if (grant.subject.type === "user") users.push(grant);
-      if (grant.subject.type === "role") groups.push(grant);
+      if (grant.subject.type === "user") numUsers++;
+      if (grant.subject.type === "role") numGroups++;
     });
-
-    const links = [];
-    record.parent?.access?.links?.forEach((link) => {
-      if (link.id !== null) links.push(link);
-    });
+    if (record?.expanded?.parent?.access?.owned_by) numUsers++;
 
     const panes = [
       {
@@ -107,7 +103,7 @@ export class ShareModal extends Component {
           <MenuItem key="accessUsers">
             <Icon name="user" />
             {i18next.t("People")}
-            <Label size="tiny">{users?.length + 1}</Label>
+            <Label size="tiny">{numUsers}</Label>
           </MenuItem>
         ),
         render: () => (
@@ -122,13 +118,14 @@ export class ShareModal extends Component {
         ),
       },
     ];
+
     if (groupsEnabled) {
       panes.push({
         menuItem: (
           <MenuItem key="accessGroups">
             <Icon name="users" />
             {i18next.t("Groups")}
-            <Label size="tiny">{groups?.length}</Label>
+            <Label size="tiny">{numGroups}</Label>
           </MenuItem>
         ),
         render: () => (
@@ -144,13 +141,18 @@ export class ShareModal extends Component {
       });
     }
 
+    let numLinks = 0;
+    record.parent?.access?.links?.forEach((link) => {
+      if (link.id !== null) numLinks++;
+    });
+
     panes.push(
       {
         menuItem: (
           <MenuItem key="accessLinks">
             <Icon name="linkify" />
             {i18next.t("Links")}
-            <Label size="tiny">{links?.length}</Label>
+            <Label size="tiny">{numLinks}</Label>
           </MenuItem>
         ),
         render: () => (


### PR DESCRIPTION
Records may have no owner (`owned_by` undefined on the frontend) when the record has been created by the system. This PR accounts for that + simplify count computation on tabs.

before:
 
[no_owner.webm](https://github.com/user-attachments/assets/5c3e5e71-b084-4293-9a14-53b99365d516)

after the modal opens as it's supposed to.