### PR TITLE
deposit: report actual file quota rather than configured values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@
 Changes
 =======
 
+Version <next>
+
+- deposit: show actual effective quota for the draft rather than config values, if available
+
 Version v13.0.0b3.dev7 (released 2025-05-08)
 
 - fix: community request page missing context variable

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -391,6 +391,17 @@ def get_form_config(**kwargs):
     )
 
 
+def get_actual_files_quota(draft):
+    """Report the actual effective quota from the draft's bucket, if available."""
+    if draft is not None and draft.bucket is not None:
+        return {
+            "quota_size": draft.bucket.quota_size,
+            "max_file_size": draft.bucket.max_file_size,
+        }
+
+    return get_files_quota(draft)
+
+
 def get_search_url():
     """Get the search URL."""
     # TODO: this should not be used
@@ -453,7 +464,7 @@ def deposit_create(community=None):
         forms_config=get_form_config(
             dashboard_routes=dashboard_routes,
             createUrl="/api/records",
-            quota=get_files_quota(),
+            quota=get_actual_files_quota(None),
             hide_community_selection=community_use_jinja_header,
             is_doi_required=is_doi_required,
         ),
@@ -529,7 +540,7 @@ def deposit_edit(pid_value, draft=None, draft_files=None, files_locked=True):
         apiUrl=f"/api/records/{pid_value}/draft",
         dashboard_routes=dashboard_routes,
         # maybe quota should be serialized into the record e.g for admins
-        quota=get_files_quota(draft._record),
+        quota=get_actual_files_quota(draft._record),
         # hide react community component
         hide_community_selection=community_use_jinja_header,
         is_doi_required=is_doi_required,


### PR DESCRIPTION
Previously, the deposit form would get its information about the draft's quota from the RDM-Records `get_file_quota()` function.
That one seems to be intended more for initialization-only logic though, since it only reports configuration values and not the actual effective values.

In this PR, I introduce a new function that tries to get the effective values from the draft first and only afterwards falls back to the configuration values.
That way, the displayed values are more aligned with reality.