### PR TITLE
remove flask upper pin

### DIFF
--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2019-2021 Northwestern University.
 # Copyright (C)      2021 TU Wien.
 # Copyright (C) 2022 KTH Royal Institute of Technology
-# Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2023-2024 Graz University of Technology.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -185,7 +185,7 @@ class VocabulariesOptions:
         """Dump subjects vocabulary (limitTo really)."""
         subjects = (
             VocabularyScheme.query.filter_by(parent_id="subjects")
-            .options(load_only("id"))
+            .options(load_only(VocabularyScheme.id))
             .all()
         )
         limit_to = [{"text": "All", "value": "all"}]


### PR DESCRIPTION
context: migrate to flask >= 3.0

- fix: remove DeprecationWarning for sqlalchemy
- setup: remove flask upper pin

* the sqlalchemy commit is here because without upgrading sqlalchemy it is not possible to go to flask >= 2.3

* the remove of invenio-admin is not part of the migration to flask >= 3.0 because the problem with the app.before_first_request has been fixed in invenio-admin. nevertheless the PR for it should be merged!