### PR TITLE
fix: eslint warnings

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/CompareRevisionsDropdown.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/CompareRevisionsDropdown.js
@@ -1,6 +1,7 @@
 /*
  * // This file is part of Invenio-App-Rdm
  * // Copyright (C) 2025 CERN.
+ * // Copyright (C) 2025 Graz University of Technology.
  * //
  * // Invenio-App-Rdm is free software; you can redistribute it and/or modify it
  * // under the terms of the MIT License; see LICENSE file for more details.
@@ -80,4 +81,9 @@ CompareRevisionsDropdown.propTypes = {
   onCompare: PropTypes.func.isRequired,
   srcRevision: PropTypes.object,
   targetRevision: PropTypes.object,
+};
+
+CompareRevisionsDropdown.defaultProps = {
+  srcRevision: 0,
+  targetRevision: 0,
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/RevisionsDiffViewer.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/components/RevisionsDiffViewer.js
@@ -1,6 +1,7 @@
 /*
  * // This file is part of Invenio-App-Rdm
  * // Copyright (C) 2025 CERN.
+ * // Copyright (C) 2025 Graz University of Technology.
  * //
  * // Invenio-App-Rdm is free software; you can redistribute it and/or modify it
  * // under the terms of the MIT License; see LICENSE file for more details.
@@ -74,4 +75,8 @@ export class RevisionsDiffViewer extends Component {
 RevisionsDiffViewer.propTypes = {
   diff: PropTypes.object,
   viewerProps: PropTypes.object.isRequired,
+};
+
+RevisionsDiffViewer.defaultProps = {
+  diff: {},
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/records/CompareRevisions.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/records/CompareRevisions.js
@@ -1,6 +1,7 @@
 /*
  * // This file is part of Invenio-App-Rdm
  * // Copyright (C) 2025 CERN.
+ * // Copyright (C) 2025 Graz University of Technology.
  * //
  * // Invenio-App-Rdm is free software; you can redistribute it and/or modify it
  * // under the terms of the MIT License; see LICENSE file for more details.
@@ -28,6 +29,14 @@ export class CompareRevisions extends Component {
     };
   }
 
+  componentDidMount() {
+    this.fetchRevisions();
+  }
+
+  componentWillUnmount() {
+    this.cancellableAction && this.cancellableAction.cancel();
+  }
+
   async fetchRevisions() {
     const { resource } = this.props;
     this.setState({ loading: true });
@@ -48,14 +57,6 @@ export class CompareRevisions extends Component {
       this.setState({ error: error, loading: false });
       console.error(error);
     }
-  }
-
-  componentDidMount() {
-    this.fetchRevisions();
-  }
-
-  componentWillUnmount() {
-    this.cancellableAction && this.cancellableAction.cancel();
   }
 
   handleModalClose = () => {
@@ -100,7 +101,7 @@ export class CompareRevisions extends Component {
             </Modal.Content>
           )}
           <Modal.Content scrolling>
-            <RevisionsDiffViewer diff={this.state.diff} />
+            <RevisionsDiffViewer diff={diff} />
           </Modal.Content>
         </Modal.Content>
         <Modal.Actions>

--- a/run-js-linter.sh
+++ b/run-js-linter.sh
@@ -16,16 +16,19 @@ RED='\033[0;31m'
 NC='\033[0m' # No Color
 
 for arg in $@; do
-	case ${arg} in
-		-i|--install)
-			npm install --no-save --no-package-lock @inveniosoftware/eslint-config-invenio@^2.0.0;;
-	  -f|--fix)
-	    printf "${GREEN}Run eslint${NC}\n";
-      npx eslint -c .eslintrc.yml invenio_app_rdm/**/*.js --fix;;
-		*)
-			printf "Argument ${RED}$arg${NC} not supported\n"
-			exit;;
-	esac
+    case ${arg} in
+        -i|--install)
+            npm install --no-save --no-package-lock @inveniosoftware/eslint-config-invenio@^2.0.0
+            ;;
+        -f|--fix)
+            printf "${GREEN}Run eslint${NC}\n";
+            npx eslint -c .eslintrc.yml invenio_app_rdm/**/*.js --fix
+            ;;
+        *)
+            printf "Argument ${RED}$arg${NC} not supported\n"
+            exit
+            ;;
+    esac
 done
 
 printf "${GREEN}Run eslint${NC}\n"


### PR DESCRIPTION
* warning propType "diff" is not required, but has no corresponding
  defaultProps declaration

* warning propType "srcRevision" is not required, but has no
  corresponding defaultProps declaration

* warning propType "targetRevision" is not required, but has no
  corresponding defaultProps declaration

* warning fetchRevisions should be placed after componentWillUnmount

* warning 'diff' is assigned a value but never used

* warning Must use destructuring state assignment

* apply indentation to run-js-linter.sh with only spaces
