### PR TITLE
search-result: fix issues

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/communityRecordsSearch/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/communityRecordsSearch/index.js
@@ -1,5 +1,6 @@
 // This file is part of Invenio
 // Copyright (C) 2022 CERN.
+// Copyright (C) 2024 Northwestern University.
 //
 // Invenio is free software; you can redistribute it and/or modify it under the
 // terms of the MIT License; see LICENSE file for more details.
@@ -37,12 +38,16 @@ const CommunityRecordSearchAppLayoutWAppName = parametrize(
   }
 );
 
+const CommunityRecordsResultsListItem = parametrize(RecordsResultsListItem, {
+  appName: appName,
+});
+
 const defaultComponents = {
   [`${appName}.BucketAggregation.element`]: ContribBucketAggregationElement,
   [`${appName}.BucketAggregationValues.element`]: ContribBucketAggregationValuesElement,
   [`${appName}.ResultsGrid.item`]: RDMRecordResultsGridItem,
   [`${appName}.EmptyResults.element`]: RDMEmptyResults,
-  [`${appName}.ResultsList.item`]: RecordsResultsListItem,
+  [`${appName}.ResultsList.item`]: CommunityRecordsResultsListItem,
   [`${appName}.SearchApp.facets`]: ContribSearchAppFacetsWithConfig,
   [`${appName}.SearchApp.layout`]: CommunityRecordSearchAppLayoutWAppName,
   [`${appName}.SearchBar.element`]: CommunityRecordsSearchBarElement,

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/DisplayPartOfCommunities.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/DisplayPartOfCommunities.js
@@ -4,7 +4,7 @@
 // Invenio App RDM is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import React from "react";
+import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 
@@ -20,12 +20,12 @@ export const DisplayPartOfCommunities = ({ communities }) => {
           {i18next.t("Part of ")}
           {communitiesEntries.map((community, index) => {
             return (
-              <>
+              <Fragment key={community.slug}>
                 <a href={`/communities/${community.slug}`}>
                   {community.metadata?.title}
                 </a>
                 {index !== communitiesEntries.length - 1 && ", "}
-              </>
+              </Fragment>
             );
           })}
         </>


### PR DESCRIPTION
- Fix: overridable id for community `RecordsResultsListItem.layout` wasn't namespaced because lack of `appName` 
- Fix: `Warning: Each child in a list should have a unique "key" prop.`