### PR TITLE
fix: show all contributers on dashboard page

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
@@ -60,7 +60,7 @@ export const RDMRecordResultsListItem = ({ result }) => {
       i18next.t("No description")
     ),
     title: _get(result, "metadata.title", i18next.t("No title")),
-    creators: _get(result, "ui.creators.creators", []).slice(0, 3),
+    creators: _get(result, "ui.creators.creators", []),
     subjects: _get(result, "ui.subjects", []),
     publicationDate: _get(
       result,

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
@@ -99,7 +99,7 @@ export const ComputerTabletUploadsItem = ({
         </Item.Header>
         <Item.Meta>
           <div className="creatibutors">
-            <SearchItemCreators creators={creators} />
+            <SearchItemCreators creators={creators} othersLink={viewLink} />
           </div>
         </Item.Meta>
         <Item.Description className="truncate-lines-2">


### PR DESCRIPTION
Closes https://github.com/zenodo/ops/issues/532
:heart: Thank you for your contribution!
Before:
<img width="825" height="495" alt="image" src="https://github.com/user-attachments/assets/f97076ac-7411-49a2-a20d-f9ded2d87a7d" />

After:
<img width="808" height="558" alt="image" src="https://github.com/user-attachments/assets/67498a86-530f-4fe6-a4b9-67c5e6c1bc05" />
