### PR TITLE
fix: align selector with semantic-ui

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/accordion.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/accordion.overrides
@@ -40,7 +40,7 @@ div.affiliations.accordion div.title button.down {
   &.invenio-accordion-field {
     margin-bottom: 2rem;
 
-    .title {
+    .title:not(.ui) {
       background-color: @brandColor;
       color: @white;
       padding: 1em;


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

For styling, semantic ui targets the title of an accordion via `.ui.accordion .title:not(.ui)` so that you can escape the styling by adding the ui class.  This is important as the selector is for any `.title`s that are children, not just direct children.

<img width="1102" height="526" alt="image" src="https://github.com/user-attachments/assets/be032f75-674f-4d74-9293-088c7dc3d5ab" />

This is relevant for my upcoming pull requests where I want to use an accordion field inside a section which looks like 
<img width="864" height="283" alt="image" src="https://github.com/user-attachments/assets/ebad61fb-284e-4220-ab78-3c4379314c69" />
but with this PR instead looks like this:
<img width="867" height="252" alt="image" src="https://github.com/user-attachments/assets/6473f7c3-c453-402b-8535-e64253ed8aa8" />

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
