### PR TITLE
users: fix hardcoded deposit URL in uploads dashboard

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
@@ -146,7 +146,7 @@ export const RDMEmptyResults = (props) => {
           positive
           icon="upload"
           floated="right"
-          href="/uploads/new"
+          href={document.getElementById("invenio-search-config").dataset.depositUrl}
           content={i18next.t("New upload")}
         />
       </Segment>
@@ -170,7 +170,7 @@ export const DashboardUploadsSearchLayout = DashboardSearchLayoutHOC({
     <Button
       positive
       icon="upload"
-      href="/uploads/new"
+      href={document.getElementById("invenio-search-config").dataset.depositUrl}
       content={i18next.t("New upload")}
       floated="right"
     />

--- a/invenio_app_rdm/users_ui/templates/semantic-ui/invenio_app_rdm/users/uploads.html
+++ b/invenio_app_rdm/users_ui/templates/semantic-ui/invenio_app_rdm/users/uploads.html
@@ -19,7 +19,7 @@
   <div
     id="invenio-search-config"
     data-invenio-search-config='{{ search_app_rdm_user_uploads_config(app_id="InvenioAppRdm.DashboardUploads") | tojson }}'
-    data-deposit-url="{{ url_for('invenio_app_rdm_records.deposit_create') }}"
+    data-deposit-url="{{ invenio_url_for('invenio_app_rdm_records.deposit_create') }}"
   >
 
 </div>

--- a/invenio_app_rdm/users_ui/templates/semantic-ui/invenio_app_rdm/users/uploads.html
+++ b/invenio_app_rdm/users_ui/templates/semantic-ui/invenio_app_rdm/users/uploads.html
@@ -19,6 +19,7 @@
   <div
     id="invenio-search-config"
     data-invenio-search-config='{{ search_app_rdm_user_uploads_config(app_id="InvenioAppRdm.DashboardUploads") | tojson }}'
+    data-deposit-url="{{ url_for('invenio_app_rdm_records.deposit_create') }}"
   >
 
 </div>


### PR DESCRIPTION
* FIX Replaces hardcoded '/uploads/new' URL with dynamic URL from APP_RDM_ROUTES config.

:heart: Thank you for your contribution!

### Description

## What does this PR fix?

Fixes #3340

## Changes

The "New Upload" button in the user dashboard had a hardcoded URL '/uploads/new' in two places in `uploads.js`. This breaks the button when `APP_RDM_ROUTES` is configured to use a different 'deposit_create' route.

## How was it fixed?

- Added 'data-deposit-url' attribute to the template 'uploads.html' using 'url_for('invenio_app_rdm_records.deposit_create')' to dynamically resolve the URL
- Updated 'uploads.js' to read the URL from the DOM instead of using the hardcoded value.
