### PR TITLE
fix(landing_page): use text instead of html for fileKey

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
@@ -13,7 +13,7 @@ $("#record-doi-badge").on("click", function () {
 });
 
 $(".preview-link").on("click", function (event) {
-  $("#preview-file-title").html(event.target.dataset.fileKey);
+  $("#preview-file-title").text(event.target.dataset.fileKey);
 });
 
 // Export dropdown on landing page


### PR DESCRIPTION
Not cherry-picking the entire [commit](https://github.com/inveniosoftware/invenio-app-rdm/commit/c36d8c730efcbf4a6e849b0a6c35b861aa6c6000) to avoid adding other features that are v14-specific