### PR TITLE
feat: add max-width to tombstone container

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/restricted_with_doi_tombstone.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/restricted_with_doi_tombstone.html
@@ -7,7 +7,7 @@
 {% extends config.THEME_ERROR_TEMPLATE %}
 
 {%- block message %}
-<div class="container centered rel-pt-2">
+<div class="ui container max-w-3/5 centered rel-pt-2">
   <h1 class="ui header inline-block">
     <i class="icon lightning" aria-hidden="true"></i>
     <div class="content">

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/tombstone.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/tombstone.html
@@ -14,7 +14,7 @@
 {%- endif %}
 
 {%- block message %}
-<div class="container centered rel-pt-2">
+<div class="ui container max-w-3/5 centered rel-pt-2">
   <h1 class="ui header inline-block">
     <i class="icon lightning" aria-hidden="true"></i>
     <div class="content pl-0 rel-pr-1">

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/container.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/container.overrides
@@ -82,6 +82,7 @@
       width: 100% !important; // Overwriting semantic-ui's !important. Please don't remove.
     }
   }
+
   &.ml-0-mobile {
     @media screen and (max-width: @largestMobileScreen) {
       margin-left: 0 !important;
@@ -92,6 +93,10 @@
     @media screen and (max-width: @largestMobileScreen) {
       margin-right: 0 !important;
     }
+  }
+
+  &.max-w-3\/5 {
+    max-width: 60% !important;
   }
 }
 


### PR DESCRIPTION
### Description

Sets max-width limit on the tombstone container, so it looks better on larger screens.

#### Before
<img width="2880" height="1618" alt="image" src="https://github.com/user-attachments/assets/0ed8fe89-361b-4777-ab3d-4f2b6cc8756c" />

#### After
<img width="2916" height="1652" alt="image" src="https://github.com/user-attachments/assets/36caa58c-7382-4c06-92e9-777989c78f72" />


