### PR TITLE
config: compat with new VCS integration

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019-2025 CERN.
+# Copyright (C) 2019-2026 CERN.
 # Copyright (C) 2019-2020 Northwestern University.
 # Copyright (C) 2021-2025 Graz University of Technology.
 # Copyright (C) 2022-2025 KTH Royal Institute of Technology.
@@ -80,7 +80,6 @@ from invenio_rdm_records.services.errors import (
     InvalidAccessRestrictions,
     InvalidCommunityVisibility,
 )
-from invenio_rdm_records.services.github.release import RDMGithubRelease
 from invenio_rdm_records.services.permissions import RDMRequestsPermissionPolicy
 from invenio_rdm_records.services.stats import permissions_policy_lookup_factory
 from invenio_rdm_records.services.tasks import StatsRDMReindexTask
@@ -1480,13 +1479,6 @@ REQUESTS_ERROR_HANDLERS = {
 }
 
 
-# Invenio-Github
-# =================
-#
-GITHUB_RELEASE_CLASS = RDMGithubRelease
-"""Default RDM release class."""
-
-
 # Flask-Menu
 # ==========
 #
@@ -1564,3 +1556,11 @@ APP_RDM_MODERATION_REQUEST_FACETS = {
     "is_open": {"facet": facets.is_open, "ui": {"field": "is_open"}},
 }
 """Available facets defined for this module."""
+
+# Invenio-VCS
+# ===========
+VCS_TEMPLATE_INDEX = "invenio_vcs/rdm-index.html"
+VCS_TEMPLATE_INDEX_ITEM = "invenio_vcs/rdm-index-item.html"
+VCS_TEMPLATE_VIEW = "invenio_vcs/rdm-view.html"
+VCS_TEMPLATE_REPO_SWITCH = "invenio_vcs/rdm-repo-switch.html"
+VCS_TEMPLATE_RELEASE_ITEM = "invenio_vcs/rdm-release-item.html"


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-vcs/issues/2

---

* We are updating `invenio-github` to be a generic package supporting many VCS providers, not just GitHub. As such, it will be renamed (currently to `invenio-vcs`).

* The `RDMGitHubRelease` class has been renamed and restructured, so this must be reflected in `config.py` for continued functionality. No other changes are needed to this repository at the moment.

* See https://github.com/inveniosoftware/invenio-rdm-records/pull/2284 and https://github.com/inveniosoftware/invenio-rdm-records/pull/2283