### PR TITLE
feat(administration): allow blocking with removal reason

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/UserActions.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/UserActions.js
@@ -10,18 +10,19 @@
 import isEmpty from "lodash/isEmpty";
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Button, Icon, Dropdown } from "semantic-ui-react";
-import { NotificationContext } from "@js/invenio_administration";
+import { Button, Icon, Dropdown, Modal } from "semantic-ui-react";
+import { ActionModal, NotificationContext } from "@js/invenio_administration";
 import { withCancel } from "react-invenio-forms";
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 import { ImpersonateUser } from "../components/ImpersonateUser";
 import { SetQuotaAction } from "../components/SetQuotaAction";
 import { UserModerationApi } from "./api";
+import UserBlockForm from "./UserBlockForm";
 
 export class UserActions extends Component {
   constructor(props) {
     super(props);
-    this.state = { loading: false };
+    this.state = { loading: false, blockModalOpen: false };
   }
 
   componentWillUnmount() {
@@ -30,7 +31,24 @@ export class UserActions extends Component {
 
   static contextType = NotificationContext;
 
+  openBlockModal = () => this.setState({ blockModalOpen: true });
+
+  closeBlockModal = () => this.setState({ blockModalOpen: false });
+
+  handleBlockSuccess = () => {
+    const { successCallback } = this.props;
+    this.setState({ blockModalOpen: false });
+    successCallback();
+  };
+
   handleAction = async (action) => {
+    // The "block" action requires picking a removal reason, so it opens a
+    // dedicated modal instead of firing the API call immediately.
+    if (action === "block") {
+      this.openBlockModal();
+      return;
+    }
+
     this.setState({ loading: true });
     const { user, successCallback } = this.props;
     const { addNotification } = this.context;
@@ -42,12 +60,6 @@ export class UserActions extends Component {
         icon: "undo",
         apiFunction: UserModerationApi.restoreUser,
         notificationTitle: i18next.t("Restored"),
-      },
-      block: {
-        label: i18next.t("Block"),
-        icon: "ban",
-        apiFunction: UserModerationApi.blockUser,
-        notificationTitle: i18next.t("Blocked"),
       },
       deactivate: {
         label: i18next.t("Suspend"),
@@ -110,7 +122,7 @@ export class UserActions extends Component {
       displayQuota,
       useDropdown,
     } = this.props;
-    const { loading } = this.state;
+    const { loading, blockModalOpen } = this.state;
     const isUserBlocked = !isEmpty(user.blocked_at);
     const isUserActive = user.active;
     const isUserVerified = !isEmpty(user.verified_at);
@@ -235,6 +247,16 @@ export class UserActions extends Component {
             {generateActions()}
           </Button.Group>
         )}
+        <ActionModal modalOpen={blockModalOpen} resource={user}>
+          <Modal.Header>{i18next.t("Block user")}</Modal.Header>
+          {blockModalOpen && (
+            <UserBlockForm
+              user={user}
+              actionSuccessCallback={this.handleBlockSuccess}
+              actionCancelCallback={this.closeBlockModal}
+            />
+          )}
+        </ActionModal>
       </div>
     );
   }

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/UserBlockForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/UserBlockForm.js
@@ -1,0 +1,250 @@
+/*
+ * This file is part of Invenio.
+ * Copyright (C) 2026 CERN.
+ *
+ * Invenio is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Formik } from "formik";
+import { ErrorMessage, Image, TextAreaField, withCancel } from "react-invenio-forms";
+import { Button, Form, Header, Icon, Message, Modal, Segment } from "semantic-ui-react";
+import { NotificationContext } from "@js/invenio_administration";
+import { i18next } from "@translations/invenio_app_rdm/i18next";
+import * as Yup from "yup";
+import RemovalReasonsSelect from "../records/RemovalReasonsSelect";
+import { UserModerationApi } from "./api";
+
+export default class UserBlockForm extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { loading: false, error: undefined, blocked: false };
+    this.schema = Yup.object({
+      removal_reason: Yup.string().required(i18next.t("A removal reason is required.")),
+      note: Yup.string(),
+    });
+  }
+
+  static contextType = NotificationContext;
+
+  componentWillUnmount() {
+    this.cancellableAction && this.cancellableAction.cancel();
+  }
+
+  handleSubmit = async (values) => {
+    const { user } = this.props;
+    const { addNotification } = this.context;
+    const name = user.profile?.full_name || user.email || user.username || user.id;
+
+    this.setState({ loading: true });
+
+    const payload = {
+      removal_reason_id: values.removal_reason,
+      ...(values.note ? { note: values.note } : {}),
+    };
+
+    this.cancellableAction = withCancel(UserModerationApi.blockUser(user, payload));
+
+    try {
+      await this.cancellableAction.promise;
+      this.cancellableAction = null;
+      this.setState({ loading: false, error: undefined, blocked: true });
+      // Fire the notification for pages that mount a NotificationController
+      // (admin views). The in-modal confirmation handles the rest.
+      addNotification({
+        title: i18next.t("Blocked"),
+        content: i18next.t("User {{name}} was blocked.", { name }),
+        type: "success",
+      });
+    } catch (error) {
+      if (error === "UNMOUNTED") return;
+      this.cancellableAction = null;
+      this.setState({
+        loading: false,
+        error: error?.response?.data?.message || error?.message,
+      });
+      console.error(error);
+    }
+  };
+
+  renderUserSummary() {
+    const { user } = this.props;
+    const displayName =
+      user.profile?.full_name || user.username || user.email || user.id;
+    const hasIdentities = user.identities?.orcid || user.identities?.github;
+
+    return (
+      <Segment>
+        <Header as="h4" className="mt-0 mb-5">
+          {user.links?.avatar && (
+            <Image
+              src={user.links.avatar}
+              avatar
+              inline
+              size="mini"
+              className="mr-10"
+              loadFallbackFirst
+            />
+          )}
+          <strong>{displayName}</strong>
+        </Header>
+        <div className="text-muted mb-5">
+          {user.username && <span>@{user.username}</span>}
+          {user.username && user.profile?.affiliations && <span> · </span>}
+          {user.profile?.affiliations && (
+            <span>
+              <Icon name="university" />
+              {user.profile.affiliations}
+            </span>
+          )}
+        </div>
+        {(user.email || hasIdentities) && (
+          <div>
+            {user.email && (
+              <a className="mr-15" href={`mailto:${user.email}`}>
+                <Icon name="mail" />
+                {user.email}
+              </a>
+            )}
+            {user.identities?.orcid && (
+              <a
+                className="mr-15"
+                href={`https://orcid.org/${user.identities.orcid}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Icon name="linkify" />
+                {user.identities.orcid}
+              </a>
+            )}
+            {user.identities?.github && (
+              <a
+                href={`https://github.com/${user.identities.github}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Icon name="github" />
+                {user.identities.github}
+              </a>
+            )}
+          </div>
+        )}
+      </Segment>
+    );
+  }
+
+  render() {
+    const { actionCancelCallback, actionSuccessCallback, user } = this.props;
+    const { loading, error, blocked } = this.state;
+
+    if (blocked) {
+      const params = new URLSearchParams({
+        q: `id:${user.id}`,
+        f: "is_blocked:1",
+      });
+      const adminUrl = `/administration/users?${params}`;
+      return (
+        <>
+          <Modal.Content>
+            {this.renderUserSummary()}
+            <Message positive className="mt-15">
+              <div className="align-items-center justify-space-between flex">
+                <div>
+                  <Message.Header>
+                    <Icon name="check circle" />
+                    {i18next.t("User blocked")}
+                  </Message.Header>
+                  <p className="mt-5 mb-0">
+                    {i18next.t(
+                      "Their records and communities are being tombstoned in the background. This may take a few minutes to complete."
+                    )}
+                  </p>
+                </div>
+                <Button
+                  as="a"
+                  size="small"
+                  className="ml-15"
+                  style={{ whiteSpace: "nowrap" }}
+                  href={adminUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {i18next.t("View in admin")}
+                  <Icon name="external alternate" className="ml-5" />
+                </Button>
+              </div>
+            </Message>
+          </Modal.Content>
+          <Modal.Actions>
+            <Button primary onClick={actionSuccessCallback}>
+              {i18next.t("Close")}
+            </Button>
+          </Modal.Actions>
+        </>
+      );
+    }
+
+    return (
+      <Formik
+        initialValues={{ removal_reason: undefined, note: "" }}
+        onSubmit={this.handleSubmit}
+        validationSchema={this.schema}
+        validateOnMount
+      >
+        {({ handleSubmit, setFieldValue, isValid }) => (
+          <Form onSubmit={handleSubmit} className="full-width">
+            {error && (
+              <ErrorMessage
+                header={i18next.t("Unable to block user")}
+                content={error}
+                icon="exclamation"
+                className="text-align-left"
+                negative
+              />
+            )}
+            <Modal.Content>
+              {this.renderUserSummary()}
+              <p className="mt-15">
+                {i18next.t(
+                  "Blocking this user will tombstone their records and communities using the removal reason below."
+                )}
+              </p>
+              <Form.Field required>
+                <RemovalReasonsSelect setFieldValue={setFieldValue} />
+              </Form.Field>
+              <Form.Field>
+                <TextAreaField
+                  fieldPath="note"
+                  label={i18next.t("Public note")}
+                  fluid
+                />
+              </Form.Field>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button type="button" onClick={actionCancelCallback} floated="left">
+                {i18next.t("Cancel")}
+              </Button>
+              <Button
+                type="submit"
+                icon="ban"
+                labelPosition="left"
+                color="red"
+                content={i18next.t("Block user")}
+                loading={loading}
+                disabled={loading || !isValid}
+              />
+            </Modal.Actions>
+          </Form>
+        )}
+      </Formik>
+    );
+  }
+}
+
+UserBlockForm.propTypes = {
+  user: PropTypes.object.isRequired,
+  actionSuccessCallback: PropTypes.func.isRequired,
+  actionCancelCallback: PropTypes.func.isRequired,
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/api/api.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/users/api/api.js
@@ -12,8 +12,8 @@ const restoreUser = async (user) => {
   return await http.post(APIRoutes.restore(user));
 };
 
-const blockUser = async (user) => {
-  return await http.post(APIRoutes.block(user));
+const blockUser = async (user, payload) => {
+  return await http.post(APIRoutes.block(user), payload || {});
 };
 
 const deactivateUser = async (user) => {

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ManageButton.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ManageButton.js
@@ -5,11 +5,10 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import React from "react";
-import { Dropdown, Modal, Button, Message } from "semantic-ui-react";
+import { Dropdown, Modal } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_app_rdm/i18next";
 import PropTypes from "prop-types";
-import { http } from "react-invenio-forms";
-import { APIRoutes } from "../administration/users/api/routes";
+import UserBlockForm from "../administration/users/UserBlockForm";
 import { RecordDeletion } from "../components/RecordDeletion";
 
 export const ManageButton = ({
@@ -24,6 +23,7 @@ export const ManageButton = ({
     return null;
   }
   const recordStatus = record.deletion_status.status;
+  const recordOwner = record?.expanded?.parent?.access?.owned_by;
   return (
     <Dropdown
       fluid
@@ -77,7 +77,7 @@ export const ManageButton = ({
                   text={i18next.t("Manage user")}
                 />
                 <Dropdown.Divider />
-                <BlockUserItem recordOwnerID={recordOwnerID} />
+                <BlockUserItem user={recordOwner || { id: recordOwnerID }} />
               </>
             )}
           </>
@@ -103,59 +103,38 @@ ManageButton.defaultProps = {
   uiProps: {},
 };
 
-const BlockUserItem = ({ recordOwnerID }) => {
+const BlockUserItem = ({ user }) => {
   const [modalOpen, setModalOpen] = React.useState(false);
-  const handleOpen = () => setModalOpen(true);
   const handleClose = () => setModalOpen(false);
-  const blockUser = () => {
-    http.post(APIRoutes.block({ id: recordOwnerID }));
-    handleClose();
-  };
 
   return (
     <>
       <Dropdown.Item
         as="a"
         className="error"
-        onClick={handleOpen}
+        onClick={() => setModalOpen(true)}
         key="block_user"
         text={i18next.t("Block user")}
       />
       <Modal
         open={modalOpen}
-        closeIcon
         onClose={handleClose}
         role="dialog"
         closeOnDimmerClick={false}
       >
-        <Modal.Header as="h2">{i18next.t("Block User")}</Modal.Header>
-        <Modal.Description>
-          <Message
-            warning
-            icon="warning sign"
-            content={i18next.t(
-              "Blocking the user will delete all existing records of the user."
-            )}
+        <Modal.Header as="h2">{i18next.t("Block user")}</Modal.Header>
+        {modalOpen && (
+          <UserBlockForm
+            user={user}
+            actionSuccessCallback={handleClose}
+            actionCancelCallback={handleClose}
           />
-        </Modal.Description>
-        <Modal.Actions>
-          <Button onClick={() => handleClose()} floated="left">
-            Cancel
-          </Button>
-          <Button
-            size="small"
-            labelPosition="left"
-            icon="warning"
-            color="red"
-            content={i18next.t("Block")}
-            onClick={blockUser}
-          />
-        </Modal.Actions>
+        )}
       </Modal>
     </>
   );
 };
 
 BlockUserItem.propTypes = {
-  recordOwnerID: PropTypes.string.isRequired,
+  user: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
> AI use disclaimer: All of the UI parts were done with Claude Code, mostly focusing on UX while testing.


* Depends on:
  * https://github.com/inveniosoftware/invenio-users-resources/pull/199
  * https://github.com/inveniosoftware/invenio-communities/pull/1374
  * https://github.com/inveniosoftware/invenio-rdm-records/pull/2326
* Introduces a modal when blocking a user (via the Users administration
  or manage dropdown on the record landing page), which previews the
  user to be deleted and allows for choosing a removal reason and
  public note.


### Block modal via record manage dropdown (to showcase "view in admin" button)

https://github.com/user-attachments/assets/e14f1860-23e3-4ea4-b246-bf52957566bc


