### PR TITLE
replace view_func with default_view_func to make APP_RDM_USER_DASHBOARD_ROUTES overwriteable

### DIFF
--- a/invenio_app_rdm/users_ui/views/ui.py
+++ b/invenio_app_rdm/users_ui/views/ui.py
@@ -14,6 +14,7 @@ from flask_login import current_user
 
 from ..searchapp import search_app_context
 from .dashboard import communities, requests, uploads
+from invenio_app_rdm.theme.views import create_url_rule
 
 
 #
@@ -47,19 +48,25 @@ def create_ui_blueprint(app):
     )
 
     blueprint.add_url_rule(
-        routes["uploads"],
-        view_func=uploads,
+        **create_url_rule(
+            routes["uploads"],
+            default_view_func=uploads,
+        )
     )
 
     # Settings tab routes
     blueprint.add_url_rule(
-        routes["communities"],
-        view_func=communities,
+        **create_url_rule(
+            routes["communities"],
+            default_view_func=communities,
+        )
     )
 
     blueprint.add_url_rule(
-        routes["requests"],
-        view_func=requests,
+        **create_url_rule(
+            routes["requests"],
+            default_view_func=requests,
+        )
     )
 
     # Register context processor


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This change makes[ `APP_RDM_USER_DASHBOARD_ROUTES`](https://github.com/inveniosoftware/invenio-app-rdm/blob/56893c6a21e6ff58dd6732fa77ae34554c263a7b/invenio_app_rdm/config.py#L766) configurable by using an approach like this in invenio.cfg:

```
from invenio_app_rdm.config import APP_RDM_ROUTES
from invenio_app_rdm.config import APP_RDM_USER_DASHBOARD_ROUTES
from mysite.views import custom_render
APP_RDM_ROUTES["index"] = ("/", custom_render)
APP_RDM_USER_DASHBOARD_ROUTES["uploads"] = ("/me/uploads", custom_render)
```
