### PR TITLE
Overridable extra and after blocks

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -128,22 +128,29 @@ export class RDMDepositForm extends Component {
     }));
     const UploaderField = useUppy ? UppyUploader : FileUploader;
 
+    const overridableBlocksCommonProps = {
+      record,
+      files,
+      config,
+      permissions,
+      preselectedCommunity,
+      filesLocked,
+      recordRestrictionGracePeriod,
+      allowRecordRestriction,
+      groupsEnabled,
+      allowEmptyFiles,
+      customFieldsUI,
+      vocabularies: this.vocabularies,
+      noFiles: this.noFiles,
+      hideCommunitySelection: this.hide_community_selection,
+    };
+
     return (
       <Overridable
         id="InvenioAppRdm.Deposit.RDMDepositForm.layout"
-        record={record}
-        files={files}
-        config={config}
-        permissions={permissions}
-        preselectedCommunity={preselectedCommunity}
-        filesLocked={filesLocked}
-        recordRestrictionGracePeriod={recordRestrictionGracePeriod}
-        allowRecordRestriction={allowRecordRestriction}
-        recordDeletion={recordDeletion}
+        {...overridableBlocksCommonProps}
         fileModification={fileModification}
-        groupsEnabled={groupsEnabled}
-        allowEmptyFiles={allowEmptyFiles}
-        customFieldsUI={customFieldsUI}
+        recordDeletion={recordDeletion}
         recordSerializer={null}
       >
         <DepositFormApp
@@ -183,20 +190,7 @@ export class RDMDepositForm extends Component {
               <Grid.Column mobile={16} tablet={16} computer={11}>
                 <Overridable
                   id="InvenioAppRdm.Deposit.Files.before.container"
-                  record={record}
-                  files={files}
-                  permissions={permissions}
-                  preselectedCommunity={preselectedCommunity}
-                  filesLocked={filesLocked}
-                  recordRestrictionGracePeriod={recordRestrictionGracePeriod}
-                  allowRecordRestriction={allowRecordRestriction}
-                  groupsEnabled={groupsEnabled}
-                  allowEmptyFiles={allowEmptyFiles}
-                  customFieldsUI={customFieldsUI}
-                  config={this.config}
-                  vocabularies={this.vocabularies}
-                  noFiles={this.noFiles}
-                  hideCommunitySelection={this.hide_community_selection}
+                  {...overridableBlocksCommonProps}
                 />
                 <Overridable
                   id="InvenioAppRdm.Deposit.AccordionFieldFiles.container"
@@ -252,20 +246,7 @@ export class RDMDepositForm extends Component {
                 </Overridable>
                 <Overridable
                   id="InvenioAppRdm.Deposit.Files.after.container"
-                  record={record}
-                  files={files}
-                  permissions={permissions}
-                  preselectedCommunity={preselectedCommunity}
-                  filesLocked={filesLocked}
-                  recordRestrictionGracePeriod={recordRestrictionGracePeriod}
-                  allowRecordRestriction={allowRecordRestriction}
-                  groupsEnabled={groupsEnabled}
-                  allowEmptyFiles={allowEmptyFiles}
-                  customFieldsUI={customFieldsUI}
-                  config={this.config}
-                  vocabularies={this.vocabularies}
-                  noFiles={this.noFiles}
-                  hideCommunitySelection={this.hide_community_selection}
+                  {...overridableBlocksCommonProps}
                 />
                 <Overridable
                   id="InvenioAppRdm.Deposit.AccordionFieldBasicInformation.container"
@@ -428,39 +409,13 @@ export class RDMDepositForm extends Component {
                     </Overridable>
                     <Overridable
                       id="InvenioAppRdm.Deposit.AccordionFieldBasicInformation.extra"
-                      record={record}
-                      files={files}
-                      permissions={permissions}
-                      preselectedCommunity={preselectedCommunity}
-                      filesLocked={filesLocked}
-                      recordRestrictionGracePeriod={recordRestrictionGracePeriod}
-                      allowRecordRestriction={allowRecordRestriction}
-                      groupsEnabled={groupsEnabled}
-                      allowEmptyFiles={allowEmptyFiles}
-                      customFieldsUI={customFieldsUI}
-                      config={this.config}
-                      vocabularies={this.vocabularies}
-                      noFiles={this.noFiles}
-                      hideCommunitySelection={this.hide_community_selection}
+                      {...overridableBlocksCommonProps}
                     />
                   </AccordionField>
                 </Overridable>
                 <Overridable
                   id="InvenioAppRdm.Deposit.BasicInformation.after.container"
-                  record={record}
-                  files={files}
-                  permissions={permissions}
-                  preselectedCommunity={preselectedCommunity}
-                  filesLocked={filesLocked}
-                  recordRestrictionGracePeriod={recordRestrictionGracePeriod}
-                  allowRecordRestriction={allowRecordRestriction}
-                  groupsEnabled={groupsEnabled}
-                  allowEmptyFiles={allowEmptyFiles}
-                  customFieldsUI={customFieldsUI}
-                  config={this.config}
-                  vocabularies={this.vocabularies}
-                  noFiles={this.noFiles}
-                  hideCommunitySelection={this.hide_community_selection}
+                  {...overridableBlocksCommonProps}
                 />
                 <Overridable
                   id="InvenioAppRdm.Deposit.AccordionFieldRecommendedInformation.container"
@@ -563,8 +518,16 @@ export class RDMDepositForm extends Component {
                     >
                       <PublisherField fieldPath="metadata.publisher" />
                     </Overridable>
+                    <Overridable
+                      id="InvenioAppRdm.Deposit.AccordionFieldRecommendedInformation.extra"
+                      {...overridableBlocksCommonProps}
+                    />
                   </AccordionField>
                 </Overridable>
+                <Overridable
+                  id="InvenioAppRdm.Deposit.RecommendedInformation.after.container"
+                  {...overridableBlocksCommonProps}
+                />
                 <Overridable
                   id="InvenioAppRdm.Deposit.AccordionFieldFunding.container"
                   ui={this.accordionStyle}
@@ -660,8 +623,16 @@ export class RDMDepositForm extends Component {
                         }}
                       />
                     </Overridable>
+                    <Overridable
+                      id="InvenioAppRdm.Deposit.AccordionFieldFunding.extra"
+                      {...overridableBlocksCommonProps}
+                    />
                   </AccordionField>
                 </Overridable>
+                <Overridable
+                  id="InvenioAppRdm.Deposit.Funding.after.container"
+                  {...overridableBlocksCommonProps}
+                />
                 <Overridable
                   id="InvenioAppRdm.Deposit.AccordionFieldAlternateIdentifiers.container"
                   vocabularies={this.vocabularies}
@@ -688,8 +659,16 @@ export class RDMDepositForm extends Component {
                         showEmptyValue
                       />
                     </Overridable>
+                    <Overridable
+                      id="InvenioAppRdm.Deposit.AccordionFieldAlternateIdentifiers.extra"
+                      {...overridableBlocksCommonProps}
+                    />
                   </AccordionField>
                 </Overridable>
+                <Overridable
+                  id="InvenioAppRdm.Deposit.AlternateIdentifiers.after.container"
+                  {...overridableBlocksCommonProps}
+                />
 
                 <Overridable
                   id="InvenioAppRdm.Deposit.AccordionFieldRelatedWorks.container"
@@ -715,8 +694,16 @@ export class RDMDepositForm extends Component {
                         showEmptyValue
                       />
                     </Overridable>
+                    <Overridable
+                      id="InvenioAppRdm.Deposit.AccordionFieldRelatedWorks.extra"
+                      {...overridableBlocksCommonProps}
+                    />
                   </AccordionField>
                 </Overridable>
+                <Overridable
+                  id="InvenioAppRdm.Deposit.RelatedWorks.after.container"
+                  {...overridableBlocksCommonProps}
+                />
                 <Overridable
                   id="InvenioAppRdm.Deposit.AccordionFieldReferences.container"
                   vocabularies={this.vocabularies}
@@ -737,8 +724,16 @@ export class RDMDepositForm extends Component {
                     >
                       <ReferencesField fieldPath="metadata.references" showEmptyValue />
                     </Overridable>
+                    <Overridable
+                      id="InvenioAppRdm.Deposit.AccordionFieldReferences.extra"
+                      {...overridableBlocksCommonProps}
+                    />
                   </AccordionField>
                 </Overridable>
+                <Overridable
+                  id="InvenioAppRdm.Deposit.References.after.container"
+                  {...overridableBlocksCommonProps}
+                />
                 {!_isEmpty(customFieldsUI) && (
                   <Overridable
                     id="InvenioAppRdm.Deposit.CustomFields.container"


### PR DESCRIPTION
* Adds overridable extra and after blocks for each deposit section.
* Includes `record` in the overridable contexts where it was missing.

These changes were somehow discussed at Hamburg's User Group meeting (2025) during a session on [Improving Overridables](https://pad.uni-hamburg.de/EXJf0G3pSFWUzHkd46xU6Q?view#).