### PR TITLE
fix: use config variable PREVIEWER_CONTAINER_ITEM_PREFERENCE

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -976,7 +976,7 @@ If the value is callable, its return value will be used for the field
 
 APP_RDM_DEPOSIT_FORM_CUSTOM_FIELD_DEFAULTS = {}
 """Default values for custom fields in new records in the deposit UI.
-    
+
 The keys denote the dot-separated path, where in the record's custom field
 values should be set (see invenio-records.dictutils).
 If the value is callable, its return value will be used for the field
@@ -1197,7 +1197,7 @@ PREVIEWER_PREFERENCE = [
 PREVIEWER_ABSTRACT_TEMPLATE = "invenio_previewer/rdm_abstract_previewer.html"
 """Override the abstract template with an RDM-specific one."""
 
-CONTAINER_ITEM_PREVIEWER_PREFERENCE = [
+PREVIEWER_CONTAINER_ITEM_PREFERENCE = [
     "csv_papaparsejs",
     "pdfjs",
     "simple_image",


### PR DESCRIPTION
### Description

Rename config variable CONTAINER_ITEM_PREVIEWER_PREFERENCE to PREVIEWER_CONTAINER_ITEM_PREFERENCE, the expected config variable name by invenio_previewer. 
This enables invenio_previewer to correctly choose a previewer for zip inside zip using the config variable PREVIEWER_CONTAINER_ITEM_PREFERENCE.
Now, the incorrectly named variable results in PREVIEWER_PREFERENCE being used as a fallback, which results in error when trying to preview a zip inside zip.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
