### PR TITLE
fix(deposits): update doi default option only if managed

### DIFF
--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -84,10 +84,12 @@ def get_form_pids_config(record=None):
                 optional_doi_transitions["message"] = optional_doi_transitions.get(
                     "message"
                 ).format(sitename=sitename)
-                if set(optional_doi_transitions["allowed_providers"]) - set(
-                    ["external", "not_needed"]
+                if (
+                    "external" not in optional_doi_transitions["allowed_providers"]
+                    and "not_needed"
+                    not in optional_doi_transitions["allowed_providers"]
                 ):
-                    # In case we have locally managed provider as an allowed one, we need to
+                    # In case we have locally managed provider(s) as allowed ones, we need to
                     # select it by default. That is relevant for the case when the
                     # user creates a new version of the record and the previous version
                     # had a datacite DOI.


### PR DESCRIPTION
fixes: https://github.com/CERNDocumentServer/cds-rdm/issues/523

If the DOI is set as not required in the config and the record is published with 'No, I don't need one' selected, editing of that record will not change the DOI checkbox option. It should only update it to 'No, I need one' when the record already has a DOI.