### PR TITLE
ui: fix namespace url filter

### DIFF
--- a/invenio_app_rdm/records_ui/views/filters.py
+++ b/invenio_app_rdm/records_ui/views/filters.py
@@ -166,6 +166,10 @@ def truncate_number(value, max_value):
 def namespace_url(field):
     """Get custom field namespace url."""
     namespace_array = field.split(":")
+    if len(namespace_array) < 2:
+        # Not a namespaced field
+        return None
+
     namespace = namespace_array[0]
     namespace_value = namespace_array[1]
     namespaces = current_app.config.get("RDM_NAMESPACES")
@@ -179,6 +183,10 @@ def namespace_url(field):
 def custom_fields_search(field, field_value, field_cfg=None):
     """Get custom field search url."""
     namespace_array = field.split(":")
+    if len(namespace_array) < 2:
+        # Not a namespaced field
+        return None
+
     namespace = namespace_array[0]
     namespaces = current_app.config.get("RDM_NAMESPACES")
 

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -51,6 +51,10 @@ class MockManifestLoader(JinjaManifestLoader):
 def app_config(app_config):
     """Create test app."""
     app_config["WEBPACKEXT_MANIFEST_LOADER"] = MockManifestLoader
+    app_config["RDM_NAMESPACES"] = {
+        "test": "https://example.com/terms/#",
+        "empty": None,
+    }
     return app_config
 
 

--- a/tests/ui/test_filters.py
+++ b/tests/ui/test_filters.py
@@ -1,4 +1,4 @@
-from invenio_app_rdm.records_ui.views.filters import get_scheme_label
+from invenio_app_rdm.records_ui.views.filters import get_scheme_label, namespace_url
 
 
 def test_get_scheme_label(app):
@@ -8,3 +8,11 @@ def test_get_scheme_label(app):
     assert "arXiv" == get_scheme_label("arxiv")
 
     assert "Bibcode" == get_scheme_label("ads")
+
+
+def test_namespace_url(app):
+    """Test namespace URL filters."""
+    assert namespace_url("no_namespaced_field") is None
+    assert namespace_url("empty:field_name") is None
+    assert namespace_url("test") is None
+    assert namespace_url("test:field_name") == "https://example.com/terms/#field_name"


### PR DESCRIPTION
* The filter was failing with and IndexError when trying to parse fields with no namespace.