### PR TITLE
ui: ensure accordion caret icons rotate when opened/closed

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/accordion.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/accordion.overrides
@@ -3,6 +3,15 @@
   &.tab-menu-accordion {
     transform: none;
   }
+
+  transform: rotate(90deg);
+}
+
+.ui.accordion .title .icon.icon:not(.button) {
+  transition: transform 0.1s ease;
+  width: auto;
+  height: auto;
+  vertical-align: baseline;
 }
 
 /* use these classes to change accordion title when up/down */


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Accordion icons weren't rotating across the site due to some overrides of Semantic UI's `dropdown` class

* Added some CSS to ensure the rotation occurs anywhere an accordion is used, using the same transition parameters as used in Semantic UI. Some custom CSS was necessary here despite the guidelines, as the existing overrides mean the `dropdown` class within an accordion [(as documented in Semantic UI](https://semantic-ui.com/modules/accordion.html)) creates a strange-looking rotation effect.

* Closes #3059

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.
