### PR TITLE
Security: XSS via Unescaped Description in Template

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html
@@ -13,9 +13,8 @@
 {% if description %}
   <section id="description" class="rel-mt-2 rich-input-content" aria-label="{{ _('Record description') }}">
     <h2 id="description-heading" class="sr-only">{{ _('Description') }}</h2>
-    {# description data is being sanitized by marshmallow in the backend #}
     <div style="word-wrap: break-word;">
-      {{ description | safe }}
+      {{ description }}
     </div>
   </section>
 {% endif %}


### PR DESCRIPTION
## Summary

Security: XSS via Unescaped Description in Template

## Problem

**Severity**: `High` | **File**: `invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html:L17`

In `description.html`, the `description` variable is rendered with the `| safe` filter, which marks the content as safe HTML and bypasses Jinja2's auto-escaping. While the comment states 'description data is being sanitized by marshmallow in the backend', if the backend sanitization is ever bypassed, incomplete, or has vulnerabilities, this creates a stored XSS vulnerability. The `| safe` filter should not be used on user-controlled content without rigorous server-side sanitization.

## Solution

Remove the `| safe` filter and ensure the backend returns properly escaped content. If HTML is truly required, use a strict HTML sanitizer like bleach or nh3 on the backend, and consider using a dedicated safe HTML rendering approach rather than `| safe`.

## Changes

- `invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/description.html` (modified)