### PR TITLE
fix: enable community owner to remove it from record

### DIFF
--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -296,6 +296,7 @@ def record_detail(
 
     record_requests = get_record_requests(record, g.identity)
 
+    # permissions needs to include extra params to be passed to the template
     permissions = record.has_permissions_to(
         [
             "edit",
@@ -313,13 +314,13 @@ def record_detail(
         ]
     )
     permissions["removable_community_ids"] = [
-        str(cid)
+        cid
         for cid in record._record.parent.communities.ids
         if current_rdm_records.records_service.check_permission(
             g.identity,
             "remove_community_from_record",
             record=record._record,
-            community_id=str(cid),
+            community_id=cid,
         )
     ]
 

--- a/invenio_app_rdm/records_ui/views/records.py
+++ b/invenio_app_rdm/records_ui/views/records.py
@@ -296,6 +296,33 @@ def record_detail(
 
     record_requests = get_record_requests(record, g.identity)
 
+    permissions = record.has_permissions_to(
+        [
+            "edit",
+            "new_version",
+            "manage",
+            "update_draft",
+            "read_files",
+            "review",
+            "view",
+            "media_read_files",
+            "moderate",
+            "request_deletion",
+            "immediately_delete",
+            "remove_community_from_record",
+        ]
+    )
+    permissions["removable_community_ids"] = [
+        str(cid)
+        for cid in record._record.parent.communities.ids
+        if current_rdm_records.records_service.check_permission(
+            g.identity,
+            "remove_community_from_record",
+            record=record._record,
+            community_id=str(cid),
+        )
+    ]
+
     return render_community_theme_template(
         current_app.config.get("APP_RDM_RECORD_LANDING_PAGE_TEMPLATE"),
         theme=theme,
@@ -304,22 +331,7 @@ def record_detail(
         files=files_dict,
         media_files=media_files_dict,
         user_communities_memberships=get_user_communities_memberships(),
-        permissions=record.has_permissions_to(
-            [
-                "edit",
-                "new_version",
-                "manage",
-                "update_draft",
-                "read_files",
-                "review",
-                "view",
-                "media_read_files",
-                "moderate",
-                "request_deletion",
-                "immediately_delete",
-                "remove_community_from_record",
-            ]
-        ),
+        permissions=permissions,
         custom_fields_ui=custom_fields["ui"],
         is_preview=is_preview,
         include_deleted=include_deleted,

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesListModal/RecordCommunitiesSearchItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordCommunitiesListModal/RecordCommunitiesSearchItem.js
@@ -14,7 +14,7 @@ export class RecordCommunitiesSearchItem extends Component {
       recordParent,
       permissions: {
         can_manage: canManage,
-        can_remove_community_from_record: canRemoveCommunity,
+        removable_community_ids: removableCommunityIds,
       },
       recordRequests,
     } = this.props;
@@ -32,7 +32,7 @@ export class RecordCommunitiesSearchItem extends Component {
           result={result}
           recordCommunityEndpoint={recordCommunityEndpoint}
           successCallback={successCallback}
-          canRemoveCommunity={canRemoveCommunity}
+          canRemoveCommunity={removableCommunityIds?.includes(result?.id)}
         />
       </>
     );


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Via the UI, the button to remove a community from a record is disabled to community owners, with a message of "you don't have permission".

CommunityCurators should be able to remove the community from the record, but only for those communities the user is a curator of.

The `remove_community_from_record` permission is a boolean, so it does not allow identifying for each communities the permission exists. To handle that, we check the permission per community and pass that to the frontend. Only the 
allowable communities will have the enabled button.

With these changes: communities for which the user is a curator (and only for those) have the button enabled

<img width="951" height="636" alt="image" src="https://github.com/user-attachments/assets/dc75ff3d-e5c1-4ed1-b004-c0d4a7850dc9" />


Closes [inveniosoftware/invenio-app-rdm#3452](https://github.com/inveniosoftware/invenio-app-rdm/issues/3452)



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
