### PR TITLE
templates(records-ui): split file macros into separate templates

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -9,71 +9,24 @@
   it under the terms of the MIT License; see LICENSE file for more details.
 #}
 
+{% from "invenio_app_rdm/records/macros/files/preview_file.html"
+import preview_file as _preview_file with context %}
+{% from "invenio_app_rdm/records/macros/files/preview_file_box.html"
+import preview_file_box as _preview_file_box with context %}
+{% from "invenio_app_rdm/records/macros/files/file_list.html"
+import file_list as _file_list with context %}
+{% from "invenio_app_rdm/records/macros/files/file_list_box.html"
+import file_list_box as _file_list_box with context %}
+{% from "invenio_app_rdm/records/macros/files/media_file_list_box.html"
+import media_file_list_box as _media_file_list_box with context %}
 
 {%- macro preview_file(preview_endpoint, pid_value, filename, is_preview, include_deleted, id='preview-iframe' ) %}
-  {%- set include_deleted_value = 0 -%}
-  {% if include_deleted %}
-    {%- set include_deleted_value = 1 -%}
-  {% endif %}
-  {% if is_preview %}
-    {%- set preview_url = url_for(preview_endpoint, pid_value=pid_value, filename=filename, preview=1, include_deleted=include_deleted_value) -%}
-  {% else %}
-    {%- set preview_url = url_for(preview_endpoint, pid_value=pid_value, filename=filename, include_deleted=include_deleted_value) -%}
-  {% endif %}
-  <iframe
-    title="{{_('Preview')}}"
-    class="preview-iframe"
-    id="{{id}}"
-    name="{{id}}"
-    src="{{ preview_url }}"
-  >
-  </iframe>
+    {{ _preview_file(preview_endpoint, pid_value, filename, is_preview, include_deleted, id='preview-iframe') }}
 {%- endmacro %}
-
 
 {% macro preview_file_box(file, pid, is_preview, record, include_deleted) %}
