### PR TITLE
dashboard: added condition to show stats for only published records

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
@@ -49,6 +49,7 @@ export const RDMRecordResultsListItem = ({ result }) => {
   };
 
   const isPublished = result.is_published;
+  const isDraft = result.is_draft;
   const access = {
     accessStatusId: _get(result, "ui.access_status.id", i18next.t("open")),
     accessStatus: _get(result, "ui.access_status.title_l10n", i18next.t("Open")),
@@ -76,6 +77,7 @@ export const RDMRecordResultsListItem = ({ result }) => {
     createdDate: result.ui?.created_date_l10n_long,
     version: result.ui?.version ?? "",
     isPublished: isPublished,
+    isDraft: isDraft,
     viewLink: isPublished ? `/records/${result.id}` : `/uploads/${result.id}`,
     publishingInformation: _get(result, "ui.publishing_information.journal", ""),
   };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads.js
@@ -48,6 +48,7 @@ export const RDMRecordResultsListItem = ({ result }) => {
   };
 
   const isPublished = result.is_published;
+  const isDraft = result.is_draft;
   const access = {
     accessStatusId: _get(result, "ui.access_status.id", i18next.t("open")),
     accessStatus: _get(result, "ui.access_status.title_l10n", i18next.t("Open")),
@@ -75,6 +76,7 @@ export const RDMRecordResultsListItem = ({ result }) => {
     createdDate: result.ui?.created_date_l10n_long,
     version: result.ui?.version ?? "",
     isPublished: isPublished,
+    isDraft: isDraft,
     viewLink: isPublished ? `/records/${result.id}` : `/uploads/${result.id}`,
     publishingInformation: _get(result, "ui.publishing_information.journal", ""),
   };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
@@ -30,6 +30,7 @@ export const ComputerTabletUploadsItem = ({
     createdDate,
     version,
     isPublished,
+    isDraft,
     viewLink,
     publishingInformation,
   } = uiMetadata;
@@ -132,12 +133,14 @@ export const ComputerTabletUploadsItem = ({
                 </span>
               )}
             </small>
-            <small>
-              <CompactStats
-                uniqueViews={uniqueViews}
-                uniqueDownloads={uniqueDownloads}
-              />
-            </small>
+            {isPublished && !isDraft && (
+              <small>
+                <CompactStats
+                  uniqueViews={uniqueViews}
+                  uniqueDownloads={uniqueDownloads}
+                />
+              </small>
+            )}
           </div>
         </Item.Extra>
       </Item.Content>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
@@ -31,6 +31,7 @@ export const ComputerTabletUploadsItem = ({
     createdDate,
     version,
     isPublished,
+    isDraft,
     viewLink,
     publishingInformation,
   } = uiMetadata;
@@ -133,12 +134,14 @@ export const ComputerTabletUploadsItem = ({
                 </span>
               )}
             </small>
-            <small>
-              <CompactStats
-                uniqueViews={uniqueViews}
-                uniqueDownloads={uniqueDownloads}
-              />
-            </small>
+            {isPublished && !isDraft && (
+              <small>
+                <CompactStats
+                  uniqueViews={uniqueViews}
+                  uniqueDownloads={uniqueDownloads}
+                />
+              </small>
+            )}
           </div>
         </Item.Extra>
       </Item.Content>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/ComputerTabletUploadsItem.js
@@ -7,7 +7,7 @@ import { i18next } from "@translations/invenio_app_rdm/i18next";
 import React from "react";
 import PropTypes from "prop-types";
 import _get from "lodash/get";
-import { Button, Icon, Item, Label } from "semantic-ui-react";
+import { Button, Dropdown, Icon, Item, Label } from "semantic-ui-react";
 import { SearchItemCreators } from "../../utils";
 import { CompactStats } from "../../components/CompactStats";
 import { DisplayPartOfCommunities } from "../../components/DisplayPartOfCommunities";
@@ -70,7 +70,7 @@ export const ComputerTabletUploadsItem = ({
             {accessStatus}
           </Label>
 
-          {isPublished ? (
+          {isPublished && !isDraft ? (
             <Button
               compact
               size="small"
@@ -80,7 +80,7 @@ export const ComputerTabletUploadsItem = ({
               icon="eye"
               content={i18next.t("View")}
             />
-          ) : (
+          ) : !isPublished && isDraft ? (
             <Button
               compact
               size="small"
@@ -90,6 +90,28 @@ export const ComputerTabletUploadsItem = ({
               icon="eye"
               content={i18next.t("View")}
             />
+          ) : (
+            <Dropdown
+              compact
+              text={i18next.t("View")}
+              icon="eye"
+              labeled
+              button
+              className="icon small right floated"
+            >
+              <Dropdown.Menu>
+                <Dropdown.Item
+                  href={viewLink}
+                  key="view_record"
+                  text={i18next.t("View record")}
+                />
+                <Dropdown.Item
+                  onClick={() => viewDraft()}
+                  key="view_draft"
+                  text={i18next.t("View draft")}
+                />
+              </Dropdown.Menu>
+            </Dropdown>
           )}
         </Item.Extra>
         <Item.Header as="h2">

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/MobileUploadsItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/MobileUploadsItem.js
@@ -30,6 +30,7 @@ export const MobileUploadsItem = ({
     createdDate,
     version,
     isPublished,
+    isDraft,
     viewLink,
     publishingInformation,
   } = uiMetadata;
@@ -108,12 +109,14 @@ export const MobileUploadsItem = ({
                 )}
               </small>
               <div className="rel-mt-1">
-                <small>
-                  <CompactStats
-                    uniqueViews={uniqueViews}
-                    uniqueDownloads={uniqueDownloads}
-                  />
-                </small>
+                {isPublished && !isDraft && (
+                  <small>
+                    <CompactStats
+                      uniqueViews={uniqueViews}
+                      uniqueDownloads={uniqueDownloads}
+                    />
+                  </small>
+                )}
               </div>
             </div>
           </Item.Extra>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/MobileUploadsItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/MobileUploadsItem.js
@@ -31,6 +31,7 @@ export const MobileUploadsItem = ({
     createdDate,
     version,
     isPublished,
+    isDraft,
     viewLink,
     publishingInformation,
   } = uiMetadata;
@@ -109,12 +110,14 @@ export const MobileUploadsItem = ({
                 )}
               </small>
               <div className="rel-mt-1">
-                <small>
-                  <CompactStats
-                    uniqueViews={uniqueViews}
-                    uniqueDownloads={uniqueDownloads}
-                  />
-                </small>
+                {isPublished && !isDraft && (
+                  <small>
+                    <CompactStats
+                      uniqueViews={uniqueViews}
+                      uniqueDownloads={uniqueDownloads}
+                    />
+                  </small>
+                )}
               </div>
             </div>
           </Item.Extra>

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/MobileUploadsItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/uploads_items/MobileUploadsItem.js
@@ -124,20 +124,33 @@ export const MobileUploadsItem = ({
         <Item.Extra>
           <Dropdown button text={i18next.t("Actions")} labeled className="icon">
             <Dropdown.Menu>
-              {isPublished ? (
+              {isPublished && !isDraft ? (
                 <Dropdown.Item
                   labelposition="left"
                   href={viewLink}
                   icon="eye"
                   content={i18next.t("View")}
                 />
-              ) : (
+              ) : !isPublished && isDraft ? (
                 <Dropdown.Item
                   onClick={() => viewDraft()}
                   labelposition="left"
                   icon="eye"
                   content={i18next.t("View")}
                 />
+              ) : (
+                <>
+                  <Dropdown.Item
+                    labelposition="left"
+                    href={viewLink}
+                    content={i18next.t("View record")}
+                  />
+                  <Dropdown.Item
+                    onClick={() => viewDraft()}
+                    labelposition="left"
+                    content={i18next.t("View draft")}
+                  />
+                </>
               )}
             </Dropdown.Menu>
           </Dropdown>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes Issue https://github.com/zenodo/ops/issues/489

_Only show stats for published records with no active draft_


<img width="1105" height="656" alt="Screenshot 2026-06-02 at 16 22 20" src="https://github.com/user-attachments/assets/304b9bbd-043f-45bf-a944-997b2dce7f6f" />

**Some discussion points**

- How to make the status of a published record that has a draft in progress more obvious and apparent
- The icons and labels to be more aligned and descriptive of the state
- ~~The View button, should it be split into two buttons one for draft and one for published record~~ -> done in the last commit
<img width="961" height="253" alt="image" src="https://github.com/user-attachments/assets/7c508225-6459-4d9b-8cc3-e620655d28a3" />
<img width="533" height="358" alt="image" src="https://github.com/user-attachments/assets/00661b55-b89a-475d-8949-8c0befd5022f" />

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
