### PR TITLE
assets: fix item description overflow issue

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/RecordsResultsListItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/RecordsResultsListItem.js
@@ -108,8 +108,8 @@ class RecordsResultsListItem extends Component {
             <Item className="creatibutors">
               <SearchItemCreators creators={creators} othersLink={viewLink} />
             </Item>
-            <Item.Description>
-              {_truncate(descriptionStripped, { length: 350 })}
+            <Item.Description className="truncate-lines-2">
+              {descriptionStripped}
             </Item.Description>
             <Item.Extra>
               {subjects.map((subject) => (

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
@@ -101,10 +101,8 @@ export const ComputerTabletUploadsItem = ({
             <SearchItemCreators creators={creators} />
           </div>
         </Item.Meta>
-        <Item.Description>
-          {_truncate(descriptionStripped, {
-            length: 350,
-          })}
+        <Item.Description className="truncate-lines-2">
+          {descriptionStripped}
         </Item.Description>
         <Item.Extra>
           {subjects.map((subject) => (

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/MobileUploadsItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/MobileUploadsItem.js
@@ -77,10 +77,8 @@ export const MobileUploadsItem = ({
             <SearchItemCreators creators={creators} />
           </div>
         </Item.Meta>
-        <Item.Description>
-          {_truncate(descriptionStripped, {
-            length: 100,
-          })}
+        <Item.Description className="truncate-lines-2">
+          {descriptionStripped}
         </Item.Description>
         <Item.Extra>
           <Item.Extra>

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/item.overrides
@@ -95,6 +95,7 @@
 
 .ui.items {
 
+
   &.link > .item:hover .content .header {
     color: @darkTextColor;
   }
@@ -109,6 +110,13 @@
     }
 
     .content {
+      .description.truncate-lines-2 {
+        display: -webkit-box !important;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+
       .header {
         &.flex {
           display: flex;


### PR DESCRIPTION
* addresses mathjax formulas truncation

Forced overflow (formula simply is hidden):
<img width="1586" alt="Screenshot 2024-10-10 at 12 30 59" src="https://github.com/user-attachments/assets/b58846c0-b6ea-42a0-a737-98ec5ba78688">

before forcing the overflow
<img width="1908" alt="Screenshot 2024-10-10 at 12 31 12" src="https://github.com/user-attachments/assets/3a3919d4-1401-476e-a1bb-6a86424f6e83">

