### PR TITLE
feat(records): deposit form compatibility with per-record-version review requests

### DIFF
--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -570,10 +570,19 @@ def deposit_edit(pid_value, draft=None, draft_files=None, files_locked=True):
 
     community_ui = None
     community_theme = None
-    community = record.get("expanded", {}).get("parent", {}).get("review", {}).get(
-        "receiver"
-    ) or record.get("expanded", {}).get("parent", {}).get("communities", {}).get(
-        "default"
+    # We get the community from one of three sources, in order of priority:
+    #   1. The draft's review receiver.
+    #   2. The draft's parent's review receiver. Same as above, but refers to the deprecated `parent.review` field.
+    #      We continue to support this for backward-compatibility with records that entered the in-review status before the `review`
+    #      field was moved to be on the draft directly.
+    #   3. The draft's parent's default community, only available for new versions of existing (published) records.
+    community = (
+        record.get("expanded", {}).get("parent", {}).get("review", {}).get("receiver")
+        or record.get("expanded", {}).get("review", {}).get("receiver")
+        or record.get("expanded", {})
+        .get("parent", {})
+        .get("communities", {})
+        .get("default")
     )
 
     if community:

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordVersionsList.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordVersionsList.js
@@ -81,7 +81,7 @@ const PreviewMessage = () => {
         <Icon name="eye" />
         {i18next.t("Preview")}
       </Message.Header>
-      <p>{i18next.t("Only published versions are displayed.")}</p>
+      <p>{i18next.t("This version of the record has not yet been published.")}</p>
     </Message>
   );
 };


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/2323

---

* Changed the way we extract the community from the draft record in the deposit form Flask view handler. The review is now stored (and expanded) on the record itself. The parent record review is also kept for compatibility with existing drafts.

* Updated a message in RecordVersionList to make it make more sense when being viewed from the "Record" tab of a submission request.