### PR TITLE
Integrate Flask-MultiProfiler

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -38,6 +38,7 @@ from celery.schedules import crontab
 from flask_principal import Denial
 from flask_resources import HTTPJSONException, create_error_handler
 from invenio_access.permissions import any_user
+from invenio_administration.permissions import administration_permission
 from invenio_communities.communities.resources.config import community_error_handlers
 from invenio_communities.notifications.builders import (
     CommunityInvitationAcceptNotificationBuilder,
@@ -1562,8 +1563,28 @@ APP_RDM_MODERATION_REQUEST_FACETS = {
 
 # Invenio-VCS
 # ===========
+#
+
 VCS_TEMPLATE_INDEX = "invenio_vcs/rdm-index.html"
 VCS_TEMPLATE_INDEX_ITEM = "invenio_vcs/rdm-index-item.html"
 VCS_TEMPLATE_VIEW = "invenio_vcs/rdm-view.html"
 VCS_TEMPLATE_REPO_SWITCH = "invenio_vcs/rdm-repo-switch.html"
 VCS_TEMPLATE_RELEASE_ITEM = "invenio_vcs/rdm-release-item.html"
+
+# Flask-MultiProfiler
+# ===================
+#
+
+MULTIPROFILER_BASE_TEMPLATE = "flask_multiprofiler/index.html"
+"""Base template for the profiler page."""
+
+MULTIPROFILER_IGNORED_ENDPOINTS = [
+    "static",
+    "_debug_toolbar.static",
+    r"profiler\..+",
+    "invenio_formatter_badges.badge",
+]
+"""Ignore static assets endpoints and endpoints for the profiler itself."""
+
+MULTIPROFILER_PERMISSION = administration_permission.can
+"""Function to check for permissions to access the profiler."""

--- a/invenio_app_rdm/ext.py
+++ b/invenio_app_rdm/ext.py
@@ -173,3 +173,17 @@ def init_menu(app):
         },
         **dict(icon="upload", permissions="can_read"),
     )
+
+    # register a menu entry for the profiler, if it is installed
+    if "multiprofiler" in app.extensions:
+        permission_check_func = app.config["MULTIPROFILER_PERMISSION"]
+        current_menu.submenu("profile-admin.profiler").register(
+            "profiler.index",
+            text=_(
+                "%(icon)s Profiler",
+                icon='<i class="bar chart icon"></i>',
+            ),
+            order=10,
+            visible_when=permission_check_func,
+            permissions="can_read",
+        )

--- a/invenio_app_rdm/ext.py
+++ b/invenio_app_rdm/ext.py
@@ -16,6 +16,24 @@ from invenio_i18n import lazy_gettext as _
 
 from .communities_ui.views.ui import _show_browse_page
 
+try:
+    from flask_multiprofiler import MultiProfiler
+
+except (ImportError, ModuleNotFoundError):
+
+    class MultiProfiler:
+        """Dummy profiler for entrypoints if Flask-MultiProfiler isn't installed.
+
+        Note that this dummy extension does not register itself to ``app.extensions``.
+        """
+
+        def __init__(self, app=None):
+            """Constructor."""
+
+        def init_app(self, app):
+            """Initialize application."""
+            self.app = app
+
 
 def _is_branded_community():
     """Function used to check if community is branded."""

--- a/invenio_app_rdm/ext.py
+++ b/invenio_app_rdm/ext.py
@@ -12,6 +12,7 @@ from datetime import timedelta
 
 from flask import request
 from flask_menu import current_menu
+from invenio_app import talisman
 from invenio_i18n import lazy_gettext as _
 
 from .communities_ui.views.ui import _show_browse_page
@@ -47,6 +48,15 @@ def finalize_app(app):
     """Finalize app."""
     init_menu(app)
     init_config(app)
