### PR TITLE
community value fixes

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -1181,6 +1181,7 @@ PAGES_DEFAULT_TEMPLATE = "invenio_app_rdm/default_static_page.html"
 
 PAGES_TEMPLATES = [
     ("invenio_app_rdm/default_static_page.html", "Default"),
+    ("invenio_communities/default_static_page.html", "Community"),
 ]
 """List of available templates for pages."""
 

--- a/invenio_app_rdm/fixtures/pages.py
+++ b/invenio_app_rdm/fixtures/pages.py
@@ -68,6 +68,9 @@ class StaticPages(FixtureMixin):
                     ),
                     "lang": lang[0],
                     "description": entry.get("description", ""),
-                    "template_name": current_app.config["PAGES_DEFAULT_TEMPLATE"],
+                    "template_name": entry.get(
+                        "template_name",
+                        current_app.config["PAGES_DEFAULT_TEMPLATE"],
+                    ),
                 }
                 current_pages_service.create(system_identity, data)

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -459,7 +459,7 @@ def deposit_create(community=None, community_ui=None):
 
     community_theme = None
     if community is not None:
-        community_theme = community.get("theme", {})
+        community_theme = community_ui.get("theme", {})
 
     community_use_jinja_header = bool(community_theme)
     dashboard_routes = current_app.config["APP_RDM_USER_DASHBOARD_ROUTES"]
@@ -485,7 +485,7 @@ def deposit_create(community=None, community_ui=None):
         community_ui=community_ui,
         community_use_jinja_header=community_use_jinja_header,
         files=dict(default_preview=None, entries=[], links={}),
-        preselectedCommunity=community,
+        preselectedCommunity=community_ui,
         files_locked=False,
         permissions=get_record_permissions(
             [
@@ -521,6 +521,7 @@ def deposit_edit(pid_value, draft=None, draft_files=None, files_locked=True):
     ui_serializer = UIJSONSerializer()
     record = ui_serializer.dump_obj(draft.to_dict())
 
+    community_ui = None
     community_theme = None
     community = record.get("expanded", {}).get("parent", {}).get("review", {}).get(
         "receiver"

--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -222,7 +222,7 @@ def record_detail(
         if resolved_community
         else None
     )
-    theme = resolved_community.get("theme", {}) if resolved_community else None
+    theme = resolved_community_ui.get("theme", {}) if resolved_community else None
 
     return render_community_theme_template(
         current_app.config.get("APP_RDM_RECORD_LANDING_PAGE_TEMPLATE"),


### PR DESCRIPTION
- **fixtures: allow specifying `template_name` in page fixtures**
  

- **pages: add community base template as a valid option**
  

- **fix(views): use correct community value**
  * After the change in 33f1b0d2, values passed to the UI or used for
    accessing UI-related attributes (e.g. the "theme"), must come from
    the community UI-serialized value instead of the service result item.
  