### PR TITLE
fix: display user dashboard header for community topic requests as before

### DIFF
--- a/invenio_app_rdm/requests_ui/views/requests.py
+++ b/invenio_app_rdm/requests_ui/views/requests.py
@@ -273,6 +273,7 @@ def user_dashboard_request_view(request, **kwargs):
             invenio_request=request.to_dict(),
             permissions={**request_permissions},
             include_deleted=False,  # Could probably be removed
+            is_user_dashboard=True,
         )
 
     topic = _resolve_topic_record(request)


### PR DESCRIPTION
Problem:

<img width="1633" height="148" alt="image" src="https://github.com/user-attachments/assets/8f52ea9c-fec7-44c2-881f-4efbbeee31a0" />

Fix:

<img width="1920" height="272" alt="image" src="https://github.com/user-attachments/assets/a4c1daa9-069c-4b2a-9c19-5f59f240d08f" />
