### PR TITLE
fix: add record files restriction option to enable cache-control header

### DIFF
--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -411,7 +411,12 @@ def record_file_download(pid_value, file_item=None, is_preview=False, **kwargs):
         obj = file_item._file.object_version
         emitter(current_app, record=file_item._record, obj=obj, via_api=False)
 
-    return file_item.send_file(as_attachment=download)
+    if file_item._record.access.protection.files == "public":
+        restricted = False
+    else:
+        restricted = True
+
+    return file_item.send_file(as_attachment=download, restricted=restricted)
 
 
 @pass_record_or_draft(expand=False)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

InvenioRDM doesn't currently add cache-control headers to file links, which can result in weird behavior if a cache is put in front of the repo. This is because the cache-control headers are only added by default for non-restricted files (which makes sense) https://github.com/inveniosoftware/invenio-files-rest/blob/616dc34c38006433653211feb5a9e523b0d399e7/invenio_files_rest/helpers.py#L182. But because InvenioRDM doesn't pass this option, the cache-control headers are never added.

This should be reviewed carefully to make sure it doesn't have security implications.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
