### PR TITLE
deps: raise lower pin of invenio-rdm-records

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@
 Changes
 =======
 
+Version 12.0.9 (released 2024-09-23)
+
+- setup: bump minimum required invenio-rdm-records version
+
 Version 12.0.8 (released 2024-09-19)
 
 - deposit: provide and check publish permission for visibility

--- a/invenio_app_rdm/__init__.py
+++ b/invenio_app_rdm/__init__.py
@@ -17,6 +17,6 @@
 #
 # See PEP 0440 for details - https://www.python.org/dev/peps/pep-0440
 
-__version__ = "12.0.8"
+__version__ = "12.0.9"
 
 __all__ = ("__version__",)

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ install_requires =
     invenio-records-files>=1.2.1,<2.0.0
     # Invenio-App-RDM
     invenio-communities>=13.0.0,<14.0.0
-    invenio-rdm-records>=10.0.0,<11.0.0
+    invenio-rdm-records>=10.8.3,<11.0.0
     CairoSVG>=2.5.2,<3.0.0
     invenio-banners>=3.0.0,<4.0.0
     invenio-pages>=4.0.0,<5.0.0


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

GuestAccessNotifications are directly imported from invenio-rdm-records which only have been added in v10.7.0.

Encountered this issue when setting up an instance with another package which had very loose dependencies (no upper pin of any package). v10.0.0 of rdm-records was installed, which still satisfied the current restriction but led to an error down the way when importing guest access notifications in `setup.cfg`, which have been added in v10.7.0.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
