### PR TITLE
fix(tests): update invalid checksum format

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -12,7 +12,7 @@ from io import BytesIO
 import pytest
 from invenio_access.permissions import system_identity
 from invenio_db import db
-from invenio_files_rest.models import Bucket, FileInstance, Location, ObjectVersion
+from invenio_files_rest.models import FileInstance
 from invenio_rdm_records.proxies import current_rdm_records
 
 from invenio_app_rdm.tasks import file_integrity_report
@@ -66,7 +66,7 @@ def draft_with_file_instance(running_app, minimal_record):
 def draft_with_invalid_file_instance(draft_with_file_instance):
     # Force an invalid checksum
     draft, f = draft_with_file_instance
-    f.checksum = "invalid"
+    f.checksum = "invalid:invalid-checksum"
     f.verify_checksum()
     db.session.commit()
 


### PR DESCRIPTION
### Description

Recent change in invenio-files-rest introduced validation of checksum format, this PR fixes the format in tests.

Please backport this to v13 as well. Thank you.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
