### PR TITLE
fix(config): remove value for the deprecated WSGI_PROXIES variable

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -725,13 +725,6 @@ ACCESS_CACHE = "invenio_cache:current_cache"
 SEARCH_HOSTS = [{"host": "localhost", "port": 9200}]
 """Search hosts."""
 
-# Invenio-Base
-# ============
-# See https://invenio-base.readthedocs.io/en/latest/api.html#invenio_base.wsgi.wsgi_proxyfix  # noqa
-
-WSGI_PROXIES = 2
-"""Correct number of proxies in front of your application."""
-
 # Invenio-REST
 # ============
 


### PR DESCRIPTION
The configuration option `WSGI_PROXIES` has been deprecated in `Invenio-Base` a while ago, in favor of the more granular `PROXYFIX_CONFIG`.
The latter now gets used by default in `docker-services.yml` in the PR https://github.com/inveniosoftware/cookiecutter-invenio-rdm/pull/323

Since the value is provided in the cookiecutter already and because providing an incorrect value as fallback doesn't really provide any benefits, I've simply removed the old configuration value without replacement here.