### PR TITLE
📦 release: v13.0.0b1.dev11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,18 @@
 Changes
 =======
 
+Version v13.0.0b1.dev11 (released 2024-10-15)
+
+- config: vocabularies Datastream common OpenAIRE
+
+Version v13.0.0b1.dev10 (released 2024-10-10)
+
+- webpack: bump react-searchkit due to axios major upgrade
+- setup: bump invenio-search-ui due to axios major upgrade
+- assets: fix item description overflow issue
+    * addresses mathjax formulas truncation
+- browse: fix endpoint name.
+
 Version v13.0.0b1.dev9 (released 2024-10-08)
 
 - installation: bump invenio-communities & invenio-rdm-records

--- a/invenio_app_rdm/__init__.py
+++ b/invenio_app_rdm/__init__.py
@@ -17,6 +17,6 @@
 #
 # See PEP 0440 for details - https://www.python.org/dev/peps/pep-0440
 
-__version__ = "13.0.0b1.dev10"
+__version__ = "13.0.0b1.dev11"
 
 __all__ = ("__version__",)


### PR DESCRIPTION
Also adding missing changelog from `v13.0.0b1.dev10`.