### PR TITLE
fix: wrap long filenames on landing page

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -50,7 +50,7 @@
         class="trigger"
         aria-label="{{ _('File preview') }}"
       >
-        <span id="preview-file-title">{{ human_readable_file_name }}</span>
+        <span id="preview-file-title" class="wrap-overflowing-text">{{ human_readable_file_name }}</span>
         <i class="angle right icon" aria-hidden="true"></i>
       </div>
     </h3>
@@ -131,7 +131,7 @@ To access its content, please download it and open it locally.') }}
         {%- set file_type = file.key.split('.')[-1] %}
         <tr>
           <td class="ten wide">
-            <div>
+            <div class="wrap-overflowing-text">
               <a href="{{ file_url_download }}">{{ human_readable_file_name }}</a>
             </div>
             {%- if not is_remote_file %}


### PR DESCRIPTION
## Summary\n- Apply the existing overflow-wrapping utility to the preview filename title and file link in the landing page files panel.\n- Prevent long filenames from breaking the record detail layout.\n\n## Validation\n- \n- Jinja syntax not directly runnable here because the environment lacks project dependencies, but the change is limited to a template-only class addition.\n\nCloses #3195