### PR TITLE
Deposit form: Provide props to overridable components

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -128,7 +128,10 @@ export class RDMDepositForm extends Component {
           />
         </Overridable>
 
-        <Overridable id="InvenioAppRdm.Deposit.CommunityHeader.container">
+        <Overridable
+          id="InvenioAppRdm.Deposit.CommunityHeader.container"
+          record={record}
+        >
           {!this.hide_community_selection && (
             <CommunityHeader
               imagePlaceholderLink="/static/images/square-placeholder.png"
@@ -159,6 +162,8 @@ export class RDMDepositForm extends Component {
                     id="InvenioAppRdm.Deposit.FileUploader.container"
                     record={record}
                     config={this.config}
+                    permissions={permissions}
+                    filesLocked={filesLocked}
                   >
                     <FileUploader
                       isDraftRecord={!record.is_published}
@@ -574,6 +579,7 @@ export class RDMDepositForm extends Component {
               {!_isEmpty(customFieldsUI) && (
                 <Overridable
                   id="InvenioAppRdm.Deposit.CustomFields.container"
+                  record={record}
                   customFieldsUI={customFieldsUI}
                 >
                   <CustomFields
@@ -598,7 +604,12 @@ export class RDMDepositForm extends Component {
                 className="deposit-sidebar"
               >
                 <Sticky context={this.sidebarRef} offset={20}>
-                  <Overridable id="InvenioAppRdm.Deposit.CardDepositStatusBox.container">
+                  <Overridable
+                    id="InvenioAppRdm.Deposit.CardDepositStatusBox.container"
+                    record={record}
+                    permissions={permissions}
+                    groupsEnabled={groupsEnabled}
+                  >
                     <Card>
                       <Card.Content>
                         <DepositStatusBox />
@@ -641,6 +652,10 @@ export class RDMDepositForm extends Component {
                   <Overridable
                     id="InvenioAppRdm.Deposit.AccessRightField.container"
                     fieldPath="access"
+                    record={record}
+                    permissions={permissions}
+                    recordRestrictionGracePeriod={recordRestrictionGracePeriod}
+                    allowRecordRestriction={allowRecordRestriction}
                   >
                     <AccessRightField
                       label={i18next.t("Visibility")}


### PR DESCRIPTION
Some of the `<Overridable>` components have been using values that weren't passed as props.
This makes it hard to provide overrides for those components that are functionally the same.

For example, I am writing an override for the `InvenioAppRdm.Deposit.CardDepositStatusBox.container` for [`Invenio-Curations`](https://github.com/tu-graz-library/invenio-curations/) which adds a section for the curation review request.
Without passing the props, this override couldn't access the `props.permissions` which is used by the default component to enable/disable some buttons.

With the props being passed, I can use it as expected:
![image](https://github.com/user-attachments/assets/8f9e1f2e-51cd-48a5-9935-b0d55acff9a4)