### PR TITLE
feat(css): styles for quote replies

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/feed.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/feed.overrides
@@ -78,6 +78,16 @@
 
     .text {
       width: auto;
+
+      &.extra blockquote {
+        margin-left: 0.5rem;
+        padding-left: 0.75rem;
+        color: @mutedTextColor;
+
+        & > blockquote {
+          margin-left: 0;
+        }
+      }
     }
 
     &.requests-action-event {
@@ -160,6 +170,7 @@
     border-left: @extraTextPointer;
     font-size: @extraTextFontSize;
     line-height: @extraTextLineHeight;
+
   }
 
   /*--------------
@@ -233,4 +244,11 @@
   }
 }
 
+.ui.popup.requests-event-body-popup {
+  padding: 0;
+  border: none;
 
+  .ui.button {
+    margin: 0;
+  }
+}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-requests/issues/491

---

* Adds CSS to remove padding from the Semantic UI [`Popup`](https://react.semantic-ui.com/modules/popup/) when it's being used to show the "quote"/"copy" buttons above highlighted text in request event bodies.

* Reduce the default margin/padding on blockquotes to make nested quotes
look neater.

* Change text color within blockquotes to be a muted gray.

* **These changes only apply to blockquotes and popups shown in comment RequestEvent bodies, not globally across the site.**

### Screenshots

- Blockquote margin/padding

  - Before
    <img width="1325" height="568" alt="image" src="https://github.com/user-attachments/assets/0248727a-ee24-433c-b0da-979a08d5e8e6" />

  - After
    <img width="1321" height="565" alt="image" src="https://github.com/user-attachments/assets/addc05be-bfff-47c0-b53b-d2bfe188e6fe" />

- Removed popup padding

  - Before
    <img width="212" height="133" alt="image" src="https://github.com/user-attachments/assets/43950c66-aae0-447b-874e-e8f9d724e007" />

  - After
    <img width="141" height="82" alt="image" src="https://github.com/user-attachments/assets/cc80dc1f-cc60-487b-9346-e57292786e8a" />