### PR TITLE
feat: UI support for zip content previewing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,32 @@
 Changes
 =======
 
+Version v14.0.0b11.dev0 (released 2026-05-29)
+
+- chore(setup): bump dependencies
+- feat: UI support for zip content previewing
+- fix(alembic): script for preparing migration from 13 -> 14
+- deposits: switch to standard get syntax
+- deposit: add default values for custom fields on deposit form
+- fix(profiler): remove CSP headers for profiler result pages
+- fix(profiler): register menu item for the multi-profiler
+- fix(profiler): override the MultiProfiler base template
+- feat(profiler): integrate Flask-MultiProfiler
+- fix: linting warning
+- feat(users): implement role management in user details
+- fix(records-ui): namespace url filter
+- chore(url): use invenio_url_for for consistency in mshp-req and inv code
+- feat(mshp-req+inv): show invitation & mshp-req pages from user & community sides [+]
+- fix(urls): use invenio_url_for() instead of hard-coded URLs
+- feat: make resouce type badge clickable
+- fix(tombstone): return not-found page + log exception for PIDDeletedError
+- config: remove hardcoded publisher and use THEME_SITENAME
+- frontpage: Add aria-label to 'More' search button
+- fix(upgrade_scripts): use correct indexer for drafts
+- fix: wrap overflowing MathJax content in rich text
+- users: use invenio_url_for for deposit URL
+- users: fix hardcoded deposit URL in uploads dashboard
+
 Version v14.0.0b10.dev7 (released 2026-04-21)
 
 - feat(administration): allow blocking with removal reason

--- a/invenio_app_rdm/__init__.py
+++ b/invenio_app_rdm/__init__.py
@@ -17,6 +17,6 @@
 #
 # See PEP 0440 for details - https://www.python.org/dev/peps/pep-0440
 
-__version__ = "14.0.0b10.dev7"
+__version__ = "14.0.0b11.dev0"
 
 __all__ = ("__version__",)

