### PR TITLE
browse: fix endpoint name.

### DIFF
--- a/invenio_app_rdm/ext.py
+++ b/invenio_app_rdm/ext.py
@@ -117,7 +117,7 @@ def init_menu(app):
         **dict(icon="home", permissions="can_read"),
     )
     communities.submenu("browse").register(
-        endpoint="invenio_communities.communities_browse",
+        endpoint="invenio_app_rdm_communities.communities_browse",
         text=_("Browse"),
         order=15,
         visible_when=_show_browse_page,


### PR DESCRIPTION
The endpoint did not exist, if the menu entry is enabled it blows up. 