### PR TITLE
landing page: text-break references

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/details.html
@@ -316,7 +316,7 @@ show_alternate_identifiers, show_related_identifiers, show_funding, show_dates %
           id="references-panel"
           role="region"
           aria-labelledby="references-accordion-trigger"
-          class="active content sixteen wide mobile twelve wide tablet thirteen wide computer column"
+          class="active content sixteen wide mobile twelve wide tablet thirteen wide computer column text-break"
         >
           {{ show_references(metadata.references) }}
         </div>


### PR DESCRIPTION
Example of a Zenodo record where long URLs break the layout in the references section: https://zenodo.org/records/15005624
