### PR TITLE
Add an empty Overridable container before and after the files accordion

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -180,6 +180,23 @@ export class RDMDepositForm extends Component {
             <Grid className="mt-25">
               <Grid.Column mobile={16} tablet={16} computer={11}>
                 <Overridable
+                  id="InvenioAppRdm.Deposit.Files.before.container"
+                  record={record}
+                  files={files}
+                  permissions={permissions}
+                  preselectedCommunity={preselectedCommunity}
+                  filesLocked={filesLocked}
+                  recordRestrictionGracePeriod={recordRestrictionGracePeriod}
+                  allowRecordRestriction={allowRecordRestriction}
+                  groupsEnabled={groupsEnabled}
+                  allowEmptyFiles={allowEmptyFiles}
+                  customFieldsUI={customFieldsUI}
+                  config={this.config}
+                  vocabularies={this.vocabularies}
+                  noFiles={this.noFiles}
+                  hideCommunitySelection={this.hide_community_selection}
+                />
+                <Overridable
                   id="InvenioAppRdm.Deposit.AccordionFieldFiles.container"
                   record={record}
                   config={this.config}
@@ -231,6 +248,23 @@ export class RDMDepositForm extends Component {
                     </Overridable>
                   </AccordionField>
                 </Overridable>
+                <Overridable
+                  id="InvenioAppRdm.Deposit.Files.after.container"
+                  record={record}
+                  files={files}
+                  permissions={permissions}
+                  preselectedCommunity={preselectedCommunity}
+                  filesLocked={filesLocked}
+                  recordRestrictionGracePeriod={recordRestrictionGracePeriod}
+                  allowRecordRestriction={allowRecordRestriction}
+                  groupsEnabled={groupsEnabled}
+                  allowEmptyFiles={allowEmptyFiles}
+                  customFieldsUI={customFieldsUI}
+                  config={this.config}
+                  vocabularies={this.vocabularies}
+                  noFiles={this.noFiles}
+                  hideCommunitySelection={this.hide_community_selection}
+                />
                 <Overridable
                   id="InvenioAppRdm.Deposit.AccordionFieldBasicInformation.container"
                   config={this.config}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

In accordance with the already existing Overridable  
```js
<Overridable
  id="InvenioAppRdm.Deposit.BasicInformation.after.container"
/>
```
We added an `<Overridable/>`
 - directly before the files accordion and
 - directly after the files accordion.

in order to have additional entry points for React components.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
