### PR TITLE
fix: prevent overflow of long values and links in details and sidebar

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -559,3 +559,43 @@ dl.details-list {
   align-items: center;
   justify-content: space-between;
 }
+
+/* Prevent long values and links from overflowing in details lists */
+dl.details-list dd,
+dl.details-list a {
+  display: block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: normal;
+}
+
+/* Prevent long links/values from overflowing in the right sidebar column */
+.stackable.mobile.reversed.grid > .column:last-child {
+  min-width: 0;
+
+  a,
+  dd {
+    display: block;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    white-space: normal;
+  }
+}
+
+.publishing-info-grid {
+  margin-left: 2rem !important;
+}
+
+/* Add vertical spacing between Journal / Imprint / Thesis on small screens */
+@media only screen and (max-width: @largestMobileScreen) {
+  .publishing-info-grid .column {
+    min-width: 0;
+    margin-bottom: 2rem;
+  }
+
+  .publishing-info-grid .column:first-child {
+    margin-top: 1.5rem;
+  }
+}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This PR adds styling needed for the changes introduced in [invenio-rdm-records#2268.
](https://github.com/inveniosoftware/invenio-rdm-records/pull/2268)
Fixes overflow issues for long values and links in record details and sidebar sections.

Long, unbroken text (e.g. identifiers or titles) could exceed container width. This update ensures they wrap correctly and stay within layout boundaries. It also allows the sidebar column to shrink properly and improves spacing for publishing information on smaller screens.


### Before: 
<img width="1461" height="1034" alt="image" src="https://github.com/user-attachments/assets/722cc1e6-3a1e-499f-9292-06cf38e3a3fb" />

<img width="1363" height="1049" alt="image" src="https://github.com/user-attachments/assets/cad12ae3-601f-478c-b1bb-c352f347e004" />



### After:
<img width="1461" height="1034" alt="image" src="https://github.com/user-attachments/assets/7a0cbea4-4c5b-48a1-918a-665478eee7df" />


<img width="1380" height="1185" alt="image" src="https://github.com/user-attachments/assets/6ec7ef06-5226-4ff1-a16e-38a08e3db45b" />


## Related PR

Depends on:
https://github.com/inveniosoftware/invenio-rdm-records/pull/2268
https://github.com/inveniosoftware/invenio-app-rdm/pull/3362

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
