### PR TITLE
feat(upgrade): patch role IDs for bleeding-edge instances (Not for v13 migration)

### DIFF
--- a/invenio_app_rdm/upgrade_scripts/migrate_role_ids_to_names.py
+++ b/invenio_app_rdm/upgrade_scripts/migrate_role_ids_to_names.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CERN.
+#
+# Invenio-App-RDM is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Role migration script for InvenioRDM 14.0.
+
+Disclaimer: This script is intended to be executed *only once*, for v14
+instances where roles may have generated ids different from their names.
+It restores the invariant that ``accounts_role.id == accounts_role.name``.
+"""
+
+import sys
+
+from click import secho
+from invenio_access.models import ActionRoles
+from invenio_accounts.models import Role
+from invenio_db import db
+
+
+def execute_upgrade():
+    """Execute the role id/name migration."""
+    secho("Starting role id/name migration...", fg="green")
+
+    roles = Role.query.filter(Role.id != Role.name).all()
+
+    errors = [
+        f"Role <{role.id}> cannot be migrated to <{role.name}>: "
+        "target id already exists."
+        for role in roles
+        if db.session.get(Role, role.name)
+    ]
+
+    if errors:
+        db.session.rollback()
+        secho("Upgrade aborted due to the following errors:", fg="red", err=True)
+        for error in errors:
+            secho(error, fg="red", err=True)
+        sys.exit(1)
+
+    for role in roles:
+        old_id = role.id
+        new_id = role.name
+        users = list(role.users)
+        secho(f"Updating role <{old_id}> to <{new_id}>.", fg="yellow")
+
+        # Role.id is referenced by foreign keys without ON UPDATE CASCADE, so
+        # replace the row instead of mutating the primary key in place.
+        role.name = None
+        db.session.flush()
+
+        replacement_role = Role(
+            id=new_id,
+            name=new_id,
+            description=role.description,
+            is_managed=role.is_managed,
+        )
+        replacement_role.users = users
+        db.session.add(replacement_role)
+
+        ActionRoles.query.filter_by(role_id=old_id).update(
+            {ActionRoles.role_id: new_id}, synchronize_session=False
+        )
+        db.session.delete(role)
+
+    secho("Committing to DB", fg="green")
+    db.session.commit()
+    secho(
+        f"Data migration completed. Updated {len(roles)} role(s). "
+        "Please rebuild the search indices now.",
+        fg="green",
+    )
+
+
+if __name__ == "__main__":
+    execute_upgrade()

--- a/invenio_app_rdm/upgrade_scripts/migrate_role_ids_to_names.py
+++ b/invenio_app_rdm/upgrade_scripts/migrate_role_ids_to_names.py
@@ -1,9 +1,6 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (C) 2026 CERN.
-#
-# Invenio-App-RDM is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# SPDX-FileCopyrightText: 2026 KTH Royal Institute of Technology.
+# SPDX-FileCopyrightText: 2026 Northwestern University.
+# SPDX-License-Identifier: MIT
 
 """Role migration script for InvenioRDM 14.0.
 
@@ -16,8 +13,10 @@ import sys
 
 from click import secho
 from invenio_access.models import ActionRoles
-from invenio_accounts.models import Role
+from invenio_accounts.models import Role, userrole
+from invenio_communities.members import MemberModel
 from invenio_db import db
+from sqlalchemy import update
 
 
 def execute_upgrade():
@@ -43,26 +42,54 @@ def execute_upgrade():
     for role in roles:
         old_id = role.id
         new_id = role.name
-        users = list(role.users)
-        secho(f"Updating role <{old_id}> to <{new_id}>.", fg="yellow")
+        secho(f"Updating role id <{old_id}> to <{new_id}>.", fg="yellow")
 
-        # Role.id is referenced by foreign keys without ON UPDATE CASCADE, so
-        # replace the row instead of mutating the primary key in place.
-        role.name = None
-        db.session.flush()
+        # Role.id is referenced by foreign keys without ON UPDATE CASCADE, and
+        # we can't alter a persisted role's name directly because of
+        # https://github.com/inveniosoftware/invenio-accounts/blob/master/invenio_accounts/models.py#L128  # noqa
+        # . So idea is to create a new Role, make related entities point to it,
+        # and delete old Role afterwards. And do it all using "low-level"
+        # SQL primitives that avoid the application-level constraints.
 
+        db.session.execute(update(Role).where(Role.id == old_id).values(name=None))
+
+        # Create new Role with id == name
         replacement_role = Role(
             id=new_id,
             name=new_id,
             description=role.description,
             is_managed=role.is_managed,
         )
-        replacement_role.users = users
         db.session.add(replacement_role)
+        db.session.flush()
 
-        ActionRoles.query.filter_by(role_id=old_id).update(
-            {ActionRoles.role_id: new_id}, synchronize_session=False
+        # Change access_actionroles to use new entry
+        db.session.execute(
+            update(ActionRoles)
+            .where(ActionRoles.role_id == old_id)
+            .values(role_id=replacement_role.id)
         )
+
+        # Change accounts_userrole to use new entry
+        # fmt: off
+        db.session.execute(
+            update(userrole)
+            # Note 'c' because userrole is a Table and not a Model
+            .where(userrole.c.role_id == old_id)
+            .values(role_id=replacement_role.id)
+        )
+        # fmt: on
+
+        # Change communities_members to use new entry
+        db.session.execute(
+            update(MemberModel)
+            .where(MemberModel.group_id == old_id)
+            .values(group_id=replacement_role.id)
+        )
+
+        # Can skip archived invitations (cannot invite group)
+
+        # Delete old role
         db.session.delete(role)
 
     secho("Committing to DB", fg="green")


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Add one-time migration for restoring role ids from role names and updating related grants.
* Reindex groups after migration so search data matches the updated role records.
* Depends on https://github.com/inveniosoftware/invenio-users-resources/pull/201

The data migration script is only needed for instances that were running bleeding-edge InvenioRDM after the role name/id split and that used the roles feature before the beta release. Instances upgraded before the beta release do not need to run this migration.

#### Database migration

Execute the data migration:

```bash
invenio shell $(find $(pipenv --venv)/lib/*/site-packages/invenio_app_rdm -name migrate_role_ids_to_names.py)
```

#### Reindex

After the data migration, rebuild the search indices:

```bash
invenio index destroy --yes-i-know
invenio index init
invenio rdm rebuild-all-indices
```
If you prefer not to rebuild all indices, you can instead run the groups/users reindex custom script:

invenio shell [here](https://github.com/Samk13/invenio-dev-latest/blob/master/scripts/indices-migration-v13-14/user-groups-indices-migration.py)


> Note: This PR includes AI-assisted contributions and has been reviewed and refined manually.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
