### PR TITLE
feat(deletion-request): different checklist for immediate and request

### DIFF
--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -552,7 +552,11 @@ def deposit_edit(pid_value, draft=None, draft_files=None, files_locked=True):
                 "valid_user": rd_valid_user,
                 "allowed": rd_allowed,
                 "recordDeletion": rec_del,
-                "checklist": current_app.config["RDM_RECORD_DELETION_CHECKLIST"],
+                "checklist": (
+                    current_app.config["RDM_IMMEDIATE_RECORD_DELETION_CHECKLIST"]
+                    if immediate.allowed
+                    else current_app.config["RDM_REQUEST_RECORD_DELETION_CHECKLIST"]
+                ),
                 "context": {
                     "files": draft._record.files.count,
                     "internalDoi": draft._record.pids["doi"]["provider"] != "external",

--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -175,7 +175,11 @@ def record_detail(
             "valid_user": rd_valid_user,
             "allowed": rd_allowed,
             "recordDeletion": rec_del,
-            "checklist": current_app.config["RDM_RECORD_DELETION_CHECKLIST"],
+            "checklist": (
+                current_app.config["RDM_IMMEDIATE_RECORD_DELETION_CHECKLIST"]
+                if immediate.allowed
+                else current_app.config["RDM_REQUEST_RECORD_DELETION_CHECKLIST"]
+            ),
             "context": {
                 "files": record._record.files.count,
                 "internalDoi": record._record.pids["doi"]["provider"] != "external",


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Provides a different `checklist` to the template, depending on if it's an immediate deletion or a deletion request.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
