### PR TITLE
fix(ExportDropdown): Fix css spacing and responsiveness

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ExportDropdown.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ExportDropdown.js
@@ -32,33 +32,27 @@ export class ExportDropdown extends Component {
     });
 
     return (
-      <Grid>
-        <Grid.Column width={10}>
-          <Dropdown
-            aria-label={i18next.t("Export selection")}
-            selection
-            fluid
-            selectOnNavigation={false}
-            options={exportOptions}
-            onChange={(event, data) => this.setState({ selectedFormatUrl: data.value })}
-            defaultValue={selectedFormatUrl}
-          />
-        </Grid.Column>
-        <Grid.Column width={4} className="pl-0">
-          <Button
-            as="a"
-            role="button"
-            fluid
-            href={selectedFormatUrl}
-            title={i18next.t("Download file")}
-          >
-            {i18next.t("Export")}
-          </Button>
-        </Grid.Column>
-        <Grid.Column width={2} className="pl-0">
-          <CopyButton url={selectedFormatUrl} />
-        </Grid.Column>
-      </Grid>
+      <div className="auto-column-grid no-wrap">
+        <Dropdown
+          aria-label={i18next.t("Export selection")}
+          selection
+          fluid
+          selectOnNavigation={false}
+          options={exportOptions}
+          onChange={(event, data) => this.setState({ selectedFormatUrl: data.value })}
+          defaultValue={selectedFormatUrl}
+        />
+        <Button
+          as="a"
+          role="button"
+          fluid
+          href={selectedFormatUrl}
+          title={i18next.t("Download file")}
+        >
+          {i18next.t("Export")}
+        </Button>
+        <CopyButton url={selectedFormatUrl} />
+      </div>
     );
   }
 }


### PR DESCRIPTION
# Currently:
Wide:
<img width="522" height="330" alt="Screenshot 2026-01-20 at 11 34 29" src="https://github.com/user-attachments/assets/bbac74cb-759e-429f-9322-3333aeb360a8" />
Mobile:
<img width="403" height="343" alt="Screenshot 2026-01-20 at 11 34 53" src="https://github.com/user-attachments/assets/aebb50c7-3214-471b-815b-7661dcbd20af" />

# After fix:
Wide:
<img width="517" height="309" alt="Screenshot 2026-01-20 at 11 35 24" src="https://github.com/user-attachments/assets/4479e4f6-9023-4e83-99bb-69ad0327cee2" />

Mobile:
<img width="400" height="326" alt="Screenshot 2026-01-20 at 11 35 39" src="https://github.com/user-attachments/assets/c7376efc-3511-4f26-8829-bae6ae47ab00" />
