### PR TITLE
admin: deleted records link with include_deleted parameter

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/records/search/SearchResultItemLayout.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/records/search/SearchResultItemLayout.js
@@ -44,6 +44,13 @@ class SearchResultItemComponent extends Component {
     // See  https://github.com/inveniosoftware/invenio-app-rdm/issues/2849
     const recordOwner = result?.parent?.access?.owned_by;
 
+    let selfLink = result.links.self_html;
+    if (result?.deletion_status?.is_deleted) {
+      const url = new URL(selfLink);
+      url.searchParams.set("include_deleted", "1");
+      selfLink = url.toString();
+    }
+
     return (
       <Table.Row>
         <Table.Cell
@@ -64,7 +71,7 @@ class SearchResultItemComponent extends Component {
             color="red"
             icon="lock"
           />
-          <a target="_blank" rel="noreferrer noopener" href={result.links.self_html}>
+          <a target="_blank" rel="noreferrer noopener" href={selfLink}>
             {_truncate(result.metadata.title || i18next.t("Empty draft title"), {
               length: 100,
             })}


### PR DESCRIPTION
When reviewing deleted records, administrators usually want to see the deleted records content and not the tombstones.
It probably does not make sense to expose the "include_deleted" links in the API response, so we built the URL client-side (only needed for the admin panel).