### PR TITLE
file-list: display fallback message if file checksum is not available

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -123,7 +123,7 @@ To access its content, please download it and open it locally.') }}
               <a href="{{ file_url_download }}">{{ file.key }}</a>
             </div>
             {%- if not is_remote_file %}
-            <small class="ui text-muted font-tiny">{{ file.checksum }}
+            <small class="ui text-muted font-tiny">{{ file.checksum or _("Checksum not yet calculated.") }}
             <div class="ui icon inline-block" data-tooltip="{{_('This is the file fingerprint (checksum), which can be used to verify the file integrity.')}}">
               <i class="question circle checksum icon"></i>
             </div>


### PR DESCRIPTION
This shows a fallback message if the file's checksum is not yet available, which can be happen if the checksum is calculated asynchronously (e.g. multipart file upload with local file storage).

See also https://github.com/inveniosoftware/invenio-records-resources/pull/650