### PR TITLE
feat(mshp-req+inv): display mshp-req + invitation pages via respective views

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -1077,6 +1077,7 @@ RDM_REQUESTS_ROUTES = {
     "user-dashboard-request-details": "/me/requests/<uuid:request_pid_value>",
     "community-dashboard-request-details": "/communities/<pid_value>/requests/<uuid:request_pid_value>",
     "community-dashboard-invitation-details": "/communities/<pid_value>/invitations/<uuid:request_pid_value>",
+    "community-dashboard-membership-request-details": "/communities/<pid_value>/membership-requests/<uuid:request_pid_value>",
 }
 
 RDM_COMMUNITIES_ROUTES = {

--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/community-invitation/community_dashboard.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/community-invitation/community_dashboard.html
@@ -17,7 +17,7 @@
 {% block request_header %}
   {{
     member_request_header(
-      back_button_url=url_for("invenio_communities.invitations", pid_value=community.slug),
+      back_button_url=invenio_url_for("invenio_communities.invitations", pid_value=community.slug),
       back_button_text=_("Back to invitations"),
       request=invenio_request
     )

--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/community-membership-request/community_dashboard.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/community-membership-request/community_dashboard.html
@@ -1,38 +1,40 @@
 {# -*- coding: utf-8 -*-
 
   This file is part of Invenio.
-  Copyright (C) 2022 CERN.
+
   Copyright (C) 2026 Northwestern University.
 
   Invenio is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
 #}
+
 {% set title = invenio_request.title %}
 {% extends "invenio_requests/details/index.html" %}
 {% from "invenio_requests/macros/request_header.html" import member_request_header %}
 
 {% set active_community_header_menu_item = 'members' %}
-{% set active_members_menu_item = 'invitations' %}
+{% set active_members_menu_item = 'membership_requests' %}
 
 {% block request_header %}
   {{
     member_request_header(
-      back_button_url=url_for("invenio_communities.invitations", pid_value=community.slug),
-      back_button_text=_("Back to invitations"),
-      request=invenio_request
+      back_button_url=url_for("invenio_communities.membership_requests", pid_value=community.slug),
+      back_button_text=_("Back to membership requests"),
+      request=invenio_request,
+      accepted=is_accepted_request(invenio_request)
     )
   }}
 {% endblock %}
 
 
 {% block settings_body %}
-  <div class="sixteen wide mobile sixteen wide tablet thirteen wide computer column right floated">
-    {% block request_body %}
-      {{ super() }}
-    {% endblock request_body %}
-  </div>
+<div class="sixteen wide mobile sixteen wide tablet thirteen wide computer column right floated">
+  {% block request_body %}
+  {{ super() }}
+  {% endblock request_body %}
+</div>
 {% endblock %}
 
 {% block page_body %}
-  {{ super.super() }}
+{{ super.super() }}
 {% endblock page_body %}

--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/community-membership-request/community_dashboard.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/community-membership-request/community_dashboard.html
@@ -18,7 +18,7 @@
 {% block request_header %}
   {{
     member_request_header(
-      back_button_url=url_for("invenio_communities.membership_requests", pid_value=community.slug),
+      back_button_url=invenio_url_for("invenio_communities.membership_requests", pid_value=community.slug),
       back_button_text=_("Back to membership requests"),
       request=invenio_request,
       accepted=is_accepted_request(invenio_request)

--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/macros/request_header.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/macros/request_header.html
@@ -1,11 +1,21 @@
+{# -*- coding: utf-8 -*-
+
+  Copyright (C) 2026 CERN.
+  Copyright (C) 2026 Northwestern University.
+
+  Invenio App RDM is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+
 {%- from "invenio_app_rdm/records/macros/creatibutors.html" import show_creatibutors %}
 
-{% macro invitation_request_header(back_button_url=None, back_button_text=None, request=None, accepted=False) %}
+{% macro member_request_header(back_button_url=None, back_button_text=None, request=None, accepted=False) %}
   {#
-    Renders the member invitation request header block with:
+    Renders the member request header block with:
     - a back button
-    - a `View community` button, when accepted
     - the request's title
+    - no need for a View Community button since the header is only and already present on a community page
   #}
   <div class="flex wrap space-between">
     {% if back_button_url and back_button_text %}
@@ -19,12 +29,6 @@
     {% endif %}
 
     <div id="request-actions" class="flex align-items-center ml-auto mb-10">
-      {% if accepted %}
-        <a href="{{ url_for("invenio_app_rdm_communities.communities_detail", pid_value=request.topic.community) }}"
-           class="ui small button">
-          {{ _("View Community") }}
-        </a>
-      {% endif %}
     </div>
   </div>
 
@@ -33,6 +37,22 @@
 
   <div class="ui divider"></div>
 {% endmacro %}
+
+
+{% macro invitation_request_header(back_button_url=None, back_button_text=None, request=None, accepted=False) %}
+{#
+  DEPRECATED. Will eventually be removed.
+#}
+  {{
+    member_request_header(
+      back_button_url=back_button_url,
+      back_button_text=back_button_text,
+      request=request,
+      accepted=acceptd,
+    )
+  }}
+{% endmacro %}
+
 
 {% macro inclusion_request_header(back_button_url=None, back_button_text=None, request=None, record=None, accepted=False) %}
 {#

--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/user_dashboard.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/user_dashboard.html
@@ -14,7 +14,7 @@
 {% block request_header %}
   <div class="flex wrap space-between">
     <div class="mb-10">
-      <a href="{{ url_for('invenio_app_rdm_users.requests') }}" class="ui small button labeled icon rel-mr-1">
+      <a href="{{ invenio_url_for('invenio_app_rdm_users.requests') }}" class="ui small button labeled icon rel-mr-1">
         <i class="ui icon left arrow" aria-hidden="true"></i>
         {{ _("Back to requests") }}
       </a>
@@ -23,7 +23,7 @@
     <div id="request-actions" class="flex align-items-center ml-auto mb-10">
       {% if is_accepted_request(invenio_request) %}
       {# In this case we know the topic is always a community #}
-      <a href="{{ url_for('invenio_app_rdm_communities.communities_detail', pid_value=invenio_request['expanded']['topic']['slug']) }}"
+      <a href="{{ invenio_url_for('invenio_app_rdm_communities.communities_detail', pid_value=invenio_request['expanded']['topic']['slug']) }}"
         class="ui small button">
         {{ _("View Community") }}
       </a>

--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/user_dashboard.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/user_dashboard.html
@@ -22,7 +22,8 @@
 
     <div id="request-actions" class="flex align-items-center ml-auto mb-10">
       {% if is_accepted_request(invenio_request) %}
-      <a href="{{ url_for('invenio_app_rdm_communities.communities_detail', pid_value=invenio_request.topic.community) }}"
+      {# In this case we know the topic is always a community #}
+      <a href="{{ url_for('invenio_app_rdm_communities.communities_detail', pid_value=invenio_request['expanded']['topic']['slug']) }}"
         class="ui small button">
         {{ _("View Community") }}
       </a>

--- a/invenio_app_rdm/requests_ui/views/requests.py
+++ b/invenio_app_rdm/requests_ui/views/requests.py
@@ -9,8 +9,9 @@
 
 """Request views module."""
 
-from flask import current_app, g, redirect, render_template, url_for
+from flask import current_app, g, redirect, render_template
 from flask_login import current_user, login_required
+from invenio_base import invenio_url_for
 from invenio_checks.api import ChecksAPI
 from invenio_communities.config import COMMUNITIES_ROLES
 from invenio_communities.members.services.request import CommunityInvitation
@@ -372,7 +373,7 @@ def community_dashboard_request_view(request, community, community_ui, **kwargs)
         # From legacy of this view serving
         # /communities/<community pid>/requests/<request pid>
         return redirect(
-            url_for(
+            invenio_url_for(
                 "invenio_app_rdm_requests.community_dashboard_invitation_view",
                 pid_value=kwargs["pid_value"],
                 request_pid_value=kwargs["request_pid_value"],

--- a/invenio_app_rdm/requests_ui/views/requests.py
+++ b/invenio_app_rdm/requests_ui/views/requests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019-2026 CERN.
-# Copyright (C) 2019-2022 Northwestern University.
+# Copyright (C) 2019-2026 Northwestern University.
 # Copyright (C)      2022 TU Wien.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
@@ -9,7 +9,7 @@
 
 """Request views module."""
 
-from flask import current_app, g, render_template
+from flask import current_app, g, redirect, render_template, url_for
 from flask_login import current_user, login_required
 from invenio_checks.api import ChecksAPI
 from invenio_communities.config import COMMUNITIES_ROLES
@@ -20,7 +20,10 @@ from invenio_communities.subcommunities.services.request import (
     SubCommunityRequest,
 )
 from invenio_communities.utils import identity_cache_key
-from invenio_communities.views.communities import render_community_theme_template
+from invenio_communities.views.communities import (
+    MEMBERS_PERMISSIONS,
+    render_community_theme_template,
+)
 from invenio_communities.views.decorators import pass_community
 from invenio_i18n.ext import current_i18n
 from invenio_pidstore.errors import PIDDoesNotExistError
@@ -272,7 +275,7 @@ def user_dashboard_request_view(request, **kwargs):
             user_avatar=avatar,
             invenio_request=request.to_dict(),
             permissions={**request_permissions},
-            include_deleted=False,  # Could probably be removed
+            include_deleted=False,
             is_user_dashboard=True,
         )
 
@@ -366,20 +369,14 @@ def community_dashboard_request_view(request, community, community_ui, **kwargs)
         )
 
     elif is_member_invitation:
-        if not permissions["can_search_invites"]:
-            raise PermissionDeniedError()
-
-        return render_community_theme_template(
-            f"invenio_requests/{request_type}/community_dashboard.html",
-            theme=community.to_dict().get("theme", {}),
-            base_template="invenio_communities/details/members/base.html",
-            invenio_request=request.to_dict(),
-            community=community,
-            community_ui=community_ui,
-            permissions=permissions,
-            request_is_accepted=request_is_accepted,
-            user_avatar=avatar,
-            include_deleted=False,
+        # From legacy of this view serving
+        # /communities/<community pid>/requests/<request pid>
+        return redirect(
+            url_for(
+                "invenio_app_rdm_requests.community_dashboard_invitation_view",
+                pid_value=kwargs["pid_value"],
+                request_pid_value=kwargs["request_pid_value"],
+            )
         )
 
     elif is_subcommunity_request or is_subcommunity_invitation_request:
@@ -395,6 +392,78 @@ def community_dashboard_request_view(request, community, community_ui, **kwargs)
             user_avatar=avatar,
             include_deleted=False,
         )
+
+
+@login_required
+@pass_request(expand=True)
+@pass_community(serialize=True)
+def community_dashboard_invitation_view(request, community, community_ui, **kwargs):
+    """Community dashboard's invitation view."""
+    request_type = request["type"]
+    permissions = community.has_permissions_to(MEMBERS_PERMISSIONS)
+    request_permissions = request.has_permissions_to(
+        ["action_cancel", "lock_request", "create_comment", "reply_comment"]
+    )
+    permissions.update(request_permissions)
+
+    if not permissions["can_search_invites"]:
+        raise PermissionDeniedError()
+
+    # TODO: This should just be a context_processor or filter
+    avatar = current_user_resources.users_service.links_item_tpl.expand(
+        g.identity, current_user
+    )["avatar"]
+
+    return render_community_theme_template(
+        f"invenio_requests/{request_type}/community_dashboard.html",
+        theme=community.to_dict().get("theme", {}),
+        base_template="invenio_communities/details/members/base.html",
+        invenio_request=request.to_dict(),  # so to not clash with flask's `request`
+        community=community,
+        community_ui=community_ui,
+        permissions=permissions,
+        user_avatar=avatar,
+    )
+
+
+@login_required
+@pass_request(expand=True)
+@pass_community(serialize=True)
+def community_dashboard_membership_request_view(
+    request, community, community_ui, **kwargs
+):
+    """Community dashboard's membership request view."""
+    request_type = request["type"]
+    permissions = community.has_permissions_to(MEMBERS_PERMISSIONS)
+    request_permissions = request.has_permissions_to(
+        [
+            "action_accept",
+            "action_decline",
+            "lock_request",
+            "create_comment",
+            "reply_comment",
+        ]
+    )
+    permissions.update(request_permissions)
+
+    if not permissions["can_search_membership_requests"]:
+        raise PermissionDeniedError()
+
+    # TODO: This should just be a context_processor or filter
+    avatar = current_user_resources.users_service.links_item_tpl.expand(
+        g.identity, current_user
+    )["avatar"]
+
+    return render_community_theme_template(
+        f"invenio_requests/{request_type}/community_dashboard.html",
+        theme=community.to_dict().get("theme", {}),
+        base_template="invenio_communities/details/members/base.html",
+        invenio_request=request.to_dict(),  # so to not clash with flask's `request`
+        community=community,
+        community_ui=community_ui,
+        permissions=permissions,
+        user_avatar=avatar,
+    )
 
 
 def is_accepted_request(request_dict):

--- a/invenio_app_rdm/requests_ui/views/ui.py
+++ b/invenio_app_rdm/requests_ui/views/ui.py
@@ -24,6 +24,8 @@ from sqlalchemy.exc import NoResultFound
 
 from ...records_ui.searchapp import search_app_context
 from .requests import (
+    community_dashboard_invitation_view,
+    community_dashboard_membership_request_view,
     community_dashboard_request_view,
     is_accepted_request,
     user_dashboard_request_view,
@@ -54,7 +56,12 @@ def create_ui_blueprint(app):
 
     blueprint.add_url_rule(
         routes["community-dashboard-invitation-details"],
-        view_func=community_dashboard_request_view,
+        view_func=community_dashboard_invitation_view,
+    )
+
+    blueprint.add_url_rule(
+        routes["community-dashboard-membership-request-details"],
+        view_func=community_dashboard_membership_request_view,
     )
 
     blueprint.add_url_rule(

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/input.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/input.overrides
@@ -2,7 +2,9 @@
          Invenio App RDM Input Overrides
 ***********************************************/
 
-.input.invitation-searchbar {
+.input.invitation-searchbar,
+.input.invitations-searchbar,
+.input.membership-requests-searchbar {
     width: 100%;
 }
 


### PR DESCRIPTION
This PR is part 5 of the series of PRs that revive and merge the "Request to join a community as a user" feature. It goes with (should be merged after) https://github.com/inveniosoftware/invenio-communities/pull/1380 . This PR covers the part of the feature that deals with the frontend on community side (the request pages themselves).

This also extracts invitation view code from request view so that the "community_dashboard_invitation_view" endpoint name can be used to generate `/communities/<community pid>/invitations/<req id>` (and to split responsibility for easier change).

**Out of bounds/future PRs**: dependency bump of invenio-communities: I will add it in separate PR when all PRs of invenio-communities are merged and *it* is released to save on intermediary overhead. Tests pass, the membership request page url won't work yet, but that's ok bc the feature is not complete yet.  

**Related PRs**
- Draft RFC here: https://github.com/inveniosoftware/rfcs/pull/111 .
- invenio-communities side of the UI: https://github.com/inveniosoftware/invenio-communities/pull/1380 . It contains the screenshots enabled by this PR.
