### PR TITLE
fix: using app locale for citations

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCitationField.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCitationField.js
@@ -58,7 +58,13 @@ export class RecordCitationField extends Component {
 
   fetchCitation = async (recordLinks, style, includeDeleted) => {
     const includeDeletedParam = includeDeleted === true ? "&include_deleted=1" : "";
-    const url = `${recordLinks.self}?locale=${navigator.language}&style=${style}${includeDeletedParam}`;
+    const navLang = (navigator.language || "").toLowerCase();
+    const uiLang = (i18next.language || "").toLowerCase();
+    const citationLocale =
+      uiLang && navLang.startsWith(uiLang)
+        ? navigator.language
+        : i18next.language || navigator.language;
+    const url = `${recordLinks.self}?locale=${citationLocale}&style=${style}${includeDeletedParam}`;
     return await http.get(url, {
       headers: {
         Accept: "text/x-bibliography",


### PR DESCRIPTION
* app was using navigator.language which is always
* browser setting. The change enables using localization
* based on app settings and using translated strigns that exist in
* citeproc library


### Description

Currently, the citation is always generated based on browser selected locale. This change uses language selected in the app. Normally, in invenio you only have access to language code, so if the language setting in the browser starts with this language code it sends the entire locale i.e. en_GB, if not, it only sends en. The citeproc library has good behavior, even in case only language code is provided. 

Before:
<img width="766" height="452" alt="image" src="https://github.com/user-attachments/assets/d36eb97b-9176-4371-9045-95a4602fa2ed" />



After:

<img width="708" height="344" alt="image" src="https://github.com/user-attachments/assets/6e1a2329-fa8f-4fed-b862-9aa837e7fc7f" />

Noter that benefit depens on the citation style i.e. some styles that contain more text, other than record data benefit more. 

Please let us know what you think.




**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
