### PR TITLE
fix(components): use ClipboardItem API for Safari-compatible clipboard writes

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/CopyButton.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/CopyButton.js
@@ -10,19 +10,33 @@ import { Button, Popup } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 
 class SimpleCopyButton extends React.Component {
-  fetchUrl = async (url) => {
-    return await (await fetch(url)).text();
-  };
-
-  handleClick = async () => {
+  handleClick = () => {
     const { url, text, onCopy } = this.props;
-    let textToCopy = text;
-    if (url) {
-      textToCopy = await this.fetchUrl(url);
-    }
 
-    await navigator.clipboard.writeText(textToCopy);
-    onCopy(text);
+    if (url) {
+      // When a URL is provided, the content must be fetched before copying.
+      // Safari requires clipboard writes to occur synchronously within the
+      // user-gesture call stack. Using async/await with fetch() breaks this
+      // chain. The ClipboardItem API accepts a Promise, keeping the
+      // clipboard.write() call synchronous while resolving data internally.
+      const textPromise = fetch(url).then((response) => response.text());
+
+      if (typeof ClipboardItem !== "undefined") {
+        const item = new ClipboardItem({
+          "text/plain": textPromise.then(
+            (fetchedText) => new Blob([fetchedText], { type: "text/plain" })
+          ),
+        });
+        navigator.clipboard.write([item]).then(() => onCopy(text));
+      } else {
+        // Fallback for browsers where ClipboardItem is not available
+        textPromise.then((fetchedText) =>
+          navigator.clipboard.writeText(fetchedText).then(() => onCopy(text))
+        );
+      }
+    } else {
+      navigator.clipboard.writeText(text).then(() => onCopy(text));
+    }
   };
 
   render() {

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/CopyButton.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/CopyButton.js
@@ -13,29 +13,25 @@ class SimpleCopyButton extends React.Component {
   handleClick = () => {
     const { url, text, onCopy } = this.props;
 
-    if (url) {
-      // When a URL is provided, the content must be fetched before copying.
-      // Safari requires clipboard writes to occur synchronously within the
-      // user-gesture call stack. Using async/await with fetch() breaks this
-      // chain. The ClipboardItem API accepts a Promise, keeping the
-      // clipboard.write() call synchronous while resolving data internally.
-      const textPromise = fetch(url).then((response) => response.text());
+    // Resolve what to copy: fetch from URL or use text directly.
+    // Safari requires clipboard writes to occur synchronously within the
+    // user-gesture call stack. Using async/await with fetch() breaks this
+    // chain. The ClipboardItem API accepts a Promise, keeping the
+    // clipboard.write() call synchronous while resolving data internally.
+    const dataPromise = url
+      ? fetch(url).then((response) => response.text())
+      : Promise.resolve(text);
 
-      if (typeof ClipboardItem !== "undefined") {
-        const item = new ClipboardItem({
-          "text/plain": textPromise.then(
-            (fetchedText) => new Blob([fetchedText], { type: "text/plain" })
-          ),
-        });
-        navigator.clipboard.write([item]).then(() => onCopy(text));
-      } else {
-        // Fallback for browsers where ClipboardItem is not available
-        textPromise.then((fetchedText) =>
-          navigator.clipboard.writeText(fetchedText).then(() => onCopy(text))
-        );
-      }
+    if (typeof ClipboardItem !== "undefined") {
+      const item = new ClipboardItem({
+        "text/plain": dataPromise.then((t) => new Blob([t], { type: "text/plain" })),
+      });
+      navigator.clipboard.write([item]).then(() => onCopy(text));
     } else {
-      navigator.clipboard.writeText(text).then(() => onCopy(text));
+      // Fallback for browsers where ClipboardItem is not available
+      dataPromise.then((t) =>
+        navigator.clipboard.writeText(t).then(() => onCopy(text))
+      );
     }
   };
 


### PR DESCRIPTION
## Summary

- Fix `CopyButton` export copy failing in Safari with `NotAllowedError`
- Replace `async/await` clipboard pattern with synchronous `ClipboardItem` + Promise API
- Add fallback to `writeText()` for browsers without `ClipboardItem` support

## Problem

PR #3106 replaced `react-copy-to-clipboard` with direct `navigator.clipboard.writeText()` calls. When the `url` prop is provided (Export section), `await fetch(url)` suspends execution and breaks the user-gesture call stack. Safari's Clipboard API requires `clipboard.write()` to be called **synchronously** within the user gesture context, so it rejects the write with:

```
NotAllowedError: The request is not allowed by the user agent or the platform
in the current context, possibly because the user denied permission.
```

DOI/Citation copy buttons are unaffected because they pass `text` directly (no fetch needed).

## Solution

Use the `ClipboardItem` API which accepts a **Promise** as its value. This keeps `navigator.clipboard.write()` synchronous within the user gesture, while the Clipboard API internally resolves the fetch Promise:

```javascript
const item = new ClipboardItem({
  "text/plain": fetch(url)
    .then((r) => r.text())
    .then((t) => new Blob([t], { type: "text/plain" })),
});
navigator.clipboard.write([item]);
```

A fallback using `writeText()` is included for browsers where `ClipboardItem` is not available (e.g., older Firefox).

Reference: [How to use Clipboard API in Safari](https://wolfgangrittner.dev/how-to-use-clipboard-api-in-safari/)

## Browser Compatibility

| Browser | `ClipboardItem` with Promise | Previous `async/await` pattern |
|---------|:---:|:---:|
| Safari 13.1+ | ✅ | ❌ |
| Chrome 76+ | ✅ | ✅ |
| Firefox 127+ | ✅ (fallback provided) | ✅ |

## Test Plan

- [ ] Verify Export "Copy to clipboard" works in Safari
- [ ] Verify Export "Copy to clipboard" still works in Chrome
- [ ] Verify Export "Copy to clipboard" still works in Firefox
- [ ] Verify DOI copy button still works in all browsers
- [ ] Verify Citation copy button still works in all browsers

Closes #3378
Refs zenodo/zenodo-rdm#1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)