### PR TITLE
feat (deposit): allow overriding deposit serializer

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -144,6 +144,7 @@ export class RDMDepositForm extends Component {
         groupsEnabled={groupsEnabled}
         allowEmptyFiles={allowEmptyFiles}
         customFieldsUI={customFieldsUI}
+        recordSerializer={null}
       >
         <DepositFormApp
           config={this.config}
@@ -152,6 +153,7 @@ export class RDMDepositForm extends Component {
           files={files}
           permissions={permissions}
           errors={record.errors}
+          recordSerializer={null}
         >
           <Overridable
             id="InvenioAppRdm.Deposit.FormFeedback.container"


### PR DESCRIPTION
This is how you can use it
```js
import { getInputFromDOM } from "@js/invenio_rdm_records";
import { DepositFormApp } from "@js/invenio_rdm_records/src/deposit/api/DepositFormApp";
import { AwesomeSerializer} from "@js/site/records/deposit/DepositRecordSerializer"

const depositConfig = getInputFromDOM("deposits-config");
const parametrizedRDMDepositForm = parametrize(DepositFormApp, {
  recordSerializer: new AwesomeSerializer(
    depositConfig.default_locale,
    depositConfig.custom_fields.vocabularies,
  ),
});

export const overriddenComponents = {
  // Deposit
  "InvenioAppRdm.Deposit.RDMDepositForm.layout": parametrizedRDMDepositForm,
...
}
```