### PR TITLE
Webpack: Configure copy patterns for TinyMCE

### DIFF
--- a/invenio_app_rdm/theme/webpack.py
+++ b/invenio_app_rdm/theme/webpack.py
@@ -72,6 +72,22 @@ theme = WebpackThemeBundle(
                 "@js/invenio_app_rdm": "js/invenio_app_rdm",
                 "@translations/invenio_app_rdm": "translations/invenio_app_rdm",
             },
+            copy=[
+                # Copy some assets into "static/dist", as TinyMCE requires that
+                # Note that the base path for all entries is the `config.json` directory
+                {
+                    "from": "../node_modules/tinymce/skins/content/default/content.css",
+                    "to": "../../static/dist/js/skins/content/default",
+                },
+                {
+                    "from": "../node_modules/tinymce/skins/ui/oxide/skin.min.css",
+                    "to": "../../static/dist/js/skins/ui/oxide",
+                },
+                {
+                    "from": "../node_modules/tinymce/skins/ui/oxide/content.min.css",
+                    "to": "../../static/dist/js/skins/ui/oxide",
+                },
+            ],
         ),
     },
 )


### PR DESCRIPTION
This is part of the effort to make the `CopyWebpackPlugin` patterns configurable, to address the feedback in the PDF.js PR: https://github.com/inveniosoftware/invenio-previewer/pull/203

Requires https://github.com/inveniosoftware/invenio-assets/pull/173 and https://github.com/inveniosoftware/pywebpack/pull/45