### PR TITLE
fix(moderation.requests): handle empty payload key not in request

### DIFF
--- a/invenio_app_rdm/administration/moderation/requests.py
+++ b/invenio_app_rdm/administration/moderation/requests.py
@@ -138,7 +138,7 @@ class ModerationRequestDetailView(AdminResourceDetailView):
             g.identity, current_user
         )["avatar"]
         permissions = []
-        if "reason" in request["payload"]:
+        if "reason" in request.get("payload", {}):
             reason_title = vocabulary_service.read(
                 g.identity,
                 ("removalreasons", request["payload"]["reason"]),

--- a/invenio_app_rdm/administration/templates/semantic-ui/invenio_app_rdm/administration/requests_details.html
+++ b/invenio_app_rdm/administration/templates/semantic-ui/invenio_app_rdm/administration/requests_details.html
@@ -29,12 +29,14 @@ under the terms of the MIT License; see LICENSE file for more details.
             )
         }}
 
-        <div class="twelve wide column mt-10">
-          <p><strong>{{ _("Reason:") }}</strong> {{ invenio_request["payload"]["reason_label"] }}</p>
-          {%- if invenio_request["payload"]["comment"] %}
-            <p><strong>{{ _("Justification:") }}</strong> {{ invenio_request["payload"]["comment"] }}</p>
-          {%- endif %}
-        </div>
+        {%- if "payload" in invenio_request %}
+          <div class="twelve wide column mt-10">
+            <p><strong>{{ _("Reason:") }}</strong> {{ invenio_request["payload"]["reason_label"] }}</p>
+            {%- if invenio_request["payload"]["comment"] %}
+              <p><strong>{{ _("Justification:") }}</strong> {{ invenio_request["payload"]["comment"] }}</p>
+            {%- endif %}
+          </div>
+        {%- endif %}
 
         <div class="ui divider"></div>
       {%- endblock request_header %}


### PR DESCRIPTION
If there are no permissions, the payload key doesn't exist in the request data

https://github.com/inveniosoftware/invenio-requests/blob/42ffee5259be67e6372b7639fdad136d14425584/invenio_requests/services/requests/components.py#L163-L180