### PR TITLE
feat(form): rename creators to authors and help text

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -262,13 +262,13 @@
             {# Title #}
             {%- block record_title -%}
               <section id="record-title-section"
-                       aria-label="{{ _('Record title and creators') }}">
+                       aria-label="{{ _('Record title, authors and contributors') }}">
                 <h1 id="record-title"
                     class="wrap-overflowing-text">{{ metadata.title }}</h1>
 
                 {% if record_ui["ui"]["creators"] or record_ui["ui"]["contributors"] %}
                   <section id="creatibutors"
-                           aria-label="{{ _('Creators and contributors') }}">
+                           aria-label="{{ _('Authors and contributors') }}">
                     {%- include "invenio_app_rdm/records/details/creatibutors.html" %}
                   </section>
                 {% endif %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
@@ -13,7 +13,7 @@
   {% if record_ui["ui"]["creators"] and record_ui["ui"]["creators"]["creators"] %}
     <div class="row ui accordion affiliations">
       <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
-          <h3 class="sr-only">{{ _('Creators') }}</h3>
+          <h3 class="sr-only">{{ _('Authors/Creators') }}</h3>
           <ul class="creatibutors">
             {{ show_creatibutors(record_ui["ui"]["creators"]["creators"], show_affiliations=True, show_role=True) }}
           </ul>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -303,8 +303,11 @@ export class RDMDepositForm extends Component {
                       fieldPath="metadata.creators"
                     >
                       <CreatibutorsField
-                        label={i18next.t("Creators")}
+                        label={i18next.t("Authors/Creators")}
                         labelIcon="user"
+                        addButtonHelpText={i18next.t(
+                          "Use the Authors/Creators field for names that should appear in the citation. Use the Contributors field below for other names."
+                        )}
                         fieldPath="metadata.creators"
                         roleOptions={this.vocabularies.metadata.creators.role}
                         schema="creators"
@@ -423,6 +426,9 @@ export class RDMDepositForm extends Component {
                     >
                       <CreatibutorsField
                         addButtonLabel={i18next.t("Add contributor")}
+                        addButtonHelpText={i18next.t(
+                          "Contributors are not included in the citation, but are shown on the record page."
+                        )}
                         label={i18next.t("Contributors")}
                         labelIcon="user plus"
                         fieldPath="metadata.contributors"


### PR DESCRIPTION
* rename the Creators field to Authors
* add help text under Contributors to explain the difference
* closes #3197

**Requires**: https://github.com/inveniosoftware/invenio-rdm-records/pull/2176

![Screenshot 2025-10-10 at 10 08 29](https://github.com/user-attachments/assets/b103e617-3066-4cda-a8b6-c95d036b5f82)

![Screenshot 2025-10-10 at 10 08 50](https://github.com/user-attachments/assets/fd294214-e73f-40a6-9d95-3c06a4b9bb74)
