### PR TITLE
fix: license due to copy pasting

### DIFF
--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_communities/default_static_page.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_communities/default_static_page.html
@@ -1,20 +1,10 @@
-{#
-# This file is part of Invenio.
-# Copyright (C) 2025 CERN.
-#
-# Invenio is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the
-# License, or (at your option) any later version.
-#
-# Invenio is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Invenio; if not, write to the Free Software Foundation, Inc.,
-# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2025 CERN.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
 #}
 
 {% extends "invenio_communities/base.html" %}


### PR DESCRIPTION
* code in invenio-app-rdm is licensed with MIT
