### PR TITLE
bug: remove unnecessary <p> tag

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
@@ -15,7 +15,7 @@
     <h2 id="description-heading" class="sr-only">{{ _('Description') }}</h2>
     {# description data is being sanitized by marshmallow in the backend #}
     <div style="word-wrap: break-word;">
-      <p>{{ description | safe }}</p>
+      {{ description | safe }}
     </div>
   </section>
 {% endif %}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

[Error 26](https://validator.w3.org/nu/?doc=https%3A%2F%2Fsandbox.zenodo.org%2Frecords%2F143232) is because we wrap the description in a `<p>` tag, but the paragraph tag can't contain HTML like lists or paragraphs. The HTML of the page is 

```html
<section id="description" class="rel-mt-2 rich-input-content" aria-label="Record description">
    <h2 id="description-heading" class="sr-only">Description</h2>

    <div style="word-wrap: break-word;">
        <p>
        <ul>
            <li>One list item</li>
        </ul>
        </p>
    </div>
</section>
```

With paragraphs we still get [Error 26
](https://validator.w3.org/nu/?doc=https%3A%2F%2Fsandbox.zenodo.org%2Frecords%2F143235) with similar html

```html
<section id="description" class="rel-mt-2 rich-input-content" aria-label="Record description">
    <h2 id="description-heading" class="sr-only">Description</h2>

    <div style="word-wrap: break-word;">
        <p>
        <p>No list</p>
        </p>
    </div>
</section>
```

and when there is no description the section does not appear in the html
![image](https://github.com/user-attachments/assets/bf97585d-551f-4399-89d3-4deba77297c2)
![image](https://github.com/user-attachments/assets/b657d977-c5e4-45fb-8c83-fa6d9503a948)


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
