### PR TITLE
deposit: add default values for custom fields on deposit form

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -966,6 +966,15 @@ If the value is callable, its return value will be used for the field
 (e.g. lambda/function for dynamic calculation of values).
 """
 
+APP_RDM_DEPOSIT_FORM_CUSTOM_FIELD_DEFAULTS = {}
+"""Default values for custom fields in new records in the deposit UI.
+    
+The keys denote the dot-separated path, where in the record's custom field
+values should be set (see invenio-records.dictutils).
+If the value is callable, its return value will be used for the field
+(e.g. lambda/function for dynamic calculation of values).
+"""
+
 APP_RDM_DEPOSIT_FORM_AUTOCOMPLETE_NAMES = "search"
 """Behavior for autocomplete names search field for creators/contributors.
 

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -469,6 +469,11 @@ def new_record():
     defaults = current_app.config.get("APP_RDM_DEPOSIT_FORM_DEFAULTS") or {}
     for key, value in defaults.items():
         set_default_value(record, value, key)
+    cf_defaults = (
+        current_app.config.get("APP_RDM_DEPOSIT_FORM_CUSTOM_FIELD_DEFAULTS") or {}
+    )
+    for key, value in cf_defaults.items():
+        set_default_value(record, value, key, "custom_fields")
     return record
 
 

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -466,11 +466,11 @@ def new_record():
     else:
         record["pids"] = {}
     record["status"] = "draft"
-    defaults = current_app.config.get("APP_RDM_DEPOSIT_FORM_DEFAULTS") or {}
+    defaults = current_app.config.get("APP_RDM_DEPOSIT_FORM_DEFAULTS", {})
     for key, value in defaults.items():
         set_default_value(record, value, key)
-    cf_defaults = (
-        current_app.config.get("APP_RDM_DEPOSIT_FORM_CUSTOM_FIELD_DEFAULTS") or {}
+    cf_defaults = current_app.config.get(
+        "APP_RDM_DEPOSIT_FORM_CUSTOM_FIELD_DEFAULTS", {}
     )
     for key, value in cf_defaults.items():
         set_default_value(record, value, key, "custom_fields")


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

There isn't currently a way to set defaults for custom fields in the deposit field. This adds a new config variable and implements it in basically the same way as the existing field.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
