### PR TITLE
feat: add remove_community permission check

### DIFF
--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -302,6 +302,7 @@ def record_detail(
                 "moderate",
                 "request_deletion",
                 "immediately_delete",
+                "remove_community_from_record",
             ]
         ),
         custom_fields_ui=custom_fields["ui"],

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesListModal/RecordCommunitiesSearchItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesListModal/RecordCommunitiesSearchItem.js
@@ -12,7 +12,10 @@ export class RecordCommunitiesSearchItem extends Component {
       updateRecordCallback,
       recordCommunityEndpoint,
       recordParent,
-      permissions: { can_manage: canManage },
+      permissions: {
+        can_manage: canManage,
+        can_remove_community_from_record: canRemoveCommunity,
+      },
       recordRequests,
     } = this.props;
 
@@ -29,6 +32,7 @@ export class RecordCommunitiesSearchItem extends Component {
           result={result}
           recordCommunityEndpoint={recordCommunityEndpoint}
           successCallback={successCallback}
+          canRemoveCommunity={canRemoveCommunity}
         />
       </>
     );

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RemoveFromCommunity/RemoveFromCommunityAction.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RemoveFromCommunity/RemoveFromCommunityAction.js
@@ -6,7 +6,7 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import React, { Component } from "react";
-import { Button, Modal, Message, Icon, Checkbox } from "semantic-ui-react";
+import { Button, Modal, Message, Icon, Checkbox, Popup } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 import { http, ErrorMessage } from "react-invenio-forms";
 import PropTypes from "prop-types";
@@ -85,23 +85,37 @@ export class RemoveFromCommunityAction extends Component {
       checkboxRecords,
       buttonDisabled,
     } = this.state;
-    const { result } = this.props;
+    const { result, canRemoveCommunity } = this.props;
     const communityTitle = result.metadata.title;
+
+    const removeButton = (
+      <Button
+        size="mini"
+        negative
+        labelPosition="left"
+        icon="trash"
+        floated="right"
+        onClick={this.openConfirmModal}
+        content={i18next.t("Remove")}
+        disabled={!canRemoveCommunity}
+        aria-label={i18next.t("Remove {{communityTitle}} from this record", {
+          communityTitle,
+        })}
+      />
+    );
 
     return (
       <>
-        <Button
-          size="mini"
-          negative
-          labelPosition="left"
-          icon="trash"
-          floated="right"
-          onClick={this.openConfirmModal}
-          content={i18next.t("Remove")}
-          aria-label={i18next.t("Remove {{communityTitle}} from this record", {
-            communityTitle,
-          })}
-        />
+        {canRemoveCommunity ? (
+          removeButton
+        ) : (
+          <Popup
+            content={i18next.t(
+              "You don't have permission to remove this community from the record"
+            )}
+            trigger={<span>{removeButton}</span>}
+          />
+        )}
         <Modal size="tiny" dimmer="blurring" open={modalOpen}>
           <Modal.Header as="h2">{i18next.t("Remove community")}</Modal.Header>
           <Modal.Content>
@@ -185,4 +199,9 @@ RemoveFromCommunityAction.propTypes = {
   result: PropTypes.object.isRequired,
   recordCommunityEndpoint: PropTypes.object.isRequired,
   successCallback: PropTypes.func.isRequired,
+  canRemoveCommunity: PropTypes.bool,
+};
+
+RemoveFromCommunityAction.defaultProps = {
+  canRemoveCommunity: true,
 };


### PR DESCRIPTION
Add permission control for removing records from communities:
- Add remove_community to permissions list in record detail view
- Conditionally render RemoveFromCommunityAction based on can_remove_community permission
- closes https://github.com/CERNDocumentServer/cds-rdm/issues/630
