### PR TITLE
rdm parent persistent identifiers none

### DIFF
--- a/invenio_app_rdm/ext.py
+++ b/invenio_app_rdm/ext.py
@@ -33,13 +33,11 @@ def finalize_app(app):
 
 def init_config(app):
     """Initialize configuration."""
-    record_doi_required = (
+    record_doi_required = bool(
         app.config["RDM_PERSISTENT_IDENTIFIERS"].get("doi", {}).get("required")
     )
-    parent_doi_required = (
-        app.config["RDM_PARENT_PERSISTENT_IDENTIFIERS"]
-        .get("doi", {})
-        .get("required", False)
+    parent_doi_required = bool(
+        app.config["RDM_PARENT_PERSISTENT_IDENTIFIERS"].get("doi", {}).get("required")
     )
 
     if record_doi_required != parent_doi_required:


### PR DESCRIPTION
- **default parent_doi_required to False**
- **pid-config: cast to bool RDM_(PARENT)_PERSISTENT_IDENTIFIERS required check**
- superseding https://github.com/inveniosoftware/invenio-app-rdm/pull/3097