### PR TITLE
fix: correct types for props

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/CopyButton.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/CopyButton.js
@@ -46,7 +46,7 @@ class SimpleCopyButton extends React.Component {
 SimpleCopyButton.propTypes = {
   text: PropTypes.string.isRequired,
   onCopy: PropTypes.func.isRequired,
-  url: PropTypes.func,
+  url: PropTypes.string,
   hoverState: PropTypes.func,
   size: PropTypes.string,
 };
@@ -130,7 +130,7 @@ export class CopyButton extends Component {
 CopyButton.propTypes = {
   popUpPosition: PropTypes.string,
   text: PropTypes.string,
-  url: PropTypes.func,
+  url: PropTypes.string,
   size: PropTypes.string,
 };
 

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/CommunitiesManagementDropdown.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/CommunitiesManagementDropdown.js
@@ -173,7 +173,7 @@ export class CommunitiesManagementDropdown extends Component {
 CommunitiesManagementDropdown.propTypes = {
   userCommunitiesMemberships: PropTypes.object.isRequired,
   recordCommunityEndpoint: PropTypes.string.isRequired,
-  recordCommunitySearchConfig: PropTypes.string.isRequired,
+  recordCommunitySearchConfig: PropTypes.object.isRequired,
   recordUserCommunitySearchConfig: PropTypes.string.isRequired,
   toggleManageCommunitiesModal: PropTypes.func.isRequired,
   actionSucceed: PropTypes.func,


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

- `url` is only used in `fetch(url)` and `fetch` only takes a path
- recordCommunitySearchConfig is a config, so is an object

This clutters up the browser console when you're doing development on the record page

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
