### PR TITLE
feat(previewer): show message for outdated records

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -1173,6 +1173,9 @@ PREVIEWER_PREFERENCE = [
 ]
 """Preferred previewers."""
 
+PREVIEWER_ABSTRACT_TEMPLATE = "invenio_previewer/rdm_abstract_previewer.html"
+"""Override the abstract template with an RDM-specific one."""
+
 RECORDS_RESOURCES_IMAGE_FORMATS = ["." + ext for ext in IIIF_FORMATS.keys()]
 """RECORDS_RESOURCES_IMAGE_FORMATS must contain all possible IIIF formats to ensure their metadata is extracted."""
 

--- a/invenio_app_rdm/records_ui/views/decorators.py
+++ b/invenio_app_rdm/records_ui/views/decorators.py
@@ -111,6 +111,19 @@ def pass_is_preview(f):
     return view
 
 
+def pass_is_iframe(f):
+    """Decorate a view to check if it's being requested from inside an iframe."""
+
+    @wraps(f)
+    def view(**kwargs):
+        # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Dest
+        header_value = request.headers.get("Sec-Fetch-Dest")
+        kwargs["is_iframe"] = header_value == "iframe"
+        return f(**kwargs)
+
+    return view
+
+
 # TODO to be improved as a request arg schema (following the REST views)
 def pass_include_deleted(f):
     """Decorate a view to check if it's a include deleted."""

--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -49,6 +49,7 @@ from .decorators import (
     pass_file_item,
     pass_file_metadata,
     pass_include_deleted,
+    pass_is_iframe,
     pass_is_preview,
     pass_record_files,
     pass_record_from_pid,
@@ -147,7 +148,9 @@ class PreviewFile:
     `invenio_previewer.api.PreviewFile`.
     """
 
-    def __init__(self, file_item, record_pid_value, record=None, url=None):
+    def __init__(
+        self, file_item, record_pid_value, record=None, url=None, is_iframe=False
+    ):
         """Create a new PreviewFile."""
         self.file = file_item
         self.data = file_item.data
@@ -160,6 +163,7 @@ class PreviewFile:
             pid_value=record_pid_value,
             filename=self.filename,
         )
+        self.is_iframe = is_iframe
 
     def is_local(self):
         """Check if file is local."""
@@ -347,6 +351,7 @@ def record_export(
 @pass_include_deleted
 @pass_record_or_draft(expand=False)
 @pass_file_metadata
+@pass_is_iframe
 def record_file_preview(
     pid_value,
     record=None,
@@ -354,6 +359,7 @@ def record_file_preview(
     file_metadata=None,
     is_preview=False,
     include_deleted=False,
+    is_iframe=False,
     **kwargs,
 ):
     """Render a preview of the specified file."""
@@ -365,7 +371,7 @@ def record_file_preview(
     )
 
     # Find a suitable previewer
-    fileobj = PreviewFile(file_metadata, pid_value, record, url)
+    fileobj = PreviewFile(file_metadata, pid_value, record, url, is_iframe)
     # Try to see if specific previewer preference is set for the file
     file_previewer = (file_metadata.data.get("metadata") or {}).get("previewer")
     if file_previewer:

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_previewer/latest_record.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_previewer/latest_record.html
@@ -1,0 +1,18 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2026 CERN.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% if file.record.data["is_published"] and file.record.data["links"]["latest_html"] and not file.record.data["versions"]["is_latest"] %}
+  <div class="ui warning flashed attached manage message pl-10 pr-10">
+    <p>
+      {% trans link_start=('<a href="' + file.record.data["links"]["latest_html"] + '"><b>')|safe, link_end='</b></a>'|safe %}
+        You are viewing a file from an older version of this record. {{ link_start }}View latest record{{ link_end }}.
+      {% endtrans %}
+    </p>
+  </div>
+{% endif %}

--- a/invenio_app_rdm/theme/templates/semantic-ui/invenio_previewer/rdm_abstract_previewer.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/invenio_previewer/rdm_abstract_previewer.html
@@ -1,0 +1,30 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2026 CERN.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- extends "invenio_previewer/base.html" %}
+
+{%- block head %}
+  {% for css_bundle in css_bundles %}
+    {{ webpack[css_bundle] }}
+  {% endfor %}
+  {{ webpack['theme.css'] }}
+{%- endblock %}
+
+{%- block page_body %}
+  {%- if request.args.get('embed') %}
+    {%- include 'invenio_previewer/top.html' %}
+  {%- endif %}
+  {%- if not file.is_iframe %}
+    {%- include "invenio_previewer/latest_record.html" %}
+  {%- endif %}
+  {%- block panel %}{% endblock %}
+  {%- if request.args.get('embed') %}
+    {%- include 'invenio_previewer/bottom.html' %}
+  {%- endif %}
+{%- endblock %}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-previewer/issues/246

---

* Added a message shown in the file preview template when the file's record is outdated and a newer one is available. The message aims to avoid implying that there is a new version of that specific file available, since the file itself might not have changed or might have been deleted. The message has almost the same style as the one on the record detail page.

* The message is only shown in the full-screen preview, since users often share links to that directly. It is not shown in the record detail page iframe, since there's already a message there about the record being outdated. The widely-supported Sec-Fetch-Dest header is used to detect whether the preview is being requested inside an iframe.

* This is an RDM-specific feature so it makes sense to include it in this repository as an override to the templates.

<img width="1905" height="120" alt="image" src="https://github.com/user-attachments/assets/02ca6e70-17f5-47dc-831f-0a1d3a4aefa5" />
