### PR TITLE
pass config to deposit_create and deposit_edit

### DIFF
--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -385,12 +385,14 @@ def deposit_create(community=None):
         community_theme = community.get("theme", {})
 
     community_use_jinja_header = bool(community_theme)
-    dashboard_route = current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"]["uploads"]
+    dashboard_uploads_route = current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"][
+        "uploads"
+    ]
     return render_community_theme_template(
         current_app.config["APP_RDM_DEPOSIT_FORM_TEMPLATE"],
         theme=community_theme,
         forms_config=get_form_config(
-            dashboard_route=dashboard_route,
+            dashboard_uploads_route=dashboard_uploads_route,
             createUrl="/api/records",
             quota=get_files_quota(),
             hide_community_selection=community_use_jinja_header,
@@ -451,13 +453,15 @@ def deposit_edit(pid_value, draft=None, draft_files=None, files_locked=True):
     # for unpublished records we fallback to the react component so users can change
     # communities
     community_use_jinja_header = bool(community_theme)
-    dashboard_route = current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"]["uploads"]
+    dashboard_uploads_route = current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"][
+        "uploads"
+    ]
     return render_community_theme_template(
         current_app.config["APP_RDM_DEPOSIT_FORM_TEMPLATE"],
         theme=community_theme,
         forms_config=get_form_config(
             apiUrl=f"/api/records/{pid_value}/draft",
-            dashboard_route=dashboard_route,
+            dashboard_uploads_route=dashboard_uploads_route,
             # maybe quota should be serialized into the record e.g for admins
             quota=get_files_quota(draft._record),
             # hide react community component

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -385,14 +385,12 @@ def deposit_create(community=None):
         community_theme = community.get("theme", {})
 
     community_use_jinja_header = bool(community_theme)
-    dashboard_uploads_route = current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"][
-        "uploads"
-    ]
+    dashboard_routes = current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"]
     return render_community_theme_template(
         current_app.config["APP_RDM_DEPOSIT_FORM_TEMPLATE"],
         theme=community_theme,
         forms_config=get_form_config(
-            dashboard_uploads_route=dashboard_uploads_route,
+            dashboard_routes=dashboard_routes,
             createUrl="/api/records",
             quota=get_files_quota(),
             hide_community_selection=community_use_jinja_header,
@@ -453,15 +451,13 @@ def deposit_edit(pid_value, draft=None, draft_files=None, files_locked=True):
     # for unpublished records we fallback to the react component so users can change
     # communities
     community_use_jinja_header = bool(community_theme)
-    dashboard_uploads_route = current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"][
-        "uploads"
-    ]
+    dashboard_routes = current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"]
     return render_community_theme_template(
         current_app.config["APP_RDM_DEPOSIT_FORM_TEMPLATE"],
         theme=community_theme,
         forms_config=get_form_config(
             apiUrl=f"/api/records/{pid_value}/draft",
-            dashboard_uploads_route=dashboard_uploads_route,
+            dashboard_routes=dashboard_routes,
             # maybe quota should be serialized into the record e.g for admins
             quota=get_files_quota(draft._record),
             # hide react community component

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -385,11 +385,12 @@ def deposit_create(community=None):
         community_theme = community.get("theme", {})
 
     community_use_jinja_header = bool(community_theme)
-
+    dashboard_route = current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"]["uploads"]
     return render_community_theme_template(
         current_app.config["APP_RDM_DEPOSIT_FORM_TEMPLATE"],
         theme=community_theme,
         forms_config=get_form_config(
+            dashboard_route=dashboard_route,
             createUrl="/api/records",
             quota=get_files_quota(),
             hide_community_selection=community_use_jinja_header,
@@ -450,12 +451,13 @@ def deposit_edit(pid_value, draft=None, draft_files=None, files_locked=True):
     # for unpublished records we fallback to the react component so users can change
     # communities
     community_use_jinja_header = bool(community_theme)
-
+    dashboard_route = current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"]["uploads"]
     return render_community_theme_template(
         current_app.config["APP_RDM_DEPOSIT_FORM_TEMPLATE"],
         theme=community_theme,
         forms_config=get_form_config(
             apiUrl=f"/api/records/{pid_value}/draft",
+            dashboard_route=dashboard_route,
             # maybe quota should be serialized into the record e.g for admins
             quota=get_files_quota(draft._record),
             # hide react community component


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

In order to fix https://github.com/inveniosoftware/invenio-rdm-records/issues/1846 this passes `current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"]["uploads"]` to the deposit form react app.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
