### PR TITLE
fix: limit max width of community logo

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/image.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/image.overrides
@@ -60,6 +60,7 @@
   img {
     max-height: @tinyWidth;
     min-width: @tinyWidth;
+    max-width: @mediumWidth;
     object-fit: contain;
   }
 }


### PR DESCRIPTION
Closes: https://github.com/inveniosoftware/invenio-communities/issues/1243

:heart: Thank you for your contribution!

### Description

#### Before 
<img width="2286" height="554" alt="image" src="https://github.com/user-attachments/assets/883b666a-b5d9-4efa-bd46-42d8f6489834" />

#### After
<img width="2301" height="412" alt="image" src="https://github.com/user-attachments/assets/6264abe0-3c30-4d04-be25-be0faf6273c3" />
