### PR TITLE
Backport and release v13

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@
 Changes
 =======
 
+Version v13.0.3 (released 2025-09-25)
+
+- help: correct search instructions for missing fields
+- deposit: pass to the form config the published record if we edit one 
+
 Version v13.0.2 (released 2025-08-25)
 
 - i18n: pulled translations

--- a/invenio_app_rdm/__init__.py
+++ b/invenio_app_rdm/__init__.py
@@ -17,6 +17,6 @@
 #
 # See PEP 0440 for details - https://www.python.org/dev/peps/pep-0440
 
-__version__ = "13.0.2"
+__version__ = "13.0.3"
 
 __all__ = ("__version__",)

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -521,6 +521,12 @@ def deposit_edit(pid_value, draft=None, draft_files=None, files_locked=True):
     ui_serializer = UIJSONSerializer()
     record = ui_serializer.dump_obj(draft.to_dict())
 
+    published_record = None
+    # if editing draft of a published record
+    if record.get("status") == "published":
+        _record = service.read(g.identity, id_=record["id"]).to_dict()
+        published_record = ui_serializer.dump_obj(_record)
+
     community_ui = None
     community_theme = None
     community = record.get("expanded", {}).get("parent", {}).get("review", {}).get(
@@ -559,6 +565,7 @@ def deposit_edit(pid_value, draft=None, draft_files=None, files_locked=True):
         hide_community_selection=community_use_jinja_header,
         is_doi_required=is_doi_required,
         record=draft._record,
+        published_record=published_record,
     )
 
     if is_doi_required and not record.get("pids", {}).get("doi"):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Fix deposit form DOI handling from https://github.com/inveniosoftware/invenio-rdm-records/pull/2166



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
