### PR TITLE
records-ui: add error handler for `NoResultFound` exceptions

### DIFF
--- a/invenio_app_rdm/records_ui/views/__init__.py
+++ b/invenio_app_rdm/records_ui/views/__init__.py
@@ -22,6 +22,7 @@ from invenio_records_resources.services.errors import (
     PermissionDeniedError,
     RecordPermissionDeniedError,
 )
+from sqlalchemy.orm.exc import NoResultFound
 
 from invenio_app_rdm.views import create_url_rule
 
@@ -161,6 +162,7 @@ def create_blueprint(app):
     blueprint.register_error_handler(PIDUnregistered, not_found_error)
     blueprint.register_error_handler(KeyError, not_found_error)
     blueprint.register_error_handler(FileKeyNotFoundError, not_found_error)
+    blueprint.register_error_handler(NoResultFound, not_found_error)
     blueprint.register_error_handler(DraftNotCreatedError, draft_not_found_error)
     blueprint.register_error_handler(
         PermissionDeniedError, record_permission_denied_error


### PR DESCRIPTION
This is relevant for the case when sharing access to files for unpublished drafts.

## Example

Given there is a draft `87ra6-2bs54` with the file `TU Wien Research Data - 2025.pdf` and the user has access to the draft, then...

Accessing the URL `https://localhost:5000/records/87ra6-2bs54/files/TU Wien Research Data - 2025.pdf?download=1&preview=1` works fine – the file is downloaded as expected.
However, if the `preview=1` flag is omitted from the URL, then it breaks apart with a `500 internal server error` response. :boom: 

Since at TUW we're sending emails about unhandled exceptions to admins, this spams our inbox with this sort of errors.