--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -801,7 +801,9 @@ APP_RDM_ROUTES = {
     "record_detail": "/records/<pid_value>",
     "record_export": "/records/<pid_value>/export/<export_format>",
     "record_file_preview": "/records/<pid_value>/preview/<path:filename>",
+    "record_container_item_preview": "/records/<pid_value>/preview/<path:filename>/container/<path:path>",
     "record_file_download": "/records/<pid_value>/files/<path:filename>",
+    "record_container_item_download": "/records/<pid_value>/files/<path:filename>/container/<path:path>",
     "record_thumbnail": "/records/<pid_value>/thumb<int:size>",
     "record_media_file_download": "/records/<pid_value>/media-files/<path:filename>",
     "record_from_pid": "/<any({schemes}):pid_scheme>/<path:pid_value>",
@@ -1163,6 +1165,10 @@ IIIF_FORMATS_PIL_MAP = {
 }
 """Mapping of IIIF formats to PIL-compatible formats."""
 
+
+PREVIEWABLE_ZIP_PREVIEWER_NATIVE_EXTENSIONS = ["zip"]
+"""Extensions for previewable zip."""
+
 # Invenio-Previewer
 # =================
 # See https://github.com/inveniosoftware/invenio-previewer/blob/master/invenio_previewer/config.py  # noqa
@@ -1178,13 +1184,27 @@ PREVIEWER_PREFERENCE = [
     "video_videojs",
     "audio_videojs",
     "ipynb",
-    "zip",
+    "previewable_zip",
     "txt",
 ]
 """Preferred previewers."""
 
 PREVIEWER_ABSTRACT_TEMPLATE = "invenio_previewer/rdm_abstract_previewer.html"
 """Override the abstract template with an RDM-specific one."""
+
+CONTAINER_ITEM_PREVIEWER_PREFERENCE = [
+    "csv_papaparsejs",
+    "pdfjs",
+    "simple_image",
+    "json_prismjs",
+    "xml_prismjs",
+    "mistune",
+    "video_videojs",
+    "audio_videojs",
+    "ipynb",
+    "zip",
+    "txt",
+]
 
 RECORDS_RESOURCES_IMAGE_FORMATS = ["." + ext for ext in IIIF_FORMATS.keys()]
 """RECORDS_RESOURCES_IMAGE_FORMATS must contain all possible IIIF formats to ensure their metadata is extracted."""

--- a/invenio_app_rdm/records_ui/previewer/previewable_zip.py
+++ b/invenio_app_rdm/records_ui/previewer/previewable_zip.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2025 CESNET i.a.l.e.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Simple ZIP archive previewer."""
+
+import sys
+
+from flask import current_app, render_template
+from invenio_access.permissions import system_identity
+from invenio_base import invenio_url_for
+from invenio_previewer.proxies import current_previewer
+from invenio_previewer.views import is_container_item_previewable
+from invenio_rdm_records.proxies import current_rdm_records_service
+from werkzeug.local import LocalProxy
+
+from ..views.records import PreviewContainerItem
+
+previewable_extensions = LocalProxy(
+    lambda: current_app.config["PREVIEWABLE_ZIP_PREVIEWER_NATIVE_EXTENSIONS"]
+)
+
+
+def create_container_item_preview_link(record_id, container_filename, item_path):
+    """Create preview link for a container item."""
+    values = {
+        "pid_value": record_id,
+        "filename": container_filename,  # specific .zip file
+        "path": item_path,
+    }
+    return invenio_url_for(
+        "invenio_app_rdm_records.record_container_item_preview", **values
+    )
+
+
+def convert_zip_list_container(entries, directories, record_id, container_filename):
+    """Convert structure returned by files.list_container(...).to_dict()."""
+    counter = iter(range(sys.maxsize))
+
+    def create_parent_hierarchy(node, path):
+        """Create and get the child node at the specified path from the given parent node."""
+        for path_item in path:
+            items = node["children"]
+            for child_item in items:
+                if child_item["name"] == path_item:
+                    node = child_item
+                    break
+            else:
+                node = {
+                    "type": "directory",
+                    "name": path_item,
+                    "id": f"directory{next(counter)}",
+                    "children": [],
+                }
+                items.append(node)
+        return node
+
+    def convert_file_entry(key, node):
+        """Convert one node (file or directory)."""
+        converted = {
+            "name": key,
+            "type": "item",
+            "id": f"item{next(counter)}",
+        }
+
+        # Copy metadata fields if they exist
+        for field in ("size", "compressed_size", "mime_type", "crc", "links"):
+            if field in node:
+                converted[field] = node[field]
+
+        # create preview link
+        container_item_extension = key.split(".")[-1].lower()
+        if is_container_item_previewable(container_item_extension):
+            converted["links"].update(
+                {
+                    "preview": create_container_item_preview_link(
+                        record_id, container_filename, node["key"]
+                    )
+                }
+            )
+        return converted
+
+    def convert_directory(key, node):
+        """Convert one node (file or directory)."""
+        converted = {
+            "name": key,
+            "type": "directory",
+            "id": f"directory{next(counter)}",
+            "children": [],
+            "links": node["links"],
+        }
+        return converted
+
+    # Root directory
+    root = {"type": "directory", "id": -1, "children": []}
+
+    # Convert items of root
+    for directory in sorted(directories, key=lambda x: x["key"]):
+        directory_key = directory["key"].split("/")
+        converted = convert_directory(directory_key[-1], directory)
+        hierarchy_position = create_parent_hierarchy(root, directory_key[:-1])
+        hierarchy_position["children"].append(converted)
+
+    for entry in sorted(entries, key=lambda x: x["key"]):
+        entry_key = entry["key"].split("/")
+        converted = convert_file_entry(entry_key[-1], entry)
+        hierarchy_position = create_parent_hierarchy(root, entry_key[:-1])
+        hierarchy_position["children"].append(converted)
+
+    return root
+
+
+def can_preview(file):
+    """Return True if filetype can be previewed."""
+    return (
+        file.is_local()
+        and file.has_extensions(".zip")
+        and not isinstance(file, PreviewContainerItem)  # we are top level file
+    )
+
+
+def preview(file):
+    """Return the appropriate template and pass the file and an embed flag."""
+    tree_raw = current_rdm_records_service.files.list_container(
+        system_identity, file.record["id"], file.filename
+    ).to_dict()
+
+    converted_tree = convert_zip_list_container(
+        tree_raw["entries"], tree_raw["directories"], file.record["id"], file.filename
+    )
+    tree_list = converted_tree["children"]
+    return render_template(
+        "invenio_previewer/previewable_zip.html",
+        file=file,
+        tree=tree_list,
+        limit_reached=False,
+        error=None,
+        js_bundles=current_previewer.js_bundles + ["previewable-zip.js"],
+        css_bundles=current_previewer.css_bundles + ["zip_css.css"],
+    )

--- a/invenio_app_rdm/records_ui/views/__init__.py
+++ b/invenio_app_rdm/records_ui/views/__init__.py
@@ -48,6 +48,8 @@ from .filters import (
 from .records import (
     draft_not_found_error,
     not_found_error,
+    record_container_item_download,
+    record_container_item_preview,
     record_detail,
     record_export,
     record_file_download,
@@ -114,11 +116,23 @@ def create_blueprint(app):
             default_view_func=record_file_preview,
         )
     )
+    blueprint.add_url_rule(
+        **create_url_rule(
+            routes["record_container_item_preview"],
+            default_view_func=record_container_item_preview,
+        )
+    )
 
     blueprint.add_url_rule(
         **create_url_rule(
             routes["record_file_download"],
             default_view_func=record_file_download,
+        )
+    )
+    blueprint.add_url_rule(
+        **create_url_rule(
+            routes["record_container_item_download"],
+            default_view_func=record_container_item_download,
         )
     )
     blueprint.add_url_rule(

--- a/invenio_app_rdm/records_ui/views/decorators.py
+++ b/invenio_app_rdm/records_ui/views/decorators.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2025 CERN.
 # Copyright (C) 2019-2025 Northwestern University.
 # Copyright (C)      2021 TU Wien.
+# Copyright (C) 2025 CESNET i.a.l.e.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -24,6 +25,7 @@ from invenio_rdm_records.resources.serializers.signposting import (
     FAIRSignpostingProfileLvl1Serializer,
 )
 from invenio_rdm_records.services.errors import RecordDeletedException
+from invenio_records_resources.proxies import current_service_registry
 from invenio_records_resources.services.errors import PermissionDeniedError
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -242,6 +244,46 @@ def pass_file_item(is_media=False):
                     item = record_service().get_file_content(**read_kwargs)
 
                 kwargs["file_item"] = item
+                return f(**kwargs)
+
+            except RecordDeletedException:
+                # Redirect to the record page which has proper tombstone handling
+                return redirect(
+                    url_for(
+                        "invenio_app_rdm_records.record_detail",
+                        pid_value=pid_value,
+                    ),
+                    # Use 302 (temporary) instead of 301 since records can be restored
+                    code=302,
+                )
+
+        return view
+
+    return decorator
+
+
+def pass_container_item():
+    """Decorator to pass a extracted file from container (e.g. zip)."""
+
+    def decorator(f):
+        @wraps(f)
+        def view(**kwargs):
+            pid_value = kwargs.get("pid_value")
+            file_key = kwargs.get("filename")
+            path = kwargs.get("path")
+            extract_kwargs = {
+                "id_": pid_value,
+                "file_key": file_key,
+                "identity": g.identity,
+                "path": path,
+            }
+
+            file_service = current_service_registry.get("files")
+
+            try:
+                item = file_service.extract_container_item(**extract_kwargs)
+
+                kwargs["container_item"] = item
                 return f(**kwargs)
 
             except RecordDeletedException:

--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2025 CERN.
 # Copyright (C) 2019-2021 Northwestern University.
 # Copyright (C) 2021-2023 TU Wien.
+# Copyright (C) 2025 CESNET i.a.l.e.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +11,7 @@
 """Routes for record-related pages provided by Invenio-App-RDM."""
 
 import itertools
-from os.path import splitext
+from os.path import basename, splitext
 from pathlib import Path
 
 from flask import abort, current_app, g, redirect, render_template, request, url_for
@@ -46,6 +47,7 @@ from .decorators import (
     add_signposting_content_resources,
     add_signposting_landing_page,
     add_signposting_metadata_resources,
+    pass_container_item,
     pass_file_item,
     pass_file_metadata,
     pass_include_deleted,
@@ -181,6 +183,56 @@ class PreviewFile:
     def open(self):
         """Open the file."""
         return self.file._file.file.storage().open()
+
+
+class PreviewContainerItem(PreviewFile):
+    """Container Item Preview file implementation for InvenioRDM."""
+
+    def __init__(
+        self,
+        file_item,
+        record_pid_value,
+        path,
+        extracted_file_size,
+        record=None,
+        url=None,
+        is_iframe=False,
+    ):
+        """Create a new PreviewFile."""
+        super().__init__(
+            file_item=file_item,
+            record_pid_value=record_pid_value,
+            record=record,
+            url=url,
+            is_iframe=is_iframe,
+        )
+        self.path = path
+        self.size = extracted_file_size
+        self.container_item_filename = basename(self.path)
+        self.uri = url or url_for(
+            "invenio_app_rdm_records.record_container_item_download",
+            pid_value=record_pid_value,
+            filename=self.filename,
+            path=path,
+        )
+
+    def has_extensions(self, *exts):
+        """Check if file has one of the extensions.
+
+        Each `exts` has the format `.{file type}` e.g. `.txt` .
+        """
+        file_ext = splitext(self.container_item_filename)[1].lower()
+        return file_ext in exts
+
+    def open(self):
+        """Open the file."""
+        from invenio_records_resources.proxies import current_service_registry
+
+        file_service = current_service_registry.get("files")
+        opened_file = file_service.open_container_item(
+            g.identity, self.record["id"], self.filename, self.path
+        )
+        return opened_file
 
 
 #
@@ -399,6 +451,47 @@ def record_file_preview(
     return default_previewer.preview(fileobj)
 
 
+@pass_record_or_draft(expand=False)
+@pass_file_metadata
+def record_container_item_preview(
+    pid_value,
+    record=None,
+    file_metadata=None,
+    **kwargs,
+):
+    """Render a preview of the specified item in a container."""
+    filename = kwargs.get("filename")
+    path = kwargs.get("path")
+
+    url = url_for(
+        "invenio_app_rdm_records.record_container_item_download",
+        pid_value=pid_value,
+        filename=filename,
+        path=path,
+    )
+
+    extracted_file_size = 0
+    fileobj = PreviewContainerItem(
+        file_metadata, pid_value, path, extracted_file_size, record, url
+    )
+
+    # Go through all previewers to find the first one that can preview the file
+    for plugin in current_previewer.iter_container_item_previewers():
+        if plugin.can_preview(fileobj):
+            return plugin.preview(fileobj)
+
+    return default_previewer.preview(fileobj)
+
+
+def find_container_item(container_item_metadata, path_parts):
+    """Find a container item in TOC based on path parts."""
+    if not path_parts:
+        return None
+
+    container_item_id = "/".join(path_parts)
+    return container_item_metadata.get(container_item_id)
+
+
 @pass_is_preview
 @pass_file_item(is_media=False)
 @add_signposting_content_resources
@@ -418,6 +511,21 @@ def record_file_download(pid_value, file_item=None, is_preview=False, **kwargs):
         restricted = True
 
     return file_item.send_file(as_attachment=download, restricted=restricted)
+
+
+@pass_container_item()
+@add_signposting_content_resources
+def record_container_item_download(
+    pid_value, container_item=None, is_preview=False, **kwargs
+):
+    """Download a file extracted from a container (e.g., zip archive) within a record."""
+    # emit a file download stats event
+    emitter = current_stats.get_event_emitter("file-download")
+    if container_item is not None and emitter is not None:
+        obj = container_item._file_record.object_version
+        emitter(current_app, record=container_item._record, obj=obj, via_api=False)
+
+    return container_item.send_file()
 
 
 @pass_record_or_draft(expand=False)

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
@@ -2,6 +2,7 @@
 // Copyright (C) 2020-2025 CERN.
 // Copyright (C) 2020-2021 Northwestern University.
 // Copyright (C) 2021 Graz University of Technology.
+// Copyright (C) 2025 CESNET i.a.l.e.
 //
 // Invenio RDM Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -135,3 +136,22 @@ $statsInfoPopup.on("blur", function (event) {
   $(event.target).popup("hide");
   $(event.target).attr("aria-expanded", false);
 });
+
+// ZIP Previewer
+
+const broadcastChannel = new BroadcastChannel("invenio-previewer-zip");
+
+broadcastChannel.onmessage = (e) => {
+  const previewIframe = $("#preview-iframe");
+  $("#preview-file-title").html(`
+  <div class="ui breadcrumb">
+    <a class="section preview-link" href="${e.data.containerPreviewUrl}" target="preview-iframe" data-file-key="${e.data.containerFileKey}">${e.data.containerFileKey}</a>
+    <i class="divider">/</i>
+    <div class="active section">${e.data.fileKey}</div>
+  </div>
+  `);
+  $(".preview-link").on("click", function (event) {
+    $("#preview-file-title").html(event.target.dataset.fileKey);
+  });
+  previewIframe.attr("src", e.data.previewUrl);
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/previewer/previewable_zip.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/previewer/previewable_zip.js
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2025 CESNET i.a.l.e..
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import $ from "jquery";
+
+const channel = new BroadcastChannel("invenio-previewer-zip");
+
+$(".preview-link").on("click", function (e) {
+  e.preventDefault();
+  const fileKey = $(this).data("file-key");
+  const previewUrl = $(this).data("preview-url");
+  const containerFileKey = $(this).data("container-file-key");
+  const containerPreviewUrl = window.location.href;
+  channel.postMessage({
+    fileKey: fileKey,
+    previewUrl: previewUrl,
+    containerFileKey: containerFileKey,
+    containerPreviewUrl: containerPreviewUrl,
+  });
+  console.log(
+    `[${containerFileKey} at ${containerPreviewUrl}] Requested preview for fileKey: ${fileKey} with URL: ${previewUrl}`
+  );
+});

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/files-previewer-zip.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/files-previewer-zip.less
@@ -1,0 +1,11 @@
+.ui.accordion {
+  .title:not(.ui).panel-heading {
+    .ui.breadcrumb {
+      color: initial;
+
+      a.preview-link:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -4,6 +4,7 @@
 
 @import "../../landing_page/creatibutors.less";
 @import "../../landing_page/licenses.less";
+@import "../../landing_page/files-previewer-zip.less";
 
 html,
 body {

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_previewer/previewable_zip.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_previewer/previewable_zip.html
@@ -1,0 +1,92 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2025 CESNET i.a.l.e.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- extends config.PREVIEWER_ABSTRACT_TEMPLATE %}
+
+{%- block head %}
+{{super()}}
+<script src="{{ url_for('static', filename='js/fullscreen.js') }}" defer></script>
+{%- endblock %}
+
+{%- block panel %}
+{% if error %}
+  <div class="ui top attached negative message"><i class="exclamation icon"></i>{{ _(error) }}</div>
+{% else %}
+  <div class="ui equal width grid">
+    <div class="row">
+      <div class="no-padding fourteen wide column"><h4 class="blue-bg ui attached inverted header"><span><i class="file archive outline icon"></i> {{ file.filename }}</span></h4></div>
+      <div class="no-padding right aligned two wide column stretched"><h4 class="blue-bg ui attached inverted header"><span><i id="fullScreenMode" title="{{ _('Full screen') }}" class="expand arrows alternate link icon inverted"></i></span></h4></div>
+    </div>
+  </div>
+  {%- if limit_reached %}
+  <div class="ui attached negative message">
+    <i class="exclamation icon"></i>
+    {{ _('The previewer is not showing all the files.') }}
+  </div>
+  {%- endif %}
+  <div class="ui basic segment">
+    <ul class="tree list-unstyled">
+      {%- for t in tree recursive %}
+      {%- set directory_identifier = t.id %}
+      {%- if t.links is defined %}
+        {%- set file_url_download = t.links.content if t.links.content is defined else None %}
+        {%- set file_url_preview = t.links.preview if t.links.preview is defined else None %}
+      {%- endif %}
+      <li>
+        {%- if t.type != 'directory' %}
+          <div class="ui equal width grid">
+            <div class="row">
+              <div class="no-padding left floated column"><span><i class="file outline icon"></i></i> {{ t.name }}</span></div>
+              <div class="no-padding right aligned column">{{ t.size|filesizeformat }}</div>
+              <div class="no-padding right aligned column stretched">
+                <span>
+                  {% if file_url_preview %}
+                  <button class="ui compact mini button preview-link" id="{{t.id}}" data-container-file-key="{{file.filename}}" data-file-key="{{t.name}}" data-preview-url="{{file_url_preview}}">
+                    <i class="eye icon" aria-hidden="true"></i>{{_("Preview")}}
+                  </button>
+                  {% endif %}
+                  {% if file_url_download %}
+                  <a role="button" class="ui compact mini button" href="{{file_url_download}}">
+                    <i class="download icon" aria-hidden="true"></i>{{_('Download')}}
+                  </a>
+                  {% endif %}
+                </span>
+              </div>
+            </div>
+          </div>
+        {%- else %}
+          <div class="ui equal width grid">
+            <div class="row">
+              <div class="no-padding left floated column">
+                <span>
+                  <i class="folder icon"></i> <a data-toggle="collapse" href="#tree_{{ directory_identifier }}">{{ t.name }} </a>
+                </span>
+              </div>
+              <div class="no-padding right aligned column">
+                {%- if config.RDM_ARCHIVE_DOWNLOAD_ENABLED and file_url_download %}
+                <a role="button" class="ui compact mini button right floated archive-link" href="{{file_url_download}}">
+                  <i class="file archive icon button" aria-hidden="true"></i> {{_("Download all")}}
+                </a>
+                {%- endif %}
+              </div>
+            </div>
+          </div>
+          {%- if t.children -%}
+            <ul id="tree_{{ directory_identifier }}"
+              class="collapse in">
+              {{ loop(t.children) }}
+            </ul>
+          {%- endif %}
+        {%- endif %}
+      </li>
+      {%- endfor %}
+    </ul>
+   </div>
+  {%- endif %}
+{%- endblock %}

--- a/invenio_app_rdm/theme/webpack.py
+++ b/invenio_app_rdm/theme/webpack.py
@@ -44,6 +44,7 @@ theme = WebpackThemeBundle(
                 "uppy-file-uploader": "./less/invenio_app_rdm/file_uploader/uppy.less",
                 "flask-multiprofiler-style": "./less/invenio_app_rdm/multiprofiler/profiler.less",
                 "flask-multiprofiler-code": "./js/invenio_app_rdm/multiprofiler.js",
+                "previewable-zip": "./js/invenio_app_rdm/previewer/previewable_zip.js",
             },
             dependencies={
                 "@babel/runtime": "^7.9.0",

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,32 +46,32 @@ install_requires =
     invenio-rest>=3.0.0,<4.0.0
     invenio-theme>=4.0.0,<5.0.0
     # Invenio auth bundle
-    invenio-access>=5.0.0,<6.0.0
-    invenio-accounts>=7.0.0,<8.0.0
-    invenio-oauth2server>=4.0.0,<5.0.0
-    invenio-oauthclient>=7.0.0,<8.0.0
-    invenio-userprofiles>=5.0.0,<6.0.0
+    invenio-access>=6.0.0,<7.0.0
+    invenio-accounts>=8.0.0,<9.0.0
+    invenio-oauth2server>=5.0.0,<6.0.0
+    invenio-oauthclient>=8.0.0,<9.0.0
+    invenio-userprofiles>=6.0.0,<7.0.0
     # Invenio metadata bundle
-    invenio-indexer>=4.0.0,<5.0.0
+    invenio-indexer>=5.0.0,<6.0.0
     invenio-jsonschemas>=2.0.0,<3.0.0
-    invenio-oaiserver>=4.0.0,<5.0.0
+    invenio-oaiserver>=5.0.0,<6.0.0
     invenio-pidstore>=3.0.0,<4.0.0
-    invenio-records-rest>=4.0.0,<5.0.0
-    invenio-records-ui>=3.0.0,<4.0.0
-    invenio-records>=4.0.0,<5.0.0
+    invenio-records-rest>=5.0.0,<6.0.0
+    invenio-records-ui>=4.0.0,<5.0.0
+    invenio-records>=5.0.0,<6.0.0
     invenio-search-ui>=4.0.0,<5.0.0
     # Invenio files bundle
-    invenio-files-rest>=4.0.0,<5.0.0
-    invenio-previewer>=4.0.0,<5.0.0
-    invenio-records-files>=2.0.0,<3.0.0
+    invenio-files-rest>=5.0.0,<6.0.0
+    invenio-previewer>=5.0.0,<6.0.0
+    invenio-records-files>=3.0.0,<4.0.0
     # Invenio-App-RDM
-    invenio-collections>=8.0.0,<9.0.0
-    invenio-communities>=26.0.0,<27.0.0
-    invenio-rdm-records>=28.0.0,<29.0.0
+    invenio-collections>=9.0.0,<10.0.0
+    invenio-communities>=27.0.0,<28.0.0
+    invenio-rdm-records>=29.0.0,<30.0.0
     CairoSVG>=2.5.2,<3.0.0
-    invenio-banners>=6.0.0,<7.0.0
-    invenio-pages>=8.0.0,<9.0.0
-    invenio-audit-logs>=2.0.0,<3.0.0
+    invenio-banners>=7.0.0,<8.0.0
+    invenio-pages>=9.0.0,<10.0.0
+    invenio-audit-logs>=3.0.0,<4.0.0
     invenio-sitemap>=0.1.0,<2.0.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,6 +114,7 @@ invenio_assets.webpack =
     invenio_app_rdm_theme = invenio_app_rdm.theme.webpack:theme
 invenio_previewer.previewers =
     iiif_simple = invenio_app_rdm.records_ui.previewer.iiif_simple
+    previewable_zip = invenio_app_rdm.records_ui.previewer.previewable_zip
 invenio_celery.tasks =
     invenio_app_rdm = invenio_app_rdm.tasks
 invenio_administration.views =


### PR DESCRIPTION
### Description

This PR is one of the 4 PRs enabling invenio to preview files inside zip archives and other container files in general.

The other parts are:
* [invenio-records-resources](https://github.com/inveniosoftware/invenio-records-resources/pull/666) which provides the API for listing container and accessing/extracting container items
* [invenio-previewer](https://github.com/inveniosoftware/invenio-previewer/pull/243) which provides the configuration of previewable items inside container files
* [invenio-rdm-records](https://github.com/inveniosoftware/invenio-rdm-records/pull/2222) which provides the concrete implementation of this API for ZIP archives

This PR adds:
* New entrypoint for zip enhanced previewer
* Zip enhanced previewer
* Decorator to pass container item to views
* view function to preview specific container item and download it
* Two new routes for preview and download container items
* JS and HTML files

Additions provide new functionality but do not change existing API nor implementation.

All these features are opt-in, see RFC for configuration details.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
