### PR TITLE
communities-ui: verified icon display logic change and deterministic sorting

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -72,7 +72,8 @@
                   href="{{ url_for('invenio_app_rdm_communities.communities_detail', pid_value=community.slug) }}" class="ui small header">
                     {{ community.metadata.title }}
                   </a>
-                  {% if community.parent and community.parent.is_verified %}
+                  <!-- Show the icon for subcommunities -->
+                  {% if community.parent %}
                     <p class="ml-2 mb-0 display-inline-block"><i class="green check circle outline icon"></i></p>
                   {% endif %}
                   {% if community.parent %}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/DisplayPartOfCommunities.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/DisplayPartOfCommunities.js
@@ -13,9 +13,31 @@ export const DisplayPartOfCommunities = ({ communities }) => {
   const PartOfCommunities = () => {
     // FIXME: Uncomment to enable themed banner
     // const communitiesEntries = communities.entries?.filter((community) => !(community.id === communities?.default && community?.theme));
-    const communitiesEntries = communities.entries;
+    let communitiesEntries = communities.entries;
 
     if (communitiesEntries?.length > 0) {
+      communitiesEntries = communitiesEntries.sort((a, b) => {
+        // Put parent communities before other communities.
+        if (
+          a.children !== undefined &&
+          b.children !== undefined &&
+          a.children.allow !== b.children.allow
+        ) {
+          return a.children.allow ? -1 : 1;
+        }
+        // Put subcommunities before regular communities.
+        if ((a.parent !== undefined) !== (b.parent !== undefined)) {
+          return a.parent !== undefined ? -1 : 1;
+        }
+        // Then sort communities by their title.
+        const titleCompare = a.metadata?.title.localeCompare(b.metadata?.title);
+        if (titleCompare !== undefined && titleCompare !== 0) {
+          return titleCompare;
+        }
+        // Finally if all else is equal, sort by slug (which is unique).
+        return a.slug.localeCompare(b.slug);
+      });
+
       return (
         <>
           {i18next.t("Part of ")}
@@ -26,7 +48,8 @@ export const DisplayPartOfCommunities = ({ communities }) => {
                   {community.metadata?.title}
                 </a>
                 <span>&nbsp;</span>
-                {community.parent?.is_verified && (
+                {/* Show the icon for communities allowing children, and for subcommunities */}
+                {(community.children?.allow || community.parent !== undefined) && (
                   <Popup
                     trigger={<Icon name="check outline circle" color="green mr-0" />}
                     content="Verified community"

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesList.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesList.js
@@ -67,7 +67,9 @@ export class RecordCommunitiesList extends Component {
                   <Item.Header className="ui">
                     <Header as="a" href={community.links.self_html} size="small">
                       {community.metadata.title}
-                      {community.parent?.is_verified && (
+                      {/* Show the icon for communities allowing children, and for subcommunities */}
+                      {(community.children?.allow ||
+                        community.parent !== undefined) && (
                         <p className="ml-5 display-inline-block">
                           <Popup
                             content="Verified community"


### PR DESCRIPTION
:heart: Thank you for your contribution!

Partially fixes inveniosoftware/invenio-communities#1234
Second iteration on changes in #2883

### Description

* Not relying on the verified field which is not serialized for non admins
* Showing an icon next to parent communities too
* Deterministic sorting of communities

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
