### PR TITLE
Allow parent to be updated even when no DOI

### DIFF
--- a/invenio_app_rdm/upgrade_scripts/migrate_11_0_to_12_0.py
+++ b/invenio_app_rdm/upgrade_scripts/migrate_11_0_to_12_0.py
@@ -107,6 +107,8 @@ def execute_upgrade():
                         scheme="doi",
                         parent=True,
                     )
+        # Catch all commit for the parent
+        record.parent.commit()
 
     def update_record(record):
         # skipping deleted records because can't be committed


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

When no DOI, the parent was not updated (commit inside a if statement).
I added a catch-all commit.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [🟢 ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ 🟢] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [🟢 ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
