### PR TITLE
fix(ui): fix nested facets icon and padding

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/accordion.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/accordion.overrides
@@ -14,6 +14,11 @@
   height: @iconHeight;
 }
 
+/* use these classes to change children facets in an accordion within a facet container */
+.facet-container .ui.accordion:not(.styled) .title ~ .content:not(.ui) {
+  padding: 0em 0em 0.25em 1em;
+}
+
 /* use these classes to change accordion title when up/down */
 div.affiliations.accordion div.title.active span.up,
 div.affiliations.accordion div.title.active button.up {


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Ensures the accordion icons for parent facets are displayed in full after the change
in https://github.com/inveniosoftware/invenio-search-ui/commit/e4c83db79122cd5aa1429ce7c94fd544ea3732a5, by using the preset variables from Semantic UI.
* Adjust padding to better convey parent-child relationship visually.

**Before** 
<img width="250" height="437" alt="image" src="https://github.com/user-attachments/assets/0a69156c-21cc-4178-b4d8-6bd8bf0d6653" />

**After**
<img width="257" height="423" alt="image" src="https://github.com/user-attachments/assets/1fc2b106-484e-42ed-bc86-18da1f463f90" />


Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/3178



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
