### PR TITLE
checks: add checks tab to requests (fix record ID retrieval)

### DIFF
--- a/invenio_app_rdm/requests_ui/views/requests.py
+++ b/invenio_app_rdm/requests_ui/views/requests.py
@@ -197,13 +197,12 @@ def _resolve_checks(record, request, community=None):
     communities.append(community.id)
 
     # Resolve the record UUID
+    record_pid = record["id"]
     if is_record_inclusion:
-        record_uuid = current_rdm_records_service.record_cls.pid.resolve(
-            record["id"]
-        ).id
+        record_uuid = current_rdm_records_service.record_cls.pid.resolve(record_pid).id
     else:
         record_uuid = current_rdm_records_service.draft_cls.pid.resolve(
-            record["id"], registered_only=False
+            record_pid, registered_only=False
         ).id
 
     # Early exit if no check config found for the communities
@@ -255,7 +254,7 @@ def user_dashboard_request_view(request, **kwargs):
         record_ui = topic["record_ui"]
         record = topic["record"]
         is_draft = record_ui["is_draft"] if record_ui else False
-        checks = _resolve_checks(record, request)
+        checks = _resolve_checks(record_ui, request)
 
         files = _resolve_record_or_draft_files(record_ui, request)
         media_files = _resolve_record_or_draft_media_files(record_ui, request)
@@ -334,7 +333,7 @@ def community_dashboard_request_view(request, community, community_ui, **kwargs)
         record_ui = topic["record_ui"]
         record = topic["record"]
         is_draft = record_ui["is_draft"] if record_ui else False
-        checks = _resolve_checks(record, request, community)
+        checks = _resolve_checks(record_ui, request, community)
 
         permissions.update(topic["permissions"])
         files = _resolve_record_or_draft_files(record_ui, request)


### PR DESCRIPTION
* Fixes https://github.com/zenodo/zenodo-rdm/issues/1133

A bug causing requests like https://sandbox.zenodo.org/communities/sandbox-open-data/requests/42140fd7-8471-42f8-b73b-a886b2009f44 to fail with `TypeError: 'NoneType' object is not subscriptable` on:

```python
    communities.append(community.id)
    # Resolve the record UUID
    if is_record_inclusion:
        record_uuid = current_rdm_records_service.record_cls.pid.resolve(
            record["id"]
        ).id
```

2 other methods `_resolve_record_or_draft_files` and `_resolve_record_or_draft_media_files` are also doing `record_pid = record["id"]`, but the parameter passed to these methods is `record_ui`, not on `record`.