### PR TITLE
Upgrade script: Mint the new concept DOI for each upgraded record

### DIFF
--- a/invenio_app_rdm/upgrade_scripts/migrate_11_0_to_12_0.py
+++ b/invenio_app_rdm/upgrade_scripts/migrate_11_0_to_12_0.py
@@ -94,6 +94,12 @@ def execute_upgrade():
                     record.parent, pids
                 )
                 record.parent["pids"] = pids
+                current_rdm_records.records_service.pids.register_or_update(
+                    id_=record["id"],
+                    identity=system_identity,
+                    scheme="doi",
+                    parent=True,
+                )
 
     def update_record(record):
         # skipping deleted records because can't be committed


### PR DESCRIPTION
Previously, the script would create a new concept DOI for each record but never actually mint them on DataCite.
The [`TaskOp` part from the PIDs service component](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/services/components/pids.py#L204) was missing, which called the [`register_or_update_pid` task](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/services/pids/tasks.py#L17).