### PR TITLE
Fix UX: Inactivate Optional Accordions When No Data Is Present

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2020-2025 CERN.
  * SPDX-FileCopyrightText: 2020-2022 Northwestern University.
  * SPDX-FileCopyrightText: 2021-2022 Graz University of Technology.
- * SPDX-FileCopyrightText: 2022-2024 KTH Royal Institute of Technology.
+ * SPDX-FileCopyrightText: 2022-2025 KTH Royal Institute of Technology.
  * SPDX-License-Identifier: MIT
  */
 
@@ -538,7 +538,7 @@ export class RDMDepositForm extends Component {
                   <AccordionField
                     includesPaths={this.sectionsConfig["funding-section"]}
                     severityChecks={this.severityChecks}
-                    active
+                    active={!!_get(record, "metadata.funding.length")}
                     label={i18next.t("Funding")}
                     ui={this.accordionStyle}
                     id="funding-section"
@@ -643,7 +643,7 @@ export class RDMDepositForm extends Component {
                   <AccordionField
                     includesPaths={this.sectionsConfig["alternate-identifiers-section"]}
                     severityChecks={this.severityChecks}
-                    active
+                    active={!!_get(record, "metadata.identifiers.length")}
                     label={i18next.t("Alternate identifiers")}
                     id="alternate-identifiers-section"
                   >
@@ -680,7 +680,7 @@ export class RDMDepositForm extends Component {
                   <AccordionField
                     includesPaths={this.sectionsConfig["related-works-section"]}
                     severityChecks={this.severityChecks}
-                    active
+                    active={!!_get(record, "metadata.related_identifiers.length")}
                     label={i18next.t("Related works")}
                     id="related-works-section"
                   >
@@ -714,7 +714,7 @@ export class RDMDepositForm extends Component {
                   <AccordionField
                     includesPaths={this.sectionsConfig["references-section"]}
                     severityChecks={this.severityChecks}
-                    active
+                    active={!!_get(record, "metadata.references.length")}
                     label={i18next.t("References")}
                     id="references-section"
                   >

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -501,7 +501,6 @@ export class RDMDepositForm extends Component {
                       <DatesField
                         fieldPath="metadata.dates"
                         options={this.vocabularies.metadata.dates}
-                        showEmptyValue
                       />
                     </Overridable>
 
@@ -658,7 +657,6 @@ export class RDMDepositForm extends Component {
                         label={i18next.t("Alternate identifiers")}
                         labelIcon="barcode"
                         schemeOptions={this.vocabularies.metadata.identifiers.scheme}
-                        showEmptyValue
                       />
                     </Overridable>
                     <Overridable
@@ -693,7 +691,6 @@ export class RDMDepositForm extends Component {
                       <RelatedWorksField
                         fieldPath="metadata.related_identifiers"
                         options={this.vocabularies.metadata.related_identifiers}
-                        showEmptyValue
                       />
                     </Overridable>
                     <Overridable
@@ -724,7 +721,7 @@ export class RDMDepositForm extends Component {
                       vocabularies={this.vocabularies}
                       record={record}
                     >
-                      <ReferencesField fieldPath="metadata.references" showEmptyValue />
+                      <ReferencesField fieldPath="metadata.references" />
                     </Overridable>
                     <Overridable
                       id="InvenioAppRdm.Deposit.AccordionFieldReferences.extra"


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Hopefully closes: https://github.com/inveniosoftware/invenio-app-rdm/issues/1414 🤞

This PR cleans up several deposit form fields and accordion behaviors to reduce confusion for new users. 
In demos, users often try to fill optional fields (e.g., Alternate Identifier, Related works, ...) because the red star suggests they are required. 
By removing showEmptyValue and keeping accordions closed when no data is present, the form shows fewer empty optional fields and avoids misleading cues.

### Key points:

* Prevents users from thinking optional fields are required.
* Accordion sections stay inactive when empty.
* Provides a cleaner and clearer initial form experience.

After:
<img width="1651" height="1241" alt="Screenshot 2025-11-24 at 23 19 17" src="https://github.com/user-attachments/assets/6493ce14-8b12-486f-be77-0ffd382b6f62" />

Before:

<img width="1650" height="1283" alt="Screenshot 2025-11-24 at 23 20 52" src="https://github.com/user-attachments/assets/62c191b4-96bb-4a9b-a528-60da958ad1ef" />


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
