### PR TITLE
test: add tests for file download with and without preview flag

### DIFF
--- a/tests/ui/test_file_download.py
+++ b/tests/ui/test_file_download.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 CERN.
+# Copyright (C) 2025 KTH Royal Institute of Technology.
+#
+# Invenio-App-RDM is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+from flask import url_for
+
+
+def test_file_download_with_and_without_preview_flag(
+    client_with_login, draft_with_file
+):
+    """Test file download both with and without preview flag."""
+    client = client_with_login
+    draft_id = draft_with_file["id"]
+    file_name = "article.txt"
+
+    # The draft's owner should be able to download its file from the preview page
+    url_with_preview = url_for(
+        "invenio_app_rdm_records.record_file_download",
+        pid_value=draft_id,
+        filename=file_name,
+        download=1,
+        preview=1,
+    )
+    response = client.get(url_with_preview)
+    assert (
+        response.status_code == 200
+    ), "File download with preview flag should return 200"
+
+    # But since the draft isn't published yet, it can't be found without preview=1
+    url_without_preview = url_for(
+        "invenio_app_rdm_records.record_file_download",
+        pid_value=draft_id,
+        filename=file_name,
+        download=1,
+    )
+    response = client.get(url_without_preview)
+    assert (
+        response.status_code == 404
+    ), "File download without preview flag should return 404"
+
+
+def test_nonexistent_file_returns_404(client_with_login, draft_with_file):
+    """Test that requesting a non-existent file returns 404 via the NoResultFound handler."""
+    client = client_with_login
+    draft_id = draft_with_file["id"]
+    fake_file = "nonexistent-file.pdf"
+
+    # Downloads for files that don't exist should return a 404, both without...
+    url_without_preview = url_for(
+        "invenio_app_rdm_records.record_file_download",
+        pid_value=draft_id,
+        filename=fake_file,
+        download=1,
+    )
+    response = client.get(url_without_preview)
+    assert response.status_code == 404, "Non-existent file should return 404"
+
+    # ... as well as with the preview=1 flag
+    url_with_preview = url_for(
+        "invenio_app_rdm_records.record_file_download",
+        pid_value=draft_id,
+        filename=fake_file,
+        download=1,
+        preview=1,
+    )
+    response = client.get(url_with_preview)
+    assert (
+        response.status_code == 404
+    ), "Non-existent file with preview flag should return 404"


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* add tests for file download url with and without preview flag
* closes https://github.com/inveniosoftware/invenio-app-rdm/issues/3036




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
