### PR TITLE
Enforces Uppy component styles

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/file_uploader/uppy.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/file_uploader/uppy.less
@@ -9,29 +9,51 @@
 @import "@uppy/dashboard/dist/style.min.css";
 @import "@uppy/image-editor/dist/style.min.css";
 
+// all rules are marked as !important to override Uppy default styles. See https://uppy.io/blog/2018/04/0.24/#other-fixes--improvements
+
+.uppy-size--md .uppy-c-textInput {
+	padding: 8px 10px !important;
+}
+
+.uppy-c-textInput {
+	background-color: #fff !important;
+	border: 1px solid #ddd !important;
+	border-radius: 4px !important;
+	font-family: inherit !important;
+	font-size: 14px !important;
+	line-height: 1.5 !important;
+	padding: 6px 8px !important;
+}
+
+.uppy-Dashboard-FileCard-input {
+	display: inline-block !important;
+	vertical-align: middle !important;
+	width: 78% !important;
+}
+
 .uppy-Dashboard-AddFiles {
-  padding: 1.2rem;
+  padding: 1.2rem !important;
 }
 .uppy-Dashboard-AddFiles-info {
-  display: block;
+  display: block !important;
 }
 
 .uppy-Dashboard-note {
-  padding-top: 3rem;
+  padding-top: 3rem !important;
 }
 
 .uppy-Dashboard-inner {
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 5px 5px !important;
 }
 
 .uppy-Dashboard-innerWrap {
-  height: 350px;
+  height: 350px !important;
 
   &:has(#uppy-DashboardContent-panel--editor) {
-    height: 500px;
+    height: 500px !important;
   }
 }
 
 .uppy-DashboardContent-bar, .uppy-StatusBar {
-  z-index: 10;
+  z-index: 10 !important;
 }


### PR DESCRIPTION
Replaces: https://github.com/inveniosoftware/invenio-app-rdm/pull/3374

---

:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

Enforces `!important` declarations on various Uppy component styles, including inputs, dashboard elements, and overall layout. This ensures that the application's custom styling consistently overrides Uppy's default styles, which often require explicit `!important` to take precedence. The change resolves styling conflicts and improves the visual integration and consistency of the file uploader components within the application's theme.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.