### PR TITLE
feat: config: add last reply sort option

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -1095,7 +1095,7 @@ RDM_SEARCH_USER_COMMUNITIES = {
 
 RDM_SEARCH_USER_REQUESTS = {
     "facets": ["type", "status"],
-    "sort": ["bestmatch", "newest", "oldest"],
+    "sort": ["bestmatch", "newest", "oldest", "newestactivity", "oldestactivity"],
 }
 """User requests search configuration (i.e list of user requests)"""
 
@@ -1523,7 +1523,7 @@ SITEMAP_SECTIONS = [
 # ========================================
 APP_RDM_MODERATION_REQUEST_SEARCH = {
     "facets": ["status", "is_open"],
-    "sort": ["bestmatch", "newest", "oldest", "last_replied"],
+    "sort": ["bestmatch", "newest", "oldest", "newestactivity", "oldestactivity"],
 }
 """Moderation requests search configuration."""
 
@@ -1540,9 +1540,13 @@ APP_RDM_MODERATION_REQUEST_SORT_OPTIONS = {
         title=_("Oldest"),
         fields=["created"],
     ),
-    "last_replied": dict(
-        title=_("Last replied"),
-        fields=["last_reply.created"],
+    "newestactivity": dict(
+        title=_("Newest activity"),
+        fields=["-last_activity_at"],
+    ),
+    "oldestactivity": dict(
+        title=_("Oldest activity"),
+        fields=["last_activity_at"],
     ),
 }
 """Definitions of available record sort options."""

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -535,8 +535,10 @@ def deposit_edit(pid_value, draft=None, draft_files=None, files_locked=True):
 
     published_record = None
     if record["is_published"]:
-        published_record_result = service.read(g.identity, id_=record["id"]).to_dict()
-        published_record = ui_serializer.dump_obj(published_record_result)
+        published_record_result = service.read(
+            g.identity, id_=record["id"], expand=True
+        )
+        published_record = ui_serializer.dump_obj(published_record_result.to_dict())
 
         rec_del = RDMRecordDeletionPolicy().evaluate(
             g.identity, published_record_result._record


### PR DESCRIPTION
Makes sorting by `last_reply` possible in the user's request dashboard.

Related:
* inveniosoftware/invenio-requests#485
* inveniosoftware/invenio-rdm-records#2168
