### PR TITLE
frontpage: Add aria-label to 'More' search button

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/frontpage/RecordsList.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/frontpage/RecordsList.js
@@ -121,7 +121,9 @@ export class RecordsList extends Component {
             </Item.Group>
 
             <Container textAlign="center">
-              <Button href="/search">{i18next.t("More")}</Button>
+              <Button href="/search" aria-label={i18next.t("Load more search results")}>
+                {i18next.t("More")}
+              </Button>
             </Container>
 
             {error && <Message content={error} error icon="warning sign" />}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The "More" link at the bottom of the Recent Uploads list fails WCAG 2.4.4 Link Purpose. The link text is non-descriptive and no programmatic context exists in the surrounding markup to clarify its purpose for screen reader users. 

Adding an aria-label="Load more search results" to the anchor tag resolves this issue without making any visual changes.

From audit results by @camp5456

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
