### PR TITLE
admin: change default # of results from 10 to 20

### DIFF
--- a/invenio_app_rdm/administration/records/records.py
+++ b/invenio_app_rdm/administration/records/records.py
@@ -92,8 +92,8 @@ class RecordAdminListView(AdminResourceListView):
                 ["expand", "1"],
                 ["include_deleted", "1"],
             ],
-            page=1,
-            size=30,
+            pagination_options=(20, 50),
+            default_size=20,
         )
 
 
@@ -151,6 +151,6 @@ class DraftAdminListView(AdminResourceListView):
                 ["is_published", False],
                 ["include_deleted", "1"],
             ],
-            page=1,
-            size=30,
+            pagination_options=(20, 50),
+            default_size=20,
         )

--- a/invenio_app_rdm/administration/user_moderation/user_moderation.py
+++ b/invenio_app_rdm/administration/user_moderation/user_moderation.py
@@ -124,8 +124,8 @@ class UserModerationListView(AdminResourceListView):
                 ["expand", "1"],
                 ["type", UserModerationRequest.type_id],
             ],
-            page=1,
-            size=15,
+            pagination_options=(20, 50),
+            default_size=20,
         )
 
 

--- a/invenio_app_rdm/administration/users/users.py
+++ b/invenio_app_rdm/administration/users/users.py
@@ -112,8 +112,8 @@ class UsersListView(AdminResourceListView):
             headers=self.get_search_request_headers(),
             initial_filters=[["is_active", 1]],
             hidden_params=[],
-            page=1,
-            size=15,
+            pagination_options=(20, 50),
+            default_size=20,
         )
 
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

Close [#2899](https://github.com/inveniosoftware/invenio-app-rdm/issues/2899)

### Description

> Please describe briefly your pull request.

Setting default_size and pagination_options as changing in invenio-search-ui would change it everywhere including non-admin pages

Removing `size` as it isn't an [accepted parameter](https://github.com/inveniosoftware/invenio-search-ui/blob/master/invenio_search_ui/searchconfig.py#L94) and therefore not used and `page=1` as this is the [default](https://github.com/inveniosoftware/invenio-search-ui/blob/master/invenio_search_ui/searchconfig.py#L87)



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