+
+    # make CSP headers for profiler reports very lax
+    if "multiprofiler" in app.extensions:
+        orig_profiler_report_view = app.view_functions["profiler.report_view"]
+
+        @app.endpoint("profiler.report_view")
+        @talisman(content_security_policy={})
+        def wrapped_profiler_report_view(*args, **kwargs):
+            return orig_profiler_report_view(*args, **kwargs)
 
 
 def init_config(app):

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/multiprofiler.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/multiprofiler.js
@@ -1,0 +1,10 @@
+// This file is part of InvenioRDM
+// Copyright (C) 2026 CERN.
+//
+// Invenio App RDM is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import $ from "jquery";
+
+$(".ui.accordion").accordion();
+$(".ui.checkbox").checkbox();

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/multiprofiler/profiler.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/multiprofiler/profiler.less
@@ -1,0 +1,36 @@
+/*
+ *   Copyright (C) 2026 TU Wien.
+ *
+ * Invenio App RDM is free software; you can redistribute it and/or modify
+ * it under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+#profiler-container {
+  /* remove negative margin on the grid */
+  .ui.grid {
+    margin: 1em;
+  }
+
+  #profiler-sessions-list {
+    /* highlight child sessions */
+    .child.session.list {
+      border-left: 5px solid whitesmoke;
+      padding: 0;
+      margin: 1em 0;
+
+      /* remove extra top padding for the child session list */
+      .item .list {
+        padding-top: 0;
+      }
+    }
+
+    /* add a bit of top padding for each item */
+    .parent.session.item {
+      padding-top: 1em;
+    }
+
+    .sessions.accordion {
+      margin-top: 2em;
+    }
+  }
+}

--- a/invenio_app_rdm/theme/templates/semantic-ui/flask_multiprofiler/index.html
+++ b/invenio_app_rdm/theme/templates/semantic-ui/flask_multiprofiler/index.html
@@ -1,0 +1,24 @@
+{# -*- coding: utf-8 -*-
+
+  This file is part of Invenio.
+  Copyright (C) 2026 TU Wien.
+
+  Invenio is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- extends config.BASE_TEMPLATE %}
+
+{%- block head_title -%}
+  <title>{{ _("Profiler") }}</title>
+{%- endblock -%}
+
+{%- block javascript -%}
+  {{ super() }}
+  {{ webpack["flask-multiprofiler-code.js"] }}
+{%- endblock %}
+
+{%- block css %}
+  {{ super() }}
+  {{ webpack["flask-multiprofiler-style.css"] }}
+{%- endblock css %}

--- a/invenio_app_rdm/theme/webpack.py
+++ b/invenio_app_rdm/theme/webpack.py
@@ -42,6 +42,8 @@ theme = WebpackThemeBundle(
                 "invenio-audit-logs-administration": "./js/invenio_app_rdm/administration/auditLogs/index.js",
                 "invenio-communities-browse": "./js/invenio_app_rdm/subcommunity/browse.js",
                 "uppy-file-uploader": "./less/invenio_app_rdm/file_uploader/uppy.less",
+                "flask-multiprofiler-style": "./less/invenio_app_rdm/multiprofiler/profiler.less",
+                "flask-multiprofiler-code": "./js/invenio_app_rdm/multiprofiler.js",
             },
             dependencies={
                 "@babel/runtime": "^7.9.0",

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,10 +88,16 @@ opensearch2 =
     invenio-search[opensearch2]>=3.0.0,<4.0.0
 s3 =
     invenio-s3>=4.0.0,<5.0.0
+profiler =
+    flask-multiprofiler>=0.1.0
 
 [options.entry_points]
 flask.commands =
     rdm = invenio_app_rdm.cli:rdm
+invenio_base.apps =
+    profiler = invenio_app_rdm.ext:MultiProfiler
+invenio_base.api_apps =
+    profiler = invenio_app_rdm.ext:MultiProfiler
 invenio_base.blueprints =
     invenio_app_rdm_records = invenio_app_rdm.records_ui.views:create_blueprint
     invenio_app_rdm = invenio_app_rdm.theme.views:create_blueprint


### PR DESCRIPTION
Integrate the new `flask-multiprofiler` as an optional dependency via the new `profiler` extra (`pip install invenio-app-rdm[profiler]`).

Video:

https://github.com/user-attachments/assets/b2ee88ea-a23a-4d00-a4fd-15fd82fcb755
