### PR TITLE
admin: improve files and stats display

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/records/search/SearchResultItemLayout.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/records/search/SearchResultItemLayout.js
@@ -14,7 +14,7 @@ import { RecordActions } from "../RecordActions";
 import _truncate from "lodash/truncate";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
-import { Table, Button } from "semantic-ui-react";
+import { Popup, Table, Button } from "semantic-ui-react";
 import { withState } from "react-searchkit";
 import { AdminUIRoutes } from "@js/invenio_administration/src/routes";
 import { humanReadableBytes, toRelativeTime } from "react-invenio-forms";
@@ -96,7 +96,8 @@ class SearchResultItemComponent extends Component {
           data-label={i18next.t("Files")}
           className="word-break-all"
         >
-          {humanReadableBytes(result.files.total_bytes)} | #{result.files.count}
+          {result.files.count} file{result.files.count !== 1 ? "s" : ""}:{" "}
+          {humanReadableBytes(result.files.total_bytes, true)}
         </Table.Cell>
         <Table.Cell
           collapsing
@@ -104,8 +105,15 @@ class SearchResultItemComponent extends Component {
           data-label={i18next.t("Stats")}
           className="word-break-all"
         >
-          {result?.stats?.all_versions?.unique_views} |{" "}
-          {result?.stats?.all_versions?.unique_downloads} |{" "}
+          <Popup
+            content="views | downloads"
+            trigger={
+              <span>
+                {result?.stats?.all_versions?.unique_views ?? 0} |{" "}
+                {result?.stats?.all_versions?.unique_downloads ?? 0}
+              </span>
+            }
+          />
         </Table.Cell>
 
         <Table.Cell collapsing>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

Changes:

1. Reorder files from Size | Number to Number: Size
2. Change from MiB -> MB (etc). I think MB is more standard? But we should confirm first
3. Remove extra separator on the stats column
4. See below

![image](https://github.com/user-attachments/assets/4c66bed0-b3ef-4c8e-9469-9e26e4245dfa)

4. Add pop over to explain 
![image](https://github.com/user-attachments/assets/a3abe4ca-717f-4213-a51e-fad721b26440)


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
6. You agree that you have the right to license your contribution under the current repository’s license.
