### PR TITLE
records-ui: fix removing community branding

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ManageDefaultBrandingAction/ManageDefaultBrandingAction.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ManageDefaultBrandingAction/ManageDefaultBrandingAction.js
@@ -61,7 +61,7 @@ export class ManageDefaultBrandingAction extends Component {
             labelPosition="left"
             icon="paint brush"
             floated="right"
-            onClick={() => this.handleSetBranding("")}
+            onClick={() => this.handleSetBranding(null)}
             content={i18next.t("Remove branding")}
             aria-label={i18next.t(
               "{{communityTitle}} is a default branding for this record",


### PR DESCRIPTION
* Closes #2869.
* Passes "null" instead of empty string ("") as the "default" field
  value when removing community branding from a record.
