### PR TITLE
refactor(ui): support custom file display name resolver

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/detail.html
@@ -26,6 +26,9 @@
 {%- set title = record_ui["metadata"]["title"] %}
 {%- set metadata = record_ui["metadata"] %}
 
+<!-- Shared namespace for files to allow overridability on child blocks while maintaining reference to parent values -->
+{% set files_ns = namespace(preview_file=None, files=[]) %}
+
 {%- set can_curate_record = permissions is defined and (permissions.can_edit or permissions.can_review) %}
 
 <!-- preview_submission_request is set to true when coming from a community submission request -->
@@ -288,14 +291,19 @@
                          aria-label="{{ _('Files') }}">
                   {%- if permissions.can_read_files -%}
                     {# record has files AND user can see files #}
-                    {%- set files = files | order_entries | selectattr("status", "==", "completed") | list %}
-                    {%- if files|length > 0 -%}
+                    {# Shared namespace for files (outside blocks) #}
+                    {%- set files_ns.files = files | order_entries | selectattr("status", "==", "completed") | list %}
+                    {%- if files_ns.files|length > 0 -%}
                       <h2 id="files-heading">{{ _('Files') }}</h2>
-                      {%- if files|has_previewable_files -%}
-                        {%-set preview_file = files|select_preview_file(default_preview=record_ui["files"]["default_preview"]) %}
-                        {{ preview_file_box(preview_file, record_ui["id"], is_preview, record, include_deleted) }}
+                      {%- if files_ns.files|has_previewable_files -%}
+                        {%-set files_ns.preview_file = files_ns.files|select_preview_file(default_preview=record_ui["files"]["default_preview"]) %}
+                        {%- block record_file_preview -%}
+                          {{ preview_file_box(files_ns.preview_file, record_ui["id"], is_preview, record, include_deleted) }}
+                        {%- endblock record_file_preview -%}
                       {%- endif -%}
-                      {{ file_list_box(files, record_ui["id"], is_preview, include_deleted, record, permissions) }}
+                      {%- block record_file_list -%}
+                        {{ file_list_box(files_ns.files, record_ui["id"], is_preview, include_deleted, record, permissions) }}
+                      {%- endblock record_file_list -%}
                     {% endif %}
                   {% else %}
                     {# record has files BUT user does not have permission to see files #}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -31,8 +31,13 @@
 {%- endmacro %}
 
 
-{% macro preview_file_box(file, pid, is_preview, record, include_deleted) %}
+{% macro preview_file_box(file, pid, is_preview, record, include_deleted, display_name=None) %}
   {%- set is_remote_file = file.transfer.type == transfer_types.REMOTE %}
+  {%- if display_name %}
+    {%- set human_readable_file_name = display_name(file) or file.key %}
+  {%- else %}
+    {%- set human_readable_file_name = file.key %}
+  {%- endif %}
   <div class="ui accordion panel mb-10 {{record.ui.access_status.id}}" href="#files-preview-accordion-panel">
     <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
       <div
@@ -44,7 +49,7 @@
         class="trigger"
         aria-label="{{ _('File preview') }}"
       >
-        <span id="preview-file-title">{{ file.key }}</span>
+        <span id="preview-file-title">{{ human_readable_file_name }}</span>
         <i class="angle right icon" aria-hidden="true"></i>
       </div>
     </h3>
@@ -82,7 +87,8 @@ To access its content, please download it and open it locally.') }}
     download_endpoint='invenio_app_rdm_records.record_file_download',
     preview_endpoint='invenio_app_rdm_records.record_file_preview',
     is_media=false,
-    permissions=None
+    permissions=None,
+    display_name=None
 ) %}
   <table class="ui striped table files fluid {{record.ui.access_status.id}}">
     <thead>
@@ -108,6 +114,11 @@ To access its content, please download it and open it locally.') }}
     {% for file in files %}
       {% if not file.access.hidden %}
         {%- set is_remote_file = file.transfer.type == transfer_types.REMOTE %}
+        {%- if display_name %}
+          {%- set human_readable_file_name = display_name(file) or file.key %}
+        {%- else %}
+          {%- set human_readable_file_name = file.key %}
+        {%- endif %}
         {% if is_preview %}
           {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1, preview=1) %}
           {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=file.key, preview=1, include_deleted=include_deleted_value) %}
@@ -120,7 +131,7 @@ To access its content, please download it and open it locally.') }}
         <tr>
           <td class="ten wide">
             <div>
-              <a href="{{ file_url_download }}">{{ file.key }}</a>
+              <a href="{{ file_url_download }}">{{ human_readable_file_name }}</a>
             </div>
             {%- if not is_remote_file %}
             <small class="ui text-muted font-tiny">{{ file.checksum or _("Checksum not yet calculated.") }}
@@ -151,7 +162,7 @@ To access its content, please download it and open it locally.') }}
 {%- endmacro %}
 
 
-{% macro file_list_box(files, pid, is_preview, include_deleted, record, permissions) %}
+{% macro file_list_box(files, pid, is_preview, include_deleted, record, permissions, display_name=None) %}
   {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
   <div class="ui accordion panel mb-10 {{ record.ui.access_status.id }}" href="#files-list-accordion-panel">
     <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
@@ -174,13 +185,13 @@ To access its content, please download it and open it locally.') }}
         </div>
       {% endif %}
       <div>
-        {{ file_list(files, pid, is_preview, include_deleted, record=record,download_endpoint="invenio_app_rdm_records.record_file_download", permissions=permissions) }}
+        {{ file_list(files, pid, is_preview, include_deleted, record=record,download_endpoint="invenio_app_rdm_records.record_file_download", permissions=permissions, display_name=display_name) }}
       </div>
     </div>
   </div>
 {%- endmacro %}
 
-{% macro media_file_list_box(files, pid, is_preview, include_deleted, record, permissions) %}
+{% macro media_file_list_box(files, pid, is_preview, include_deleted, record, permissions, display_name=None) %}
   {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
   <div class="ui accordion panel mb-10 {{ record.access.record }}" href="#media-files-preview-accordion-panel">
     <h3 class="active title panel-heading {{ record.access.record }} m-0">
@@ -204,7 +215,7 @@ To access its content, please download it and open it locally.') }}
         </div>
       {% endif %}
       <div>
-        {{ file_list(files, pid, is_preview, include_deleted, record=record, with_preview=false, download_endpoint="invenio_app_rdm_records.record_media_file_download", is_media=true, permissions=permissions) }}
+        {{ file_list(files, pid, is_preview, include_deleted, record=record, with_preview=false, download_endpoint="invenio_app_rdm_records.record_media_file_download", is_media=true, permissions=permissions, display_name=display_name) }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
closes https://github.com/CERNDocumentServer/cds-rdm/issues/652

:heart: Thank you for your contribution!

### Description

- This change allows the file names shown on the record page to be customized by passing a small resolver function to the file UI macros. 

- Instead of always displaying the file key, instances can customize how the file name should be derived (for example: using file.metadata.title instead of file.key).

- New blocks added to make customization of the file name for preview box and files list, without overriding the record_files block.

See CDS-RDM override: https://github.com/CERNDocumentServer/cds-rdm/pull/655

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
