### PR TITLE
views: remove unused data attributes from recordManagementMobile

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -206,9 +206,6 @@
                   <div id="recordManagementMobile"
                        role="dialog"
                        class="ui flowing popup transition hidden"
-                       data-record='{{ record_ui | tojson }}'
-                       data-permissions='{{ permissions | tojson }}'
-                       data-is-draft="{{ is_draft | tojson }}"
                        {% if config.RDM_DETAIL_SIDE_BAR_MANAGE_ATTRIBUTES_EXTENSION_TEMPLATE %}
                         {% include config.RDM_DETAIL_SIDE_BAR_MANAGE_ATTRIBUTES_EXTENSION_TEMPLATE %}
                        {% endif %}


### PR DESCRIPTION
* Partially fixes #3211 (related because found when working on this issue)
* The `recordManagementMobile` div is [used to render the `RecordManagement` component](https://github.com/inveniosoftware/invenio-app-rdm/blob/v14.0.0b2.dev4/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js#L25)
* However, the [data attributes are always retrieved from the `recordManagement` div](https://github.com/inveniosoftware/invenio-app-rdm/blob/v14.0.0b2.dev4/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js#L28-L47)
* Therefore, the 3 data attributes can be removed from `recordManagementMobile`