### PR TITLE
Fix: enable Overridden components in frontpage, community records search and DashboardUploads

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/communityRecordsSearch/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/communityRecordsSearch/index.js
@@ -56,10 +56,8 @@ const defaultComponents = {
   [`${appName}.SearchFilters.Toggle.element`]: RDMToggleComponent,
 };
 
-const overriddenComponents = overrideStore.getAll();
-
 createSearchAppInit(
-  { ...defaultComponents, ...overriddenComponents },
+  { ...defaultComponents, ...overrideStore.components },
   true,
   "invenio-search-config",
   true

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/frontpage/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/frontpage/index.js
@@ -9,14 +9,13 @@ import ReactDOM from "react-dom";
 import { RecordsListOverridable } from "./RecordsList";
 import { OverridableContext, overrideStore } from "react-overridable";
 
-const overriddenComponents = overrideStore.getAll();
 const recordsListContainer = document.getElementById("records-list");
 const title = recordsListContainer.dataset.title;
 const fetchUrl = recordsListContainer.dataset.fetchUrl;
 const appName = "InvenioAppRDM.RecordsList";
 
 ReactDOM.render(
-  <OverridableContext.Provider value={overriddenComponents}>
+  <OverridableContext.Provider value={overrideStore.components}>
     <RecordsListOverridable title={title} fetchUrl={fetchUrl} appName={appName} />
   </OverridableContext.Provider>,
   recordsListContainer

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/frontpage/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/frontpage/index.js
@@ -12,7 +12,7 @@ import { OverridableContext, overrideStore } from "react-overridable";
 const recordsListContainer = document.getElementById("records-list");
 const title = recordsListContainer.dataset.title;
 const fetchUrl = recordsListContainer.dataset.fetchUrl;
-const appName = "InvenioAppRDM.RecordsList";
+const appName = "InvenioAppRdm.RecordsList";
 
 ReactDOM.render(
   <OverridableContext.Provider value={overrideStore.components}>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
@@ -200,10 +200,9 @@ export const defaultComponents = {
   [`${appName}.SearchBar.element`]: RDMRecordSearchBarElement,
   [`${appName}.SearchFilters.Toggle.element`]: RDMToggleComponent,
 };
-const overriddenComponents = overrideStore.getAll();
 
 createSearchAppInit(
-  { ...defaultComponents, ...overriddenComponents },
+  { ...defaultComponents, ...overrideStore.components },
   true,
   "invenio-search-config",
   true


### PR DESCRIPTION
### Description

React components can't be overridden in the frontpage, community records search, and dashboard uploads because the overriddenComponents import is broken (doesn't import the components). This PR fixes this. The PR also makes the appName in the frontpage consistent with the rest of InvenioRDM (InvenioAppRDM.RecordsList -> InvenioAppRdm.RecordsList).

The issue and fix was discussed in Discord in September 2024, and confirmed to be working for the [Rogue Scholar ](https://rogue-scholar.org/)InvenioRDM instance (with the exception of DashboardUploads). This rebased pull request fixes the commit messages


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
