### PR TITLE
fix: import `overridable-registry.js` in `records_list` macro

### DIFF
--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/macros/records_list.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/macros/records_list.html
@@ -45,5 +45,6 @@
     {% endfor %}
   </div>
 
-  {{ webpack["invenio-app-rdm-frontpage.js"]}}
+  {{ webpack['overridable-registry.js'] }}
+  {{ webpack['invenio-app-rdm-frontpage.js']}}
 {% endmacro %}


### PR DESCRIPTION
**This is an alternative fix for #3117** (thanks for opening this @mfenner!)

---

### Description

* The `records_list` macro was importing `invenio-app-rdm-frontpage.js` early, before any other component-specific JS was imported. This is necessary, as the macro can be used in a range of places, so we need to make sure its associated JS is imported wherever it is used.

* Since we were importing this JS before `overridable-registry`, the loop to add the overriden components to the singleton store: https://github.com/inveniosoftware/invenio-app-rdm/blob/979d6ab4c84fffaa8c70b2b32a40efac179bfd98/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/overridableRegistry/index.js#L11-L13 was being run _after_ the frontpage JS ran the `getAll` function on the store. This meant user-specified overrides were not included in the object (which is a deep-cloned value rather than a reference), so failed to get rendered correctly on the frontpage.

* This PR adds the `overridable-registry.js` import to the `records_list` macro. Even though this will result in a page including the import multiple times, the import behaves as a singleton so it won't actually be imported more than once. This way, we ensure the import is in the correct location regardless of where the macro is used.

* We also avoid using a pass-by-reference for the override object, which could cause some errors and conflicts if components try to accidentally modify it down the line. At the same time, this should fix the issue mentioned [in the original Discord conversation](https://discord.com/channels/692989811736182844/1224742258415239269/1283002968970362975).

* **I have not included the [ID name change](https://github.com/inveniosoftware/invenio-app-rdm/pull/3117/files#diff-36165362d41c45111f91800c4ccf6659e35d2cefbe890859fe76b35519b41310R15) from the original PR**. While the current ID prefix indeed does not follow the naming convention, changing it would likely introduce a breaking change in case anyone is already relying on this. However I'm still happy to change this if we deem the risk to be sufficiently low :)