### PR TITLE
fix(css): allow horizontal scrolling for request comment body

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/feed.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/views/feed.overrides
@@ -177,7 +177,8 @@
 
       .collapsible-comment-inner {
         display: block;
-        overflow: hidden;
+        overflow-y: hidden;
+        overflow-x: auto;
         transition: max-height 300ms ease;
         max-height: @collapsibleHeight;
       }


### PR DESCRIPTION
Right now, some content in the request comment body can overflow horizontally, and due to `overflow: hidden` (which we really only intend to use for vertical overflow) it's impossible to scroll to view it. This is a particular problem for images (although this will be fixed by #3286) but also other content with unusual scaling like weird text wrapping or rendered LaTeX blocks.