### PR TITLE
fix(requests): handle deleted drafts in reindexing (#3327)

### DIFF
--- a/invenio_app_rdm/ext.py
+++ b/invenio_app_rdm/ext.py
@@ -15,6 +15,7 @@ from flask_menu import current_menu
 from invenio_i18n import lazy_gettext as _
 
 from .communities_ui.views.ui import _show_browse_page
+from .patches import apply_patches
 
 
 def _is_branded_community():
@@ -27,6 +28,7 @@ def _is_branded_community():
 
 def finalize_app(app):
     """Finalize app."""
+    apply_patches()
     init_menu(app)
     init_config(app)
 

--- a/invenio_app_rdm/patches.py
+++ b/invenio_app_rdm/patches.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 CERN.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Monkey-patches for upstream dependency bugs.
+
+This module applies targeted fixes to dependency packages that have not yet
+released patches for known issues. Each patch should reference the upstream
+issue/PR and be removed once the fix is available upstream.
+
+Fixes applied:
+    - RDMRecordProxy.get_needs(): Handles PIDDoesNotExistError when the
+      referenced draft/record has been deleted (e.g. after cancelling a review
+      and deleting the draft). Without this fix, reindexing requests that
+      reference deleted records causes PIDDoesNotExistError.
+
+    - GrantTokensDumperExt.dump(): Defense-in-depth fix that catches any
+      entity resolution errors during request indexing, preventing a single
+      broken entity reference from blocking the entire reindex operation.
+
+    - ReviewComponent.delete_draft(): Clears the review reference on the
+      parent record when the review is in a cancelled state, preventing
+      orphaned requests from referencing deleted drafts.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _patched_get_needs(self, ctx=None):
+    """Patched get_needs that handles deleted records gracefully.
+
+    Original: invenio_rdm_records.requests.entity_resolvers.RDMRecordProxy.get_needs
+
+    When a draft is deleted after its review request was cancelled, the
+    request still references the draft. During reindexing, get_needs() tries
+    to resolve the deleted draft's PID, causing PIDDoesNotExistError.
+    This patch catches the error and returns empty needs instead.
+    """
+    from invenio_pidstore.errors import PIDDoesNotExistError, PIDUnregistered
+    from sqlalchemy.orm.exc import NoResultFound
+
+    from invenio_rdm_records.proxies import current_rdm_records_service
+
+    if ctx is None or "record_permission" not in ctx:
+        return []
+
+    try:
+        record = self.resolve()
+    except (PIDDoesNotExistError, PIDUnregistered, NoResultFound):
+        logger.warning(
+            "Could not resolve record for entity proxy %s. "
+            "The record may have been deleted. Returning empty needs.",
+            self._ref_dict,
+        )
+        return []
+
+    record_permission = ctx["record_permission"]
+    needs = current_rdm_records_service.config.permission_policy_cls(
+        record_permission, record=record
+    ).needs
+    return needs
+
+
+def _patched_grant_tokens_dump(self, request, data):
+    """Patched dump that handles entity resolution errors gracefully.
+
+    Original: invenio_requests.records.dumpers.granttokens.GrantTokensDumperExt.dump
+
+    Defense-in-depth fix: if any entity referenced by a request cannot be
+    resolved (e.g. because the referenced record was deleted), log a warning
+    and continue indexing with whatever grants could be resolved, rather
+    than crashing the entire reindex operation.
+    """
+    from invenio_records_resources.references import EntityGrant
+
+    grants = []
+    for field_name in self.fields:
+        entity = getattr(request, field_name)
+        try:
+            if isinstance(entity, list):
+                for e in entity:
+                    for need in request.type.entity_needs(e):
+                        grants.append(EntityGrant(field_name, need).token)
+            else:
+                for need in request.type.entity_needs(entity):
+                    grants.append(EntityGrant(field_name, need).token)
+        except Exception:
+            logger.warning(
+                "Failed to resolve entity needs for field '%s' "
+                "on request '%s'. The referenced entity may have "
+                "been deleted.",
+                field_name,
+                request.id,
+            )
+    data[self.grants_field] = grants
+
+
+def _patched_review_delete_draft(
+    self, identity, draft=None, record=None, force=False
+):
+    """Patched delete_draft that cleans up cancelled review requests.
+
+    Original: invenio_rdm_records.services.components.review.ReviewComponent.delete_draft
+
+    When a draft with a cancelled review is deleted, the original code
+    leaves the request as-is (only deleting requests in 'created' status).
+    This creates orphaned requests that reference deleted drafts, causing
+    PIDDoesNotExistError during reindexing.
+
+    This patch additionally clears the review topic reference for cancelled
+    requests so they no longer point to the deleted draft.
+    """
+    from invenio_i18n import lazy_gettext as _
+    from invenio_requests import current_requests_service
+
+    from invenio_rdm_records.services.errors import ReviewStateError
+
+    review = draft.parent.review
+    if review is None:
+        return
+
+    # Block deletion if the review is still open (e.g. submitted).
+    if review.is_open:
+        raise ReviewStateError(
+            _(
+                "You cannot delete a draft with an open review. Please "
+                "cancel the review first."
+            )
+        )
+
+    if review.status == "created":
+        # Delete request entirely if it was never submitted.
+        current_requests_service.delete(
+            identity, draft.parent.review.id, uow=self.uow
+        )
+    elif review.status == "cancelled":
+        # For cancelled requests: clear the topic reference so the request
+        # no longer points to the draft that is about to be deleted.
+        # This prevents PIDDoesNotExistError when the request is reindexed.
+        review.topic = None
+        review.commit()
+        # Re-index the request to update the search index.
+        from invenio_records_resources.services.uow import RecordCommitOp
+
+        self.uow.register(
+            RecordCommitOp(review, indexer=current_requests_service.indexer)
+        )
+
+
+def apply_patches():
+    """Apply all monkey-patches to fix upstream dependency bugs.
+
+    This function should be called during app finalization (in ext.py).
+    Each patch is applied independently so that a failure in one does not
+    block the others.
+    """
+    # Patch 1: RDMRecordProxy.get_needs()
+    try:
+        from invenio_rdm_records.requests.entity_resolvers import RDMRecordProxy
+
+        RDMRecordProxy.get_needs = _patched_get_needs
+        logger.debug("Applied patch: RDMRecordProxy.get_needs")
+    except Exception:
+        logger.error(
+            "Failed to apply patch for RDMRecordProxy.get_needs", exc_info=True
+        )
+
+    # Patch 2: GrantTokensDumperExt.dump()
+    try:
+        from invenio_requests.records.dumpers.granttokens import GrantTokensDumperExt
+
+        GrantTokensDumperExt.dump = _patched_grant_tokens_dump
+        logger.debug("Applied patch: GrantTokensDumperExt.dump")
+    except Exception:
+        logger.error(
+            "Failed to apply patch for GrantTokensDumperExt.dump", exc_info=True
+        )
+
+    # Patch 3: ReviewComponent.delete_draft()
+    try:
+        from invenio_rdm_records.services.components.review import ReviewComponent
+
+        ReviewComponent.delete_draft = _patched_review_delete_draft
+        logger.debug("Applied patch: ReviewComponent.delete_draft")
+    except Exception:
+        logger.error(
+            "Failed to apply patch for ReviewComponent.delete_draft", exc_info=True
+        )

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 CERN.
+#
+# Invenio App RDM is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test monkey-patches for upstream dependency bugs."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from invenio_app_rdm.patches import (
+    _patched_get_needs,
+    _patched_grant_tokens_dump,
+    _patched_review_delete_draft,
+    apply_patches,
+)
+
+
+class TestPatchedGetNeeds:
+    """Tests for the patched RDMRecordProxy.get_needs method."""
+
+    def test_returns_empty_when_no_context(self):
+        """Return empty needs when ctx is None."""
+        proxy = MagicMock()
+        result = _patched_get_needs(proxy, ctx=None)
+        assert result == []
+
+    def test_returns_empty_when_no_record_permission(self):
+        """Return empty needs when record_permission not in ctx."""
+        proxy = MagicMock()
+        result = _patched_get_needs(proxy, ctx={"other_key": "value"})
+        assert result == []
+
+    def test_returns_empty_on_pid_does_not_exist(self):
+        """Return empty needs when the record PID does not exist."""
+        from invenio_pidstore.errors import PIDDoesNotExistError
+
+        proxy = MagicMock()
+        proxy._ref_dict = {"record": "deleted-pid"}
+        proxy.resolve.side_effect = PIDDoesNotExistError("recid", "deleted-pid")
+
+        result = _patched_get_needs(proxy, ctx={"record_permission": "read"})
+        assert result == []
+
+    def test_returns_empty_on_pid_unregistered(self):
+        """Return empty needs when the record PID is unregistered."""
+        from invenio_pidstore.errors import PIDUnregistered
+
+        pid_mock = MagicMock()
+        proxy = MagicMock()
+        proxy._ref_dict = {"record": "unregistered-pid"}
+        proxy.resolve.side_effect = PIDUnregistered(pid_mock)
+
+        result = _patched_get_needs(proxy, ctx={"record_permission": "read"})
+        assert result == []
+
+    def test_returns_empty_on_no_result_found(self):
+        """Return empty needs when no DB row is found."""
+        from sqlalchemy.orm.exc import NoResultFound
+
+        proxy = MagicMock()
+        proxy._ref_dict = {"record": "missing-pid"}
+        proxy.resolve.side_effect = NoResultFound()
+
+        result = _patched_get_needs(proxy, ctx={"record_permission": "read"})
+        assert result == []
+
+    def test_returns_needs_on_success(self):
+        """Return proper needs when record resolves successfully."""
+        mock_record = MagicMock()
+        mock_needs = [MagicMock(), MagicMock()]
+        mock_policy = MagicMock()
+        mock_policy.needs = mock_needs
+
+        proxy = MagicMock()
+        proxy.resolve.return_value = mock_record
+
+        with patch(
+            "invenio_app_rdm.patches.current_rdm_records_service"
+        ) as mock_service:
+            mock_service.config.permission_policy_cls.return_value = mock_policy
+
+            result = _patched_get_needs(
+                proxy, ctx={"record_permission": "read"}
+            )
+
+            assert result == mock_needs
+            mock_service.config.permission_policy_cls.assert_called_once_with(
+                "read", record=mock_record
+            )
+
+
+class TestPatchedGrantTokensDump:
+    """Tests for the patched GrantTokensDumperExt.dump method."""
+
+    def test_dump_with_successful_entities(self):
+        """Dump grant tokens successfully when entities resolve."""
+        mock_need = MagicMock()
+        mock_entity = MagicMock()
+        mock_request = MagicMock()
+        mock_request.topic = mock_entity
+        mock_request.type.entity_needs.return_value = [mock_need]
+        mock_request.id = "test-request-id"
+
+        dumper = MagicMock()
+        dumper.fields = ["topic"]
+        dumper.grants_field = "grants"
+
+        data = {}
+        _patched_grant_tokens_dump(dumper, mock_request, data)
+
+        assert "grants" in data
+        assert len(data["grants"]) == 1
+
+    def test_dump_continues_on_entity_error(self):
+        """Continue dumping when an entity fails to resolve."""
+        from invenio_pidstore.errors import PIDDoesNotExistError
+
+        mock_entity_ok = MagicMock()
+        mock_entity_bad = MagicMock()
+
+        mock_request = MagicMock()
+        mock_request.created_by = mock_entity_ok
+        mock_request.topic = mock_entity_bad
+        mock_request.id = "test-request-id"
+
+        # topic entity_needs raises an error, created_by works fine
+        mock_need = MagicMock()
+
+        def entity_needs_side_effect(entity):
+            if entity is mock_entity_bad:
+                raise PIDDoesNotExistError("recid", "deleted-pid")
+            return [mock_need]
+
+        mock_request.type.entity_needs.side_effect = entity_needs_side_effect
+
+        dumper = MagicMock()
+        dumper.fields = ["created_by", "topic"]
+        dumper.grants_field = "grants"
+
+        data = {}
+        _patched_grant_tokens_dump(dumper, mock_request, data)
+
+        # Should still have grants from created_by, but not from topic
+        assert "grants" in data
+        assert len(data["grants"]) == 1
+
+    def test_dump_handles_list_entities(self):
+        """Handle list entity fields gracefully."""
+        mock_need = MagicMock()
+        mock_entity = MagicMock()
+        mock_request = MagicMock()
+        mock_request.reviewers = [mock_entity]
+        mock_request.type.entity_needs.return_value = [mock_need]
+        mock_request.id = "test-request-id"
+
+        dumper = MagicMock()
+        dumper.fields = ["reviewers"]
+        dumper.grants_field = "grants"
+
+        data = {}
+        _patched_grant_tokens_dump(dumper, mock_request, data)
+
+        assert "grants" in data
+        assert len(data["grants"]) == 1
+
+    def test_dump_with_none_entity(self):
+        """Handle None entity fields (e.g. topic can be None)."""
+        mock_request = MagicMock()
+        mock_request.topic = None
+        mock_request.type.entity_needs.return_value = []
+        mock_request.id = "test-request-id"
+
+        dumper = MagicMock()
+        dumper.fields = ["topic"]
+        dumper.grants_field = "grants"
+
+        data = {}
+        _patched_grant_tokens_dump(dumper, mock_request, data)
+
+        assert data["grants"] == []
+
+
+class TestApplyPatches:
+    """Tests for the apply_patches function."""
+
+    def test_apply_patches_success(self):
+        """All patches should be applied successfully."""
+        with patch(
+            "invenio_app_rdm.patches.logger"
+        ) as mock_logger:
+            apply_patches()
+            # No errors should be logged
+            mock_logger.error.assert_not_called()
+
+    def test_patches_are_applied_to_correct_classes(self):
+        """Verify patches are applied to the correct class methods."""
+        apply_patches()
+
+        from invenio_rdm_records.requests.entity_resolvers import RDMRecordProxy
+        from invenio_rdm_records.services.components.review import ReviewComponent
+        from invenio_requests.records.dumpers.granttokens import (
+            GrantTokensDumperExt,
+        )
+
+        assert RDMRecordProxy.get_needs == _patched_get_needs
+        assert GrantTokensDumperExt.dump == _patched_grant_tokens_dump
+        assert ReviewComponent.delete_draft == _patched_review_delete_draft


### PR DESCRIPTION
❤️ Thank you for your contribution!

**Description**
Please describe briefly your pull request.

As stated in inveniosoftware/invenio-app-rdm#3327, a PIDDoesNotExist Error shows up in the Sentry instance after applying reindexing commands when a draft record is saved, submitted, and deleted. This issue is solved in this PR by defensively handling missing draft and record PIDs during request indexing, specifically inside `RDMRecordProxy.get_needs()` and `GrantTokensDumperExt.dump()`, and by properly cleaning up the topic reference when a draft with a cancelled review is deleted.

**Checklist**
Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the code of conduct.
- [x] I've created logical separate commits and followed the commit message format.
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked translation strings.
- [x] I've identified the copyright holder(s) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
If you have added third-party code (copy/pasted or new dependencies), please reach out to an architect on Discord.

**Frontend**
- [ ] I've followed the CSS/JS and React guidelines.
- [ ] I've followed the web accessibility guidelines.
- [ ] I've followed the user interface guidelines.

**Reminder**
By using GitHub, you have already agreed to the GitHub’s Terms of Service including that:
You license your contribution under the same terms as the current repository’s license.
You agree that you have the right to license your contribution under the current repository’s license.
