### PR TITLE
ui: format numbers in CompactStats

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/CompactStats.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/CompactStats.js
@@ -8,6 +8,7 @@ import { i18next } from "@translations/invenio_app_rdm/i18next";
 import PropTypes from "prop-types";
 import React from "react";
 import { Icon, Label, Popup } from "semantic-ui-react";
+import { localizedFormatNumber } from "../utils";
 
 export const CompactStats = ({ uniqueViews, uniqueDownloads }) => {
   return (
@@ -19,7 +20,7 @@ export const CompactStats = ({ uniqueViews, uniqueDownloads }) => {
           trigger={
             <Label className="transparent">
               <Icon name="eye" />
-              {uniqueViews}
+              {localizedFormatNumber(uniqueViews)}
             </Label>
           }
         />
@@ -31,7 +32,7 @@ export const CompactStats = ({ uniqueViews, uniqueDownloads }) => {
           trigger={
             <Label className="transparent">
               <Icon name="download" />
-              {uniqueDownloads}
+              {localizedFormatNumber(uniqueDownloads)}
             </Label>
           }
         />

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/utils.js
@@ -119,3 +119,12 @@ export function SearchItemCreators({ creators, className, othersLink }) {
  */
 export const timestampToRelativeTime = (timestamp) =>
   DateTime.fromISO(timestamp).setLocale(i18next.language).toRelative();
+
+/**
+ * Returns a string-formatted number in the user's locale (e.g. 1,000 in en-GB but 1.000 in de-DE)
+ *
+ * @param {Number} number
+ * @returns string
+ */
+export const localizedFormatNumber = (number) =>
+  new Intl.NumberFormat(i18next.language).format(number);


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/3137

---

* Adds locale-based formatting for large numbers using the HTML API `Intl.NumberFormat`

* The locale is taken from `i18next.language`. The view count and the download count are both formatted.