-  {%- set is_remote_file = file.transfer.type == transfer_types.REMOTE %}
-  <div class="ui accordion panel mb-10 {{record.ui.access_status.id}}" href="#files-preview-accordion-panel">
-    <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
-      <div
-        role="button"
-        id="files-preview-accordion-trigger"
-        aria-controls="files-preview-accordion-panel"
-        aria-expanded="true"
-        tabindex="0"
-        class="trigger"
-        aria-label="{{ _('File preview') }}"
-      >
-        <span id="preview-file-title">{{ file.key }}</span>
-        <i class="angle right icon" aria-hidden="true"></i>
-      </div>
-    </h3>
-    <div
-      role="region"
-      id="files-preview-accordion-panel"
-      aria-labelledby="files-preview-accordion-trigger"
-      class="active content preview-container pt-0 {{record.ui.access_status.id}}"
-    >
-      {%- if is_remote_file %}
-      <div class="ui info message">
-        <div class="header">
-          {{ _('This file cannot be previewed') }}
-        </div>
-        <ul class="list">
-          <li>{{ _('This file is an external reference and not stored directly in this repository.
-To access its content, please download it and open it locally.') }}
-          </li>
-        </ul>
-      </div>
-      {%- else %}
-      <div>
-        {{ preview_file('invenio_app_rdm_records.record_file_preview', pid_value=pid, filename=file.key, is_preview=is_preview, include_deleted=include_deleted) }}
-      </div>
-      {%- endif %}
-    </div>
-  </div>
+    {{ _preview_file_box(file, pid, is_preview, record, include_deleted) }}
 {%- endmacro %}
-
 
 {%- macro file_list(
     files, pid, is_preview, include_deleted,
@@ -83,129 +36,20 @@ To access its content, please download it and open it locally.') }}
     preview_endpoint='invenio_app_rdm_records.record_file_preview',
     is_media=false,
     permissions=None
-) %}
-  <table class="ui striped table files fluid {{record.ui.access_status.id}}">
-    <thead>
-      <tr>
-        <th>{{_('Name')}}</th>
-        <th>{{_('Size')}}</th>
-        <th class>
-          {%- if config.RDM_ARCHIVE_DOWNLOAD_ENABLED %}
-            {% set archive_download_url = record.links.archive_media if is_media else record.links.archive %}
-            <a role="button" class="ui compact mini button right floated archive-link" href="{{ archive_download_url }}">
-              <i class="file archive icon button" aria-hidden="true"></i> {{_("Download all")}}
-            </a>
-          {%- endif %}
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-    {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
-    {%- set include_deleted_value = 0 -%}
-    {% if include_deleted %}
-      {%- set include_deleted_value = 1 -%}
-    {% endif %}
-    {% for file in files %}
-      {% if not file.access.hidden %}
-        {%- set is_remote_file = file.transfer.type == transfer_types.REMOTE %}
-        {% if is_preview %}
-          {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1, preview=1) %}
-          {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=file.key, preview=1, include_deleted=include_deleted_value) %}
-        {% else %}
-          {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1) %}
-          {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=file.key, include_deleted=include_deleted_value) %}
-        {% endif %}
-
-        {%- set file_type = file.key.split('.')[-1] %}
-        <tr>
-          <td class="ten wide">
-            <div>
-              <a href="{{ file_url_download }}">{{ file.key }}</a>
-            </div>
-            {%- if not is_remote_file %}
-            <small class="ui text-muted font-tiny">{{ file.checksum or _("Checksum not yet calculated.") }}
-            <div class="ui icon inline-block" data-tooltip="{{_('This is the file fingerprint (checksum), which can be used to verify the file integrity.')}}">
-              <i class="question circle checksum icon"></i>
-            </div>
-            </small>
-            {%- endif %}
-          </td>
-          <td>{%- if is_remote_file %}{{_("N/A (external)")}}{%- else -%}{{ file.size|filesizeformat(binary=binary_sizes) }}{%- endif %}</td>
-          <td class="right aligned">
-            <span>
-              {% if with_preview and file_type|lower is previewable and not is_remote_file %}
-                <a role="button" class="ui compact mini button preview-link" href="{{ file_url_preview }}" target="preview-iframe" data-file-key="{{file.key}}">
-                  <i class="eye icon" aria-hidden="true"></i>{{_("Preview")}}
-                </a>
-              {% endif %}
-              <a role="button" class="ui compact mini button" href="{{ file_url_download }}">
-                <i class="download icon" aria-hidden="true"></i>{{_('Download')}}
-              </a>
-            </span>
-          </td>
-        </tr>
-      {% endif %}
-    {% endfor %}
-    </tbody>
-  </table>
+    ) %}
+    {{ _file_list(files, pid, is_preview, include_deleted,
+        record=record,
+        with_preview=with_preview,
+        download_endpoint=download_endpoint,
+        preview_endpoint=preview_endpoint,
+        is_media=is_media,
+        permissions=permissions) }}
 {%- endmacro %}
 
-
 {% macro file_list_box(files, pid, is_preview, include_deleted, record, permissions) %}
