### PR TITLE
help: correct search instructions for missing fields

### DIFF
--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/help/search.de.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/help/search.de.html
@@ -156,13 +156,13 @@
   <h3>Fehlende Werte</h3>
   <p>
     Es ist möglich, mit den Feldnamen <code>_exists_</code> und
-    <code>_missing_</code> nach Datensätzen zu suchen,
+    <code>NOT _exists_</code> nach Datensätzen zu suchen,
     in denen entweder ein Wert fehlt oder die einen Wert in einem bestimmten Feld haben.
   </p>
   <p>
     <strong>Beispiel:</strong>
     <a
-      href="/search?page=1&amp;size=20&amp;q=_missing_:metadata.additional_titles"><code>_missing_:metadata.additional_titles</code></a>
+      href="/search?page=1&amp;size=20&amp;q=NOT%20_exists_:metadata.additional_titles"><code>NOT _exists_:metadata.additional_titles</code></a>
     (alle Datensätze ohne metadata.additional_titles)
   </p>
   <p>

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/help/search.en.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/help/search.en.html
@@ -188,9 +188,9 @@
   </p>
   <p>
     <strong>Example:</strong>
-    <a href="/search?page=1&amp;size=20&amp;q=NOT%20_exists_:metadata.additional_titles"
-      ><code>NOT _exists_:metadata.additional_titles</code></a
-    >
+    <a href="/search?page=1&amp;size=20&amp;q=NOT%20_exists_:metadata.additional_titles">
+      <code>NOT _exists_:metadata.additional_titles</code>
+    </a>
     (all records without metadata.additional_titles)
   </p>
   <p>

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/help/search.en.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/help/search.en.html
@@ -184,12 +184,12 @@
   <p>
     It is possible to search for records that either are missing a value or have
     a value in a specific field using the <code>_exists_</code> and
-    <code> not _exists_</code> field names.
+    <code>NOT _exists_</code> field names.
   </p>
   <p>
     <strong>Example:</strong>
-    <a href="/search?page=1&amp;size=20&amp;q=_missing_:metadata.additional_titles"
-      ><code>not _exists_:metadata.additional_titles</code></a
+    <a href="/search?page=1&amp;size=20&amp;q=NOT%20_exists_:metadata.additional_titles"
+      ><code>NOT _exists_:metadata.additional_titles</code></a
     >
     (all records without metadata.additional_titles)
   </p>

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/help/search.sv.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/help/search.sv.html
@@ -180,9 +180,9 @@
   </p>
   <p>
     <strong>Exempel:</strong>
-    <a href="/search?page=1&amp;size=20&amp;q=NOT%20_exists_:metadata.additional_titles"
-      ><code>NOT _exists_:metadata.additional_titles</code></a
-    >
+    <a href="/search?page=1&amp;size=20&amp;q=NOT%20_exists_:metadata.additional_titles">
+      <code>NOT _exists_:metadata.additional_titles</code>
+    </a>
     (alla poster utan metadata.additional_titles)
   </p>
   <p>

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/help/search.sv.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_app_rdm/help/search.sv.html
@@ -176,12 +176,12 @@
   <p>
     Det är möjligt att söka efter poster som antingen saknar ett värde eller har
     ett värde i ett specifikt fält med hjälp av <code>_exists_</code> och
-    <code>not _exists_</code> i kombination med fältnamn.
+    <code>NOT _exists_</code> i kombination med fältnamn.
   </p>
   <p>
     <strong>Exempel:</strong>
-    <a href="/search?page=1&amp;size=20&amp;q=_missing_:metadata.additional_titles"
-      ><code>not _exists_:metadata.additional_titles</code></a
+    <a href="/search?page=1&amp;size=20&amp;q=NOT%20_exists_:metadata.additional_titles"
+      ><code>NOT _exists_:metadata.additional_titles</code></a
     >
     (alla poster utan metadata.additional_titles)
   </p>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The current search help doesn't include the correct capitalization for NOT to find missing fields. 

example (too many results): https://zenodo.org/search?q=not%20_exists_%3Ametadata.description&l=list&p=1&s=10&sort=bestmatch

correct: https://zenodo.org/search?q=NOT%20_exists_%3Ametadata.description&l=list&p=1&s=10&sort=bestmatch

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).




**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
