### PR TITLE
fix: improve handling of additional descriptions in detail template

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/detail.html
@@ -1,6 +1,7 @@
 {#
   Copyright (C) 2020-2024 CERN.
   Copyright (C) 2024 Northwestern University.
+  Copyright (C) 2024 KTH Royal Institute of Technology.
 
   Invenio RDM Records is free software; you can redistribute it and/or modify
   it under the terms of the MIT License; see LICENSE file for more details.
@@ -60,12 +61,14 @@
 {% macro show_add_descriptions(add_descriptions) %}
   {% for add_description in add_descriptions %}
     <section id="additional-description-{{ loop.index }}" class="rel-mt-2 rich-input-content"
-             aria-label="{{ _( add_description.type.title_l10n ) }}">
-      <h2>{{ add_description.type.title_l10n }} <span
-        class="text-muted language">{{ '(' + add_description.lang.title_l10n + ')' if add_description.lang }}</span>
+             aria-label="{{ _( add_description.type.title_l10n ) if add_description.type is defined else 'Missing description!' }}">
+      <h2>{{ add_description.type.title_l10n if add_description.type is defined else _('Missing Additional description type!') }}
+        <span class="text-muted language">
+          {{ '(' + add_description.lang.title_l10n + ')' if add_description.lang is defined else '' }}
+        </span>
       </h2>
 
-      {% if add_description.type.id == "notes" %}
+      {% if add_description.type is defined and add_description.type.id == "notes" %}
         <div class="ui message warning">
           {{ add_description.description | sanitize_html() | safe }}
         </div>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Handle missing 'type' in description rendering
* Add the missing description type when the type is not specified.
* closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2931


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
