### PR TITLE
custom-fields: forward the field ID to React

### DIFF
--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -335,6 +335,8 @@ def load_custom_fields():
             # for each custom field. This is the label shown at the top of the upload
             # form
             field_error_label = field.get("props", {}).get("label")
+            # Add the field ID to the props to allow overriding the React widgets of custom fields
+            field["props"]["id"] = field["field"]
             if field_error_label:
                 error_labels[f"custom_fields.{field['field']}"] = field_error_label
             if getattr(field_instance, "relation_cls", None):


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/react-invenio-forms/issues/297

Releasing this PR before https://github.com/inveniosoftware/react-invenio-forms/pull/298 should not cause any problems as existing React widgets will simply ignore the `id` prop.

---

### Description

* Added an injection of the field ID (e.g. `cern:department`) to the React UI widget chosen for the custom field via a new `id` prop.

* This is consumed by the new function in https://github.com/inveniosoftware/react-invenio-forms/pull/298 and used to allow developers to dynamically parametrize their own custom fields based on the form state.

* This is not a breaking change and shouldn't affect any existing custom fields