### PR TITLE
Check for `get_content_files` permission in record_file_preview

### DIFF
--- a/invenio_app_rdm/records_ui/views/decorators.py
+++ b/invenio_app_rdm/records_ui/views/decorators.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2025 CERN.
 # Copyright (C) 2019-2025 Northwestern University.
 # Copyright (C)      2021 TU Wien.
+# Copyright (C) 2025 CESNET i.a.l.e.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -279,6 +280,34 @@ def pass_file_metadata(f):
             files = files_service().read_file_metadata(**read_kwargs)
 
         kwargs["file_metadata"] = files
+        return f(**kwargs)
+
+    return view
+
+
+def pass_file_content(f):
+    """Decorate a view to pass a file's content using the files service."""
+
+    @wraps(f)
+    def view(**kwargs):
+        pid_value = kwargs.get("pid_value")
+        file_key = kwargs.get("filename")
+        is_preview = kwargs.get("is_preview")
+        read_kwargs = {
+            "id_": pid_value,
+            "file_key": file_key,
+            "identity": g.identity,
+        }
+
+        if is_preview:
+            try:
+                files = draft_files_service().get_file_content(**read_kwargs)
+            except NoResultFound:
+                files = files_service().get_file_content(**read_kwargs)
+        else:
+            files = files_service().get_file_content(**read_kwargs)
+
+        kwargs["file_content"] = files
         return f(**kwargs)
 
     return view

--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2025 CERN.
 # Copyright (C) 2019-2021 Northwestern University.
 # Copyright (C) 2021-2023 TU Wien.
+# Copyright (C) 2025 CESNET i.a.l.e.
 #
 # Invenio App RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -46,6 +47,7 @@ from .decorators import (
     add_signposting_content_resources,
     add_signposting_landing_page,
     add_signposting_metadata_resources,
+    pass_file_content,
     pass_file_item,
     pass_file_metadata,
     pass_include_deleted,
@@ -363,6 +365,7 @@ def record_export(
 @pass_include_deleted
 @pass_record_or_draft(expand=False)
 @pass_file_metadata
+@pass_file_content
 @pass_is_iframe
 def record_file_preview(
     pid_value,


### PR DESCRIPTION
### Description

When previewing a file, two decorators are executed:

- `@pass_record_or_draft(expand=False)` calls `RDMRecordService.read` / `RDMRecordService.read_draft` that checks for permission `can_read` or `can_read_draft`.
- `@pass_file_metadata` calls `RDMRecordService.read_file_metadata` that checks for permission `can_read_files`.

`pass_file_metadata` doesn't check for `can_get_content_files` permission.

This PR adds decorator `pass_file_content`, which calls `RDMRecordService.get_file_content`  that checks for permission `can_get_content_files`. The result of `RDMRecordService.get_file_content`  is passed to kwargs["file_content"].

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
