### PR TITLE
ui: fix banners overlapping

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -104,7 +104,7 @@
 
     <!-- PREVIEW HEADER -->
     {% if is_preview %}
-      <div class="ui info flashed bottom attached manage message">
+      <div class="ui info flashed bottom attached manage message record-banner">
         <div class="ui container">
           <div class="header">
             <i class="eye icon"></i>
@@ -127,7 +127,7 @@
     <!-- /PREVIEW HEADER -->
 
     {% if record.is_published and record.links.latest_html and not record.versions.is_latest %}
-      <div class="ui warning flashed bottom attached manage message">
+      <div class="ui warning flashed bottom attached manage message record-banner">
         <div class="ui container">
           <div class="ui relaxed grid">
             <div class="column">

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/message.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/collections/message.overrides
@@ -5,7 +5,6 @@
 
 .ui.flashed.message,
 .ui.form .flashed.message {
-  z-index: 0;
   &.manage {
     padding: 1em 0;
   }


### PR DESCRIPTION
Closes: https://github.com/CERNDocumentServer/cds-rdm/issues/296

Page banner:
<img width="1496" alt="Screenshot 2024-12-18 at 10 25 20" src="https://github.com/user-attachments/assets/308129e3-4330-4067-82b5-a3cd1cf538b6" />

"Newer version" record banner:
<img width="1418" alt="Screenshot 2024-12-18 at 10 18 02" src="https://github.com/user-attachments/assets/1f86f187-eecc-4c4a-984b-24a8bd548944" />

Error record banner:
<img width="1384" alt="Screenshot 2024-12-18 at 10 18 25" src="https://github.com/user-attachments/assets/006e9c11-3ab3-4637-a530-3f07405b6aaa" />

"Preview" record banner
<img width="1381" alt="Screenshot 2024-12-18 at 10 18 49" src="https://github.com/user-attachments/assets/3b0c5567-efce-4b8c-affb-ebe4a7e05360" />
