### PR TITLE
theme: move styles from invenio-app-rdm to invenio-theme and invenio-administration

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -14,41 +14,6 @@ body {
   flex-direction: column;
 }
 
-:not(.ui.grid).only {
-
-  &.mobile:not(.tablet) {
-    @media all and (min-width: @tabletBreakpoint) {
-      display: none !important;
-    }
-  }
-
-  &.tablet {
-    &.mobile {
-      @media all and (min-width: @computerBreakpoint) {
-        display: none !important;
-      }
-    }
-
-    &.computer {
-      @media all and (max-width: @largestMobileScreen) {
-        display: none !important;
-      }
-    }
-
-    &:not(.computer):not(.mobile) {
-      @media not all and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
-        display: none !important;
-      }
-    }
-  }
-
-  &.computer:not(.tablet) {
-    @media all and (max-width: @largestTabletScreen) {
-      display: none !important;
-    }
-  }
-}
-
 button:focus-visible, a:focus-visible {
   outline: 3px solid @focusedFormBorderColor !important;
 }

--- a/invenio_app_rdm/theme/webpack.py
+++ b/invenio_app_rdm/theme/webpack.py
@@ -45,8 +45,6 @@ theme = WebpackThemeBundle(
             },
             dependencies={
                 "@babel/runtime": "^7.9.0",
-                "@tinymce/tinymce-react": "^4.3.0",
-                "tinymce": "^6.7.2",
                 "formik": "^2.1.0",
                 "i18next": "^20.3.0",
                 "i18next-browser-languagedetector": "^6.1.0",
@@ -76,26 +74,6 @@ theme = WebpackThemeBundle(
                 "@js/invenio_app_rdm": "js/invenio_app_rdm",
                 "@translations/invenio_app_rdm": "translations/invenio_app_rdm",
             },
-            copy=[
-                # Copy some assets into "static/dist", as TinyMCE requires that
-                # Note that the base path for all entries is the `config.json` directory
-                {
-                    "from": "../node_modules/tinymce/skins/content/default/content.css",
-                    "to": "../../static/dist/js/skins/content/default",
-                },
-                {
-                    "from": "../node_modules/tinymce/skins/ui/oxide/skin.min.css",
-                    "to": "../../static/dist/js/skins/ui/oxide",
-                },
-                {
-                    "from": "../node_modules/tinymce/skins/ui/oxide/content.min.css",
-                    "to": "../../static/dist/js/skins/ui/oxide",
-                },
-                {
-                    "from": "../node_modules/json-diff-kit/dist/viewer.css",
-                    "to": "../../static/css/json-diff-kit.css",
-                },
-            ],
         ),
     },
 )


### PR DESCRIPTION
* invenio-administration depends on the moved styles 
* Thus we move them from invenio-app-rdm to invenio-theme and invenio-administration

see: https://github.com/inveniosoftware/invenio-theme/pull/417 and https://github.com/inveniosoftware/invenio-administration/pull/258


closes: https://github.com/CERNDocumentServer/cds-ils/issues/1006