### PR TITLE
fix: wrap overflowing MathJax content in rich text

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/RecordsResultsListItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/RecordsResultsListItem.js
@@ -7,6 +7,7 @@
 
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 import _get from "lodash/get";
+import _truncate from "lodash/truncate";
 import React, { Component } from "react";
 import Overridable from "react-overridable";
 import { SearchItemCreators } from "../utils";
@@ -49,6 +50,7 @@ class RecordsResultsListItem extends Component {
     );
     const subjects = _get(result, "ui.subjects", []);
     const title = _get(result, "metadata.title", i18next.t("No title"));
+    const titleTruncated = _truncate(title, { length: 100 });
     const version = _get(result, "ui.version", null);
     const versions = _get(result, "versions");
     const uniqueViews = _get(result, "stats.all_versions.unique_views", 0);
@@ -103,7 +105,7 @@ class RecordsResultsListItem extends Component {
               </Label>
             </Item.Extra>
             <Item.Header as="h2" className="theme-primary-text">
-              <a href={viewLink}>{title}</a>
+              <a href={viewLink}>{titleTruncated}</a>
             </Item.Header>
             <Item className="creatibutors">
               <SearchItemCreators creators={creators} othersLink={viewLink} />

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/header.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/header.overrides
@@ -10,6 +10,8 @@
 
 
 .main-record-content {
+  min-width: 0;
+
   h1,
   h1.ui.header,
   .ui.huge.header {

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -86,6 +86,37 @@ button:focus-visible, a:focus-visible {
 
 .wrap-overflowing-text {
   word-wrap: break-word;
+  overflow-wrap: anywhere;
+
+  mjx-container[jax="CHTML"],
+  mjx-container[jax="CHTML"] > mjx-math,
+  mjx-container[jax="CHTML"] mjx-mrow,
+  mjx-container[jax="CHTML"] mjx-texatom,
+  mjx-container[jax="CHTML"] mjx-mi,
+  mjx-container[jax="CHTML"] mjx-mo,
+  mjx-container[jax="CHTML"] mjx-mn,
+  mjx-container[jax="CHTML"] mjx-msub,
+  mjx-container[jax="CHTML"] mjx-msup,
+  mjx-container[jax="CHTML"] mjx-msubsup {
+    white-space: normal !important;
+  }
+}
+
+.rich-input-content {
+  overflow-wrap: anywhere;
+
+  mjx-container[jax="CHTML"],
+  mjx-container[jax="CHTML"] > mjx-math,
+  mjx-container[jax="CHTML"] mjx-mrow,
+  mjx-container[jax="CHTML"] mjx-texatom,
+  mjx-container[jax="CHTML"] mjx-mi,
+  mjx-container[jax="CHTML"] mjx-mo,
+  mjx-container[jax="CHTML"] mjx-mn,
+  mjx-container[jax="CHTML"] mjx-msub,
+  mjx-container[jax="CHTML"] mjx-msup,
+  mjx-container[jax="CHTML"] mjx-msubsup {
+    white-space: normal !important;
+  }
 }
 
 // Log-in and sign-up


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/695

The issue here was not that `$...$ `was failing to be recognized as LaTeX. I checked this locally and MathJax was already enabled and rendering those expressions correctly. The actual problem was that long or malformed inline MathJax output could overflow its container and push the layout out of bounds.

This PR fixes that as a layout and wrapping issue in invenio-app-rdm.

What changed
1. Added min-width: 0 to .main-record-content so the main content column can shrink properly inside the flex layout instead of being forced wider by long MathJax content.
2. Extended the shared wrapping styles in site.overrides so both .rich-input-content and .wrap-overflowing-text also handle rendered MathJax (mjx-container and common inline MathJax elements) with normal wrapping.
3. Kept search/result titles compact by truncating them to 100 characters in RecordsResultsListItem.js, instead of letting malformed MathJax titles stretch the list view.

### Before
<img width="1638" height="584" alt="image" src="https://github.com/user-attachments/assets/e6a9dc2f-3e29-440f-afdc-8f505755bec7" />


<img width="1617" height="340" alt="image" src="https://github.com/user-attachments/assets/8718d92c-7d11-4fce-9137-91d9d68e0c9e" />

<img width="681" height="472" alt="image" src="https://github.com/user-attachments/assets/7172369f-7715-483f-acb9-d933de407e36" />

<img width="1622" height="895" alt="image" src="https://github.com/user-attachments/assets/768b160b-ff90-4abd-8a80-a2376abb3023" />



### After

<img width="1638" height="584" alt="image" src="https://github.com/user-attachments/assets/1cbd5937-12e5-4e2c-834d-64b9f5ec4c1d" />

<img width="1355" height="428" alt="image" src="https://github.com/user-attachments/assets/e1baf76c-cbfd-4688-8cbc-2f3b4eed9829" />

<img width="595" height="307" alt="image" src="https://github.com/user-attachments/assets/b4c5bbcc-9c0c-4232-888c-67146491d81e" />

<img width="1172" height="244" alt="image" src="https://github.com/user-attachments/assets/b5b07672-6507-4e89-aa8f-19b84c39f0e2" />


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
