### PR TITLE
fix(db): use UTC for Postgres

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -528,6 +528,10 @@ SQLALCHEMY_ENGINE_OPTIONS = {
     "pool_recycle": 3600,
     # set a more agressive timeout to ensure http requests don't wait for long
     "pool_timeout": 10,
+    # Ensure the database is using the UTC timezone for interpreting timestamps (Postgres only).
+    # This overrides any default setting (e.g. in postgresql.conf). Invenio expects the DB to receive
+    # and provide UTC timestamps in all cases, so it's important that this doesn't get changed.
+    "connect_args": {"options": "-c timezone=UTC"},
 }
 """SQLAlchemy engine options.
 


### PR DESCRIPTION
This PR overrides config that's originally specified in `invenio-db`. This change is therefore duplicated there: https://github.com/inveniosoftware/invenio-db/pull/196

* Right now, we don't have any restriction/requirement on the database's time zone. This can lead to unexpected behaviour when reading/writing timestamps with time zones, since they get shifted to the database's zone which might not be UTC.

* The easiest way to ensure the DB is using UTC is by specifying it on connection via SQLAlchemy. This overrides any default value specified in e.g. postgresql.conf.

* Instances can still easily override this if they should need to, but this is not recommended.