### PR TITLE
details: fix: do not sanitize additional description in template

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/detail.html
@@ -73,12 +73,13 @@
           {{ '(' ~ add_description.lang.title_l10n ~ ')' if add_description.lang is defined else '' }}
         </span>
       </h2>
+      {# additional description data is being sanitized by marshmallow in the backend #}
       {% if desc_type_defined and add_description.type.id == "notes" %}
         <div class="ui message warning">
-          {{ desc_text | sanitize_html() | safe }}
+          {{ desc_text | safe }}
         </div>
       {% else %}
-        {{ desc_text | sanitize_html() | safe }}
+        {{ desc_text | safe }}
       {% endif %}
     </section>
   {% endfor %}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Fixes #3181
    * (see linked issue for bug details)

* Template sanitization
    * [The "Description" is already *not* sanitized in the template](https://github.com/inveniosoftware/invenio-app-rdm/blob/f313791da923031c2a20b8ade491490c888cd786/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html#L18)
    * This PR removes the sanitization from the template for "Additional Description"
* Model sanitization
    * [The "Description" field is sanitized in the model](https://github.com/inveniosoftware/invenio-rdm-records/blob/20d9737089ba9c8b14956787d690b93cca492e95/invenio_rdm_records/services/schemas/metadata.py#L389)
    * The "Additional Description" field is sanitized in the model ([field definition](https://github.com/inveniosoftware/invenio-rdm-records/blob/20d9737089ba9c8b14956787d690b93cca492e95/invenio_rdm_records/services/schemas/metadata.py#L390) and [class with sanitization](https://github.com/inveniosoftware/invenio-rdm-records/blob/20d9737089ba9c8b14956787d690b93cca492e95/invenio_rdm_records/services/schemas/metadata.py#L196-L201-))
* Differences of sanitization
    * [The `SanitizedHTML` in `marshmallow-utils` allows to use the `target` attribute](https://github.com/inveniosoftware/marshmallow-utils/blob/af92e79e42496b67e9896fc4545b4ed2997c45ee/marshmallow_utils/html.py#L67-L84)
    * [The `sanitize_html` filter in `invenio-formatter` does not allow to use the `target` attribute](https://github.com/inveniosoftware/invenio-formatter/blob/5b82e1cbf1369b0ae59d966f6a756fc22aa70833/invenio_formatter/filters/html.py#L15C5-L30) (based on [the `ALLOWED_HTML_ATTRS` defined in `invenio-config`](https://github.com/inveniosoftware/invenio-config/blob/0f1fde1a9c4ebd6fd0876d81a594bf60d407ca9e/invenio_config/default.py#L50C1-L55))


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