-  {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
-  <div class="ui accordion panel mb-10 {{ record.ui.access_status.id }}" href="#files-list-accordion-panel">
-    <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
-      <div role="button" id="files-list-accordion-trigger" aria-controls="files-list-accordion-panel" aria-expanded="true" tabindex="0" class="trigger">
-        {{ _("Files") }}
-        <small class="text-muted">{% if files %} ({{files|map(attribute='size', default=0)|sum()|filesizeformat(binary=binary_sizes)}}){% endif %}</small>
-        <i class="angle right icon" aria-hidden="true"></i>
-      </div>
-    </h3>
-
-    <div role="region" id="files-list-accordion-panel" aria-labelledby="files-list-accordion-trigger" class="active content pt-0">
-      {% if record.access.files == 'restricted' %}
-        <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
-          <i class="ui {{ record.ui.access_status.icon }} icon" aria-hidden="true"></i>
-          <h4 class="inline">{{ record.ui.access_status.title_l10n }}</h4>
-          <p>{{ record.ui.access_status.description_l10n }}</p>
-          {% if record.access.embargo.reason %}
-            <p>{{_("Reason")}}: {{record.access.embargo.reason}}</p>
-          {% endif%}
-        </div>
-      {% endif %}
-      <div>
-        {{ file_list(files, pid, is_preview, include_deleted, record=record,download_endpoint="invenio_app_rdm_records.record_file_download", permissions=permissions) }}
-      </div>
-    </div>
-  </div>
+    {{ _file_list_box(files, pid, is_preview, include_deleted, record, permissions) }}
 {%- endmacro %}
 
 {% macro media_file_list_box(files, pid, is_preview, include_deleted, record, permissions) %}
-  {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
-  <div class="ui accordion panel mb-10 {{ record.access.record }}" href="#media-files-preview-accordion-panel">
-    <h3 class="active title panel-heading {{ record.access.record }} m-0">
-      <div role="button" id="media-files-preview-accordion-trigger" aria-controls="media-files-preview-accordion-panel" aria-expanded="true" tabindex="0" class="trigger">
-        {{ _("System files") }}
-        <small class="text-muted">{% if files %} ({{files|sum(attribute='size')|filesizeformat(binary=binary_sizes)}}){% endif %}</small>
-        <i class="angle right icon" aria-hidden="true"></i>
-      </div>
-    </h3>
-
-    <div role="region" id="media-files-preview-accordion-panel" aria-labelledby="media-files-preview-accordion-trigger" class="active content pt-0">
-      {% if record.access.record == 'restricted'%}
-        <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
-          <i class="ui {{ record.ui.access_status.icon }} icon"></i>
-          <h4 class="inline">{{ record.ui.access_status.title_l10n }}</h4>
-
-          <p>{{ record.ui.access_status.description_l10n }}</p>
-          {% if record.access.embargo.reason %}
-            <p>{{_("Reason")}}: {{record.access.embargo.reason}}</p>
-          {% endif%}
-        </div>
-      {% endif %}
-      <div>
-        {{ file_list(files, pid, is_preview, include_deleted, record=record, with_preview=false, download_endpoint="invenio_app_rdm_records.record_media_file_download", is_media=true, permissions=permissions) }}
-      </div>
-    </div>
-  </div>
+    {{ _media_file_list_box(files, pid, is_preview, include_deleted, record, permissions) }}
 {%- endmacro %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files/file_list.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files/file_list.html
@@ -1,0 +1,95 @@
+{#
+  Copyright (C) 2020-2025 CERN.
+  Copyright (C) 2023 Northwestern University.
+  Copyright (C) 2021 Graz University of Technology.
+  Copyright (C) 2021 TU Wien.
+  Copyright (C) New York University.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- macro file_list(
+    files, pid, is_preview, include_deleted,
+    record=None,
+    with_preview=true,
+    download_endpoint='invenio_app_rdm_records.record_file_download',
+    preview_endpoint='invenio_app_rdm_records.record_file_preview',
+    is_media=false,
+    permissions=None
+    ) %}
+    <table class="ui striped table files fluid {{ record.ui.access_status.id }}">
+        <thead>
+            <tr>
+                <th>{{ _("Name") }}</th>
+                <th>{{ _("Size") }}</th>
+                <th class>
+                    {%- if config.RDM_ARCHIVE_DOWNLOAD_ENABLED %}
+                        {% set archive_download_url = record.links.archive_media if is_media else record.links.archive %}
+                        <a role="button"
+                           class="ui compact mini button right floated archive-link"
+                           href="{{ archive_download_url }}">
+                            <i class="file archive icon button" aria-hidden="true"></i> {{ _("Download all") }}
+                        </a>
+                    {%- endif %}
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
+            {%- set include_deleted_value = 0 -%}
+            {% if include_deleted %}
+                {%- set include_deleted_value = 1 -%}
+            {% endif %}
+            {% for file in files %}
+                {% if not file.access.hidden %}
+                    {%- set is_remote_file = file.transfer.type == transfer_types.REMOTE %}
+                    {% if is_preview %}
+                        {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1, preview=1) %}
+                        {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=file.key, preview=1, include_deleted=include_deleted_value) %}
+                    {% else %}
+                        {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1) %}
+                        {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=file.key, include_deleted=include_deleted_value) %}
+                    {% endif %}
+                    {%- set file_type = file.key.split('.')[-1] %}
+                    <tr>
+                        <td class="ten wide">
+                            <div>
+                                <a href="{{ file_url_download }}">{{ file.key }}</a>
+                            </div>
+                            {%- if not is_remote_file %}
+                                <small class="ui text-muted font-tiny">{{ file.checksum or _("Checksum not yet calculated.") }}
+                                    <div class="ui icon inline-block"
+                                         data-tooltip="{{ _("This is the file fingerprint (checksum), which can be used to verify the file integrity.") }}">
+                                        <i class="question circle checksum icon"></i>
+                                    </div>
+                                </small>
+                            {%- endif %}
+                        </td>
+                        <td>
+                            {%- if is_remote_file %}{{ _("N/A (external)") }}{%- else -%}{{ file.size|filesizeformat(binary=binary_sizes) }}{%- endif %}
+                            </td>
+                            <td class="right aligned">
+                                <span>
+                                    {% if with_preview and file_type|lower is previewable and not is_remote_file %}
+                                        <a role="button"
+                                           class="ui compact mini button preview-link"
+                                           href="{{ file_url_preview }}"
+                                           target="preview-iframe"
+                                           data-file-key="{{ file.key }}">
+                                            <i class="eye icon" aria-hidden="true"></i>{{ _("Preview") }}
+                                        </a>
+                                    {% endif %}
+                                    <a role="button"
+                                       class="ui compact mini button"
+                                       href="{{ file_url_download }}">
+                                        <i class="download icon" aria-hidden="true"></i>{{ _("Download") }}
+                                    </a>
+                                </span>
+                            </td>
+                        </tr>
+                    {% endif %}
+                {% endfor %}
+            </tbody>
+        </table>
+    {%- endmacro %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files/file_list_box.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files/file_list_box.html
@@ -1,0 +1,49 @@
+{#
+  Copyright (C) 2020-2025 CERN.
+  Copyright (C) 2023 Northwestern University.
+  Copyright (C) 2021 Graz University of Technology.
+  Copyright (C) 2021 TU Wien.
+  Copyright (C) New York University.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% from "invenio_app_rdm/records/macros/files/file_list.html" import file_list with context %}
+
+{% macro file_list_box(files, pid, is_preview, include_deleted, record, permissions) %}
+    {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
+    <div class="ui accordion panel mb-10 {{ record.ui.access_status.id }}"
+         href="#files-list-accordion-panel">
+        <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
+            <div role="button"
+                 id="files-list-accordion-trigger"
+                 aria-controls="files-list-accordion-panel"
+                 aria-expanded="true"
+                 tabindex="0"
+                 class="trigger">
+                {{ _("Files") }}
+                <small class="text-muted">
+                    {% if files %}({{ files|map(attribute='size', default=0) |sum()|filesizeformat(binary=binary_sizes) }}){% endif %}
+                </small>
+                <i class="angle right icon" aria-hidden="true"></i>
+            </div>
+        </h3>
+        <div role="region"
+             id="files-list-accordion-panel"
+             aria-labelledby="files-list-accordion-trigger"
+             class="active content pt-0">
+            {% if record.access.files == 'restricted' %}
+                <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
+                    <i class="ui {{ record.ui.access_status.icon }} icon" aria-hidden="true"></i>
+                    <h4 class="inline">{{ record.ui.access_status.title_l10n }}</h4>
+                    <p>{{ record.ui.access_status.description_l10n }}</p>
+                    {% if record.access.embargo.reason %}<p>{{ _("Reason") }}: {{ record.access.embargo.reason }}</p>{% endif %}
+                </div>
+            {% endif %}
+            <div>
+                {{ file_list(files, pid, is_preview, include_deleted, record=record,download_endpoint="invenio_app_rdm_records.record_file_download", permissions=permissions) }}
+            </div>
+        </div>
+    </div>
+{%- endmacro %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files/media_file_list_box.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files/media_file_list_box.html
@@ -1,0 +1,49 @@
+{#
+  Copyright (C) 2020-2025 CERN.
+  Copyright (C) 2023 Northwestern University.
+  Copyright (C) 2021 Graz University of Technology.
+  Copyright (C) 2021 TU Wien.
+  Copyright (C) New York University.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% from "invenio_app_rdm/records/macros/files/file_list.html" import file_list with context %}
+
+{% macro media_file_list_box(files, pid, is_preview, include_deleted, record, permissions) %}
+    {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
+    <div class="ui accordion panel mb-10 {{ record.access.record }}"
+         href="#media-files-preview-accordion-panel">
+        <h3 class="active title panel-heading {{ record.access.record }} m-0">
+            <div role="button"
+                 id="media-files-preview-accordion-trigger"
+                 aria-controls="media-files-preview-accordion-panel"
+                 aria-expanded="true"
+                 tabindex="0"
+                 class="trigger">
+                {{ _("System files") }}
+                <small class="text-muted">
+                    {% if files %}({{ files|sum(attribute='size') |filesizeformat(binary=binary_sizes) }}){% endif %}
+                </small>
+                <i class="angle right icon" aria-hidden="true"></i>
+            </div>
+        </h3>
+        <div role="region"
+             id="media-files-preview-accordion-panel"
+             aria-labelledby="media-files-preview-accordion-trigger"
+             class="active content pt-0">
+            {% if record.access.record == 'restricted' %}
+                <div class="ui {{ record.ui.access_status.message_class }} message file-box-message">
+                    <i class="ui {{ record.ui.access_status.icon }} icon"></i>
+                    <h4 class="inline">{{ record.ui.access_status.title_l10n }}</h4>
+                    <p>{{ record.ui.access_status.description_l10n }}</p>
+                    {% if record.access.embargo.reason %}<p>{{ _("Reason") }}: {{ record.access.embargo.reason }}</p>{% endif %}
+                </div>
+            {% endif %}
+            <div>
+                {{ file_list(files, pid, is_preview, include_deleted, record=record, with_preview=false, download_endpoint="invenio_app_rdm_records.record_media_file_download", is_media=true, permissions=permissions) }}
+            </div>
+        </div>
+    </div>
+{%- endmacro %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files/preview_file.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files/preview_file.html
@@ -1,0 +1,28 @@
+{#
+  Copyright (C) 2020-2025 CERN.
+  Copyright (C) 2023 Northwestern University.
+  Copyright (C) 2021 Graz University of Technology.
+  Copyright (C) 2021 TU Wien.
+  Copyright (C) New York University.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- macro preview_file(preview_endpoint, pid_value, filename, is_preview, include_deleted, id='preview-iframe' ) %}
+    {%- set include_deleted_value = 0 -%}
+    {% if include_deleted %}
+        {%- set include_deleted_value = 1 -%}
+    {% endif %}
+    {% if is_preview %}
+        {%- set preview_url = url_for(preview_endpoint, pid_value=pid_value, filename=filename, preview=1, include_deleted=include_deleted_value) -%}
+    {% else %}
+        {%- set preview_url = url_for(preview_endpoint, pid_value=pid_value, filename=filename, include_deleted=include_deleted_value) -%}
+    {% endif %}
+    <iframe title="{{ _("Preview") }}"
+            class="preview-iframe"
+            id="{{ id }}"
+            name="{{ id }}"
+            src="{{ preview_url }}">
+    </iframe>
+{%- endmacro %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files/preview_file_box.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files/preview_file_box.html
@@ -1,0 +1,51 @@
+{#
+  Copyright (C) 2020-2025 CERN.
+  Copyright (C) 2023 Northwestern University.
+  Copyright (C) 2021 Graz University of Technology.
+  Copyright (C) 2021 TU Wien.
+  Copyright (C) New York University.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% from "invenio_app_rdm/records/macros/files/preview_file.html" import preview_file with context %}
+
+{% macro preview_file_box(file, pid, is_preview, record, include_deleted) %}
+    {%- set is_remote_file = file.transfer.type == transfer_types.REMOTE %}
+    <div class="ui accordion panel mb-10 {{ record.ui.access_status.id }}"
+         href="#files-preview-accordion-panel">
+        <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
+            <div role="button"
+                 id="files-preview-accordion-trigger"
+                 aria-controls="files-preview-accordion-panel"
+                 aria-expanded="true"
+                 tabindex="0"
+                 class="trigger"
+                 aria-label="{{ _("File preview") }}">
+                <span id="preview-file-title">{{ file.key }}</span>
+                <i class="angle right icon" aria-hidden="true"></i>
+            </div>
+        </h3>
+        <div role="region"
+             id="files-preview-accordion-panel"
+             aria-labelledby="files-preview-accordion-trigger"
+             class="active content preview-container pt-0 {{ record.ui.access_status.id }}">
+            {%- if is_remote_file %}
+                <div class="ui info message">
+                    <div class="header">{{ _("This file cannot be previewed") }}</div>
+                    <ul class="list">
+                        <li>
+                            {{ _('This file is an external reference and not stored directly in this repository.
+                                                        To access its content, please download it and open it locally.') }}
+                        </li>
+                    </ul>
+                </div>
+            {%- else %}
+                <div>
+                    {{ preview_file('invenio_app_rdm_records.record_file_preview', pid_value=pid, filename=file.key, is_preview=is_preview, include_deleted=include_deleted) }}
+                </div>
+            {%- endif %}
+        </div>
+    </div>
+{%- endmacro %}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This change splits `files.html` into smaller macro components so individual parts can be overridden independently. This avoids having to override the entire files.html file when only a single component needs customization.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
