### PR TITLE
feat(Creatibutors): landing-page show-all modal with searching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@
 Changes
 =======
 
+Version v15.0.0b2.dev0 (released 2026-07-21)
+
+- feat(Creatibutors): Add landing page "show-all" modal with searching for large author/contributor lists.
+- chore: Create SECURITY.md.
+- files: Improve external file size display.
+
 Version v15.0.0b1.dev0 (released 2026-07-10)
 
 - refactor(views): Move get_record_requests to RecordCommunitiesService

--- a/invenio_app_rdm/__init__.py
+++ b/invenio_app_rdm/__init__.py
@@ -13,6 +13,6 @@
 #
 # See PEP 0440 for details - https://www.python.org/dev/peps/pep-0440
 
-__version__ = "15.0.0b1.dev0"
+__version__ = "15.0.0b2.dev0"
 
 __all__ = ("__version__",)

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
@@ -15,16 +15,17 @@
 <div class="ui grid">
 
   {% if record_ui["ui"]["creators"] and record_ui["ui"]["creators"]["creators"] %}
+    {% set creatibutors_inline_list_threshold = 10 %}
     {%- set all_creators = record_ui["ui"]["creators"]["creators"] -%}
     {%- set creator_count = all_creators | length -%}
-    {%- set use_controls = creator_count > config.RDM_CREATIBUTORS_INLINE_LIST_THRESHOLD -%}
+    {%- set use_controls = creator_count > creatibutors_inline_list_threshold -%}
 
     <div id="creators-section" class="row ui accordion affiliations">
       <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
         <h3 class="sr-only">{{ _('Authors/Creators') }}</h3>
         <ul class="creatibutors">
           {{ show_creatibutors(
-               all_creators[:config.RDM_CREATIBUTORS_INLINE_LIST_THRESHOLD] if use_controls else all_creators,
+               all_creators[:creatibutors_inline_list_threshold] if use_controls else all_creators,
                show_affiliations=True, show_role=True) }}
           {%- if use_controls %}
           <li class="creatibutor-et-al">
@@ -54,14 +55,14 @@
   {% if record_ui["ui"]["contributors"] and record_ui["ui"]["contributors"]["contributors"] %}
     {%- set all_contributors = record_ui["ui"]["contributors"]["contributors"] -%}
     {%- set contributor_count = all_contributors | length -%}
-    {%- set use_controls = contributor_count > config.RDM_CREATIBUTORS_INLINE_LIST_THRESHOLD -%}
+    {%- set use_controls = contributor_count > creatibutors_inline_list_threshold -%}
 
     <div id="contributors-section" class="row ui accordion affiliations">
       <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
         <h3>{{ _('Contributors') }}</h3>
 
         {{ contributors_grouped(
-             all_contributors[:config.RDM_CREATIBUTORS_INLINE_LIST_THRESHOLD] if use_controls else all_contributors,
+             all_contributors[:creatibutors_inline_list_threshold] if use_controls else all_contributors,
              count_source=all_contributors if use_controls else none) }}
 
         {%- if use_controls %}

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/creatibutors.html
@@ -1,49 +1,89 @@
 {#
-  SPDX-FileCopyrightText: 2020-2024 CERN.
+  SPDX-FileCopyrightText: 2020-2026 CERN.
   SPDX-FileCopyrightText: 2020 Northwestern University.
   SPDX-FileCopyrightText: 2021 TU Wien.
   SPDX-License-Identifier: MIT
 #}
 
-{%- from "invenio_app_rdm/records/macros/creatibutors.html" import affiliations_accordion, show_creatibutors %}
+{%- from "invenio_app_rdm/records/macros/creatibutors.html" import
+    affiliations_accordion,
+    creatibutors_landing_modal,
+    creatibutors_show_all_link,
+    contributors_grouped,
+    show_creatibutors -%}
 
 <div class="ui grid">
+
   {% if record_ui["ui"]["creators"] and record_ui["ui"]["creators"]["creators"] %}
-    <div class="row ui accordion affiliations">
+    {%- set all_creators = record_ui["ui"]["creators"]["creators"] -%}
+    {%- set creator_count = all_creators | length -%}
+    {%- set use_controls = creator_count > config.RDM_CREATIBUTORS_INLINE_LIST_THRESHOLD -%}
+
+    <div id="creators-section" class="row ui accordion affiliations">
       <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
-          <h3 class="sr-only">{{ _('Authors/Creators') }}</h3>
-          <ul class="creatibutors">
-            {{ show_creatibutors(record_ui["ui"]["creators"]["creators"], show_affiliations=True, show_role=True) }}
-          </ul>
+        <h3 class="sr-only">{{ _('Authors/Creators') }}</h3>
+        <ul class="creatibutors">
+          {{ show_creatibutors(
+               all_creators[:config.RDM_CREATIBUTORS_INLINE_LIST_THRESHOLD] if use_controls else all_creators,
+               show_affiliations=True, show_role=True) }}
+          {%- if use_controls %}
+          <li class="creatibutor-et-al">
+            <em>{{ _('et al.') }}</em>
+            {{ creatibutors_show_all_link('creators', creator_count, _('authors')) }}
+          </li>
+          {%- endif %}
+        </ul>
       </div>
 
-        {# Todo: get full list of all affiliations (both creators & contributors) e.g.
-        record_ui["ui"]["affiliation"] and merge to one accordion #}
-        {% if record_ui["ui"]["creators"] and record_ui["ui"]["creators"]["affiliations"] %}
-          {{ affiliations_accordion('creators', record_ui["ui"]["creators"]["affiliations"])}}
-        {% endif %}
-
+      {% if not use_controls and record_ui["ui"]["creators"]["affiliations"] %}
+        {{ affiliations_accordion('creators', record_ui["ui"]["creators"]["affiliations"]) }}
+      {% endif %}
     </div>
+
+    {%- if use_controls %}
+    {% call creatibutors_landing_modal('creators', creator_count, _('authors'),
+                                       _('Authors/Creators'),
+                                       record_ui["ui"]["creators"].get("affiliations")) %}
+      <ul class="creatibutors">
+        {{ show_creatibutors(all_creators, show_affiliations=True, show_role=True) }}
+      </ul>
+    {% endcall %}
+    {%- endif %}
   {% endif %}
 
   {% if record_ui["ui"]["contributors"] and record_ui["ui"]["contributors"]["contributors"] %}
-    <div class="row ui accordion affiliations">
+    {%- set all_contributors = record_ui["ui"]["contributors"]["contributors"] -%}
+    {%- set contributor_count = all_contributors | length -%}
+    {%- set use_controls = contributor_count > config.RDM_CREATIBUTORS_INLINE_LIST_THRESHOLD -%}
+
+    <div id="contributors-section" class="row ui accordion affiliations">
       <div class="sixteen wide mobile twelve wide tablet thirteen wide computer column">
-          <h3>{{ _('Contributors') }}</h3>
-          {%- for group in record_ui["ui"]["contributors"]["contributors"]|groupby('role.title')%}
-          <div>
-            <h3 class="creatibutors-header ui small header">{{group.grouper}}{% if group.list|length > 1 %} ({{group.list|length}}){% endif %}:</h3>
-            <ul class="creatibutors">
-              {{ show_creatibutors(group.list, show_affiliations=True, type="contributors") }}
-            </ul>
-          </div>
-          {%- endfor %}
+        <h3>{{ _('Contributors') }}</h3>
+
+        {{ contributors_grouped(
+             all_contributors[:config.RDM_CREATIBUTORS_INLINE_LIST_THRESHOLD] if use_controls else all_contributors,
+             count_source=all_contributors if use_controls else none) }}
+
+        {%- if use_controls %}
+        <p class="creatibutor-et-al">
+          <em>{{ _('et al.') }}</em>
+          {{ creatibutors_show_all_link('contributors', contributor_count, _('contributors')) }}
+        </p>
+        {%- endif %}
       </div>
 
-      {% if record_ui["ui"]["contributors"] and record_ui["ui"]["contributors"]["affiliations"] %}
-        {{ affiliations_accordion('contributors', record_ui["ui"]["contributors"]["affiliations"])}}
+      {% if not use_controls and record_ui["ui"]["contributors"]["affiliations"] %}
+        {{ affiliations_accordion('contributors', record_ui["ui"]["contributors"]["affiliations"]) }}
       {% endif %}
-
     </div>
+
+    {%- if use_controls %}
+    {% call creatibutors_landing_modal('contributors', contributor_count, _('contributors'),
+                                       _('Contributors'),
+                                       record_ui["ui"]["contributors"].get("affiliations")) %}
+      {{ contributors_grouped(all_contributors) }}
+    {% endcall %}
+    {%- endif %}
   {% endif %}
+
 </div>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
@@ -146,7 +146,7 @@
     </div>
     <div class="creatibutors-count-bar mt-5">
       <span class="creatibutors-filter-count text-muted" data-total="{{ count }}">
-        {{ count }} {{ _('total') }}
+        {{ count }} / {{ count }}
       </span>
     </div>
   </div>
@@ -156,7 +156,7 @@
       {{ caller() }}
     </div>
     {%- if affiliations %}
-    <section class="creatibutors-panel-affiliations"
+    <section class="creatibutors-panel-affiliations mt-1"
              aria-label="{{ _('Affiliations for') }} {{ section_id }}">
       {{ affiliations_list(affiliations) }}
     </section>

--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/creatibutors.html
@@ -1,5 +1,5 @@
 {#
-  SPDX-FileCopyrightText: 2020-2024 CERN.
+  SPDX-FileCopyrightText: 2020-2026 CERN.
   SPDX-FileCopyrightText: 2020 Northwestern University.
   SPDX-FileCopyrightText: 2021 Graz University of Technology.
   SPDX-FileCopyrightText: 2021-2022 New York University.
@@ -36,17 +36,20 @@
 {% endmacro %}
 
 
-
 {% macro show_creatibutors(creatibutors, show_affiliations=False, type="creators", show_role=False) %}
   {% for creatibutor in creatibutors if creatibutor.person_or_org and creatibutor.person_or_org.name %}
-  <li class="creatibutor-wrap separated">
+  <li class="creatibutor-wrap separated"
+      {%- if show_affiliations and creatibutor.affiliations %}
+      data-affiliation-refs="{{ creatibutor.affiliations|map(attribute=0)|join(',') }}"
+      data-affiliations="{{ creatibutor.affiliations|join('; ', attribute='1') }}"
+      {%- endif %}>
     <a class="ui creatibutor-link"
       {% if show_affiliations and creatibutor.affiliations %}
         data-tooltip="{{ creatibutor.affiliations|join('; ', attribute='1') }}"
+        data-position="bottom center"
       {% endif %}
       href="{{url_for('invenio_search_ui.search', q='metadata.' + type + '.person_or_org.name:"' + creatibutor.person_or_org.name + '"')}}"
     >
-
       <span class="creatibutor-name">
         {{- creatibutor.person_or_org.name -}}
         {% if show_role and creatibutor.role %}
@@ -67,22 +70,36 @@
 {%- endmacro %}
 
 
-{% macro affiliations_accordion(group, affiliations) %}
-<div class="ui sixteen wide tablet three wide computer column title right aligned bottom aligned">
-  <button class="ui affiliations-button trigger button mini mr-0"
-          aria-controls="{{ group }}-affiliations"
-          data-open-text="{{_('Show affiliations')}}"
-          data-close-text="{{ _('Hide affiliations') }}"
-          aria-expanded="false"
-  >
-    {{ _("Show affiliations") }}
-  </button>
-</div>
+{% macro creatibutors_show_all_link(section_id, count, entity_label) %}
+  <a href="#"
+     class="creatibutors-show-all-link"
+     data-target="#{{ section_id }}-all-modal"
+     aria-haspopup="dialog">
+    {{ _('Show all') }} {{ count }} {{ entity_label }}
+  </a>
+{% endmacro %}
 
-<section class="ui sixteen wide column content" id="{{ group }}-affiliations" aria-label="{{ _('Affiliations for') }} {{ group }}">
+
+{% macro contributors_grouped(contributors, count_source=None) %}
+  {%- for group in contributors|groupby('role.title') %}
+  {%- set role_count = (count_source|selectattr('role.title', 'equalto', group.grouper)|list)|length
+                       if count_source else group.list|length %}
+  <div>
+    <h3 class="creatibutors-header ui small header">
+      {{ group.grouper }}{% if role_count > 1 %} ({{ role_count }}){% endif %}:
+    </h3>
+    <ul class="creatibutors">
+      {{ show_creatibutors(group.list, show_affiliations=True, type="contributors") }}
+    </ul>
+  </div>
+  {%- endfor %}
+{%- endmacro %}
+
+
+{% macro affiliations_list(affiliations) %}
   <ul>
     {% for affiliation in affiliations %}
-    <li>
+    <li data-affiliation-ref="{{ affiliation[0] }}">
       {{ affiliation[0] }}.
 
       {% if affiliation[2] %}
@@ -105,8 +122,68 @@
 
       {{ affiliation[1] }}
     </li>
-  {% endfor %}
+    {% endfor %}
+  </ul>
+{% endmacro %}
 
-    </ul>
+
+{% macro creatibutors_landing_modal(section_id, count, entity_label, modal_title, affiliations=None) %}
+<div class="ui modal creatibutors-landing-modal"
+     id="{{ section_id }}-all-modal"
+     data-section="{{ section_id }}">
+  <i class="close icon"></i>
+  <div class="header">{{ modal_title }}</div>
+
+  <div class="content creatibutors-modal-search">
+    <div class="ui fluid icon input">
+      <input type="search"
+             class="creatibutors-filter-input"
+             data-panel="{{ section_id }}-modal-list"
+             placeholder="{{ _('Search by name or affiliation…') }}"
+             aria-label="{{ _('Filter') }} {{ entity_label }}"
+             autocomplete="off" />
+      <i class="search icon" aria-hidden="true"></i>
+    </div>
+    <div class="creatibutors-count-bar mt-5">
+      <span class="creatibutors-filter-count text-muted" data-total="{{ count }}">
+        {{ count }} {{ _('total') }}
+      </span>
+    </div>
+  </div>
+
+  <div class="scrolling content">
+    <div id="{{ section_id }}-modal-list" class="creatibutors-modal-list">
+      {{ caller() }}
+    </div>
+    {%- if affiliations %}
+    <section class="creatibutors-panel-affiliations"
+             aria-label="{{ _('Affiliations for') }} {{ section_id }}">
+      {{ affiliations_list(affiliations) }}
+    </section>
+    {%- endif %}
+  </div>
+
+  <div class="actions">
+    <button type="button" class="ui button">{{ _('Close') }}</button>
+  </div>
+</div>
+{% endmacro %}
+
+
+{% macro affiliations_accordion(group, affiliations) %}
+<div id="{{ group }}-affiliations-title"
+     class="ui sixteen wide tablet three wide computer column title right aligned bottom aligned">
+  <button class="ui affiliations-button trigger button mini mr-0"
+          aria-controls="{{ group }}-affiliations"
+          data-open-text="{{_('Show affiliations')}}"
+          data-close-text="{{ _('Hide affiliations') }}"
+          aria-expanded="false"
+  >
+    {{ _("Show affiliations") }}
+  </button>
+</div>
+
+<section class="ui sixteen wide column content" id="{{ group }}-affiliations" aria-label="{{ _('Affiliations for') }} {{ group }}">
+  {{ affiliations_list(affiliations) }}
 </section>
 {% endmacro %}

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -405,8 +405,6 @@ def get_form_config(**kwargs):
         autocomplete_names=conf.get(
             "APP_RDM_DEPOSIT_FORM_AUTOCOMPLETE_NAMES", "search"
         ),
-        creatibutors_inline_list_threshold=conf["RDM_CREATIBUTORS_INLINE_LIST_THRESHOLD"],
-        creatibutors_render_batch_size=conf["RDM_CREATIBUTORS_RENDER_BATCH_SIZE"],
         current_locale=str(current_i18n.locale),
         default_locale=conf.get("BABEL_DEFAULT_LOCALE", "en"),
         pids=get_form_pids_config(record=record),

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -405,6 +405,8 @@ def get_form_config(**kwargs):
         autocomplete_names=conf.get(
             "APP_RDM_DEPOSIT_FORM_AUTOCOMPLETE_NAMES", "search"
         ),
+        creatibutors_inline_list_threshold=conf["RDM_CREATIBUTORS_INLINE_LIST_THRESHOLD"],
+        creatibutors_render_batch_size=conf["RDM_CREATIBUTORS_RENDER_BATCH_SIZE"],
         current_locale=str(current_i18n.locale),
         default_locale=conf.get("BABEL_DEFAULT_LOCALE", "en"),
         pids=get_form_pids_config(record=record),

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 CERN.
+ * SPDX-FileCopyrightText: 2020-2026 CERN.
  * SPDX-FileCopyrightText: 2020-2022 Northwestern University.
  * SPDX-FileCopyrightText: 2021-2022 Graz University of Technology.
  * SPDX-FileCopyrightText: 2022-2024 KTH Royal Institute of Technology.
@@ -351,6 +351,8 @@ export class RDMDepositForm extends Component {
                         roleOptions={this.vocabularies.metadata.creators.role}
                         schema="creators"
                         autocompleteNames={this.config.autocomplete_names}
+                        scrollThreshold={this.config.creatibutors_inline_list_threshold}
+                        batchSize={this.config.creatibutors_render_batch_size}
                         required
                       />
                     </Overridable>
@@ -451,6 +453,8 @@ export class RDMDepositForm extends Component {
                         roleOptions={this.vocabularies.metadata.contributors.role}
                         schema="contributors"
                         autocompleteNames={this.config.autocomplete_names}
+                        scrollThreshold={this.config.creatibutors_inline_list_threshold}
+                        batchSize={this.config.creatibutors_render_batch_size}
                         modal={{
                           addLabel: i18next.t("Add contributor"),
                           editLabel: i18next.t("Edit contributor"),

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -351,8 +351,6 @@ export class RDMDepositForm extends Component {
                         roleOptions={this.vocabularies.metadata.creators.role}
                         schema="creators"
                         autocompleteNames={this.config.autocomplete_names}
-                        scrollThreshold={this.config.creatibutors_inline_list_threshold}
-                        batchSize={this.config.creatibutors_render_batch_size}
                         required
                       />
                     </Overridable>
@@ -453,8 +451,6 @@ export class RDMDepositForm extends Component {
                         roleOptions={this.vocabularies.metadata.contributors.role}
                         schema="contributors"
                         autocompleteNames={this.config.autocomplete_names}
-                        scrollThreshold={this.config.creatibutors_inline_list_threshold}
-                        batchSize={this.config.creatibutors_render_batch_size}
                         modal={{
                           addLabel: i18next.t("Add contributor"),
                           editLabel: i18next.t("Edit contributor"),

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
@@ -8,24 +8,37 @@
 
 import $ from "jquery";
 
+// Normalise a string for diacritic insensitive search: decompose into base chars +
+// combining marks, strip the marks, then lower-case while still matching the literal character.
+const normalizeSearch = (str) =>
+  str
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+// Checks if the current creatibutor entry matches the search query.
 function creatibutorMatchesQuery($wrap, query) {
   if (!query) return true;
-  const text = $wrap.text().toLowerCase();
-  const affiliations = (
+  const q = normalizeSearch(query);
+  const text = normalizeSearch($wrap.text());
+  const affiliations = normalizeSearch(
     $wrap.attr("data-affiliations") ||
-    $wrap.find("[data-tooltip]").attr("data-tooltip") ||
-    ""
-  ).toLowerCase();
-  return text.includes(query) || affiliations.includes(query);
+      $wrap.find("[data-tooltip]").attr("data-tooltip") ||
+      ""
+  );
+  return text.includes(q) || affiliations.includes(q);
 }
 
+// Filters the creatibutors panel (modal) according to the current input value.
 function filterCreatibutorsPanel($input) {
-  const query = $input.val().toLowerCase().trim();
+  const query = $input.val().trim();
   const $modal = $input.closest(".creatibutors-landing-modal");
   const $panel = $(`#${$input.data("panel")}`);
+
   let shown = 0;
   const visibleAffiliationRefs = new Set();
 
+  // Walk over all creatibutors and hide those that don't match
   $panel.find(".creatibutor-wrap").each(function () {
     const $wrap = $(this);
     const matches = creatibutorMatchesQuery($wrap, query);
@@ -33,12 +46,10 @@ function filterCreatibutorsPanel($input) {
     if (!matches) return;
 
     shown += 1;
-    ($wrap.attr("data-affiliation-refs") || "")
-      .split(",")
-      .forEach((ref) => {
-        const marker = ref.trim();
-        if (marker) visibleAffiliationRefs.add(marker);
-      });
+    ($wrap.attr("data-affiliation-refs") || "").split(",").forEach((ref) => {
+      const marker = ref.trim();
+      if (marker) visibleAffiliationRefs.add(marker);
+    });
   });
 
   $panel.children("div").each(function () {
@@ -47,7 +58,10 @@ function filterCreatibutorsPanel($input) {
     $group.toggleClass("hidden", !hasVisible);
   });
 
-  const $count = $input.closest(".creatibutors-modal-search").find(".creatibutors-filter-count");
+  // Update the visible/total count
+  const $count = $input
+    .closest(".creatibutors-modal-search")
+    .find(".creatibutors-filter-count");
   if ($count.length) {
     const total = parseInt($count.data("total"), 10);
     $count.text(`${query ? shown : total} / ${total}`);
@@ -56,6 +70,7 @@ function filterCreatibutorsPanel($input) {
   const $affiliationsPanel = $modal.find(".creatibutors-panel-affiliations");
   if (!$affiliationsPanel.length) return;
 
+  // Hide/show affiliations based on what matches the current filtered list
   let visibleAffiliations = 0;
   $affiliationsPanel.find("li[data-affiliation-ref]").each(function () {
     const ref = $(this).attr("data-affiliation-ref");
@@ -66,6 +81,7 @@ function filterCreatibutorsPanel($input) {
   $affiliationsPanel.toggleClass("hidden", visibleAffiliations === 0);
 }
 
+// Every time the user types in the filter box, refilter the panel
 $(document).on("input", ".creatibutors-filter-input", function () {
   filterCreatibutorsPanel($(this));
 });

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
@@ -8,6 +8,80 @@
 
 import $ from "jquery";
 
+function creatibutorMatchesQuery($wrap, query) {
+  if (!query) return true;
+  const text = $wrap.text().toLowerCase();
+  const affiliations = (
+    $wrap.attr("data-affiliations") ||
+    $wrap.find("[data-tooltip]").attr("data-tooltip") ||
+    ""
+  ).toLowerCase();
+  return text.includes(query) || affiliations.includes(query);
+}
+
+function filterCreatibutorsPanel($input) {
+  const query = $input.val().toLowerCase().trim();
+  const $modal = $input.closest(".creatibutors-landing-modal");
+  const $panel = $(`#${$input.data("panel")}`);
+  let shown = 0;
+  const visibleAffiliationRefs = new Set();
+
+  $panel.find(".creatibutor-wrap").each(function () {
+    const $wrap = $(this);
+    const matches = creatibutorMatchesQuery($wrap, query);
+    $wrap.toggleClass("hidden", !matches);
+    if (!matches) return;
+
+    shown += 1;
+    ($wrap.attr("data-affiliation-refs") || "")
+      .split(",")
+      .forEach((ref) => {
+        const marker = ref.trim();
+        if (marker) visibleAffiliationRefs.add(marker);
+      });
+  });
+
+  $panel.children("div").each(function () {
+    const $group = $(this);
+    const hasVisible = $group.find(".creatibutor-wrap:not(.hidden)").length > 0;
+    $group.toggleClass("hidden", !hasVisible);
+  });
+
+  const $count = $input.closest(".creatibutors-modal-search").find(".creatibutors-filter-count");
+  if ($count.length) {
+    const total = parseInt($count.data("total"), 10);
+    $count.text(`${query ? shown : total} / ${total}`);
+  }
+
+  const $affiliationsPanel = $modal.find(".creatibutors-panel-affiliations");
+  if (!$affiliationsPanel.length) return;
+
+  let visibleAffiliations = 0;
+  $affiliationsPanel.find("li[data-affiliation-ref]").each(function () {
+    const ref = $(this).attr("data-affiliation-ref");
+    const show = visibleAffiliationRefs.has(ref);
+    $(this).toggleClass("hidden", !show);
+    if (show) visibleAffiliations += 1;
+  });
+  $affiliationsPanel.toggleClass("hidden", visibleAffiliations === 0);
+}
+
+$(document).on("input", ".creatibutors-filter-input", function () {
+  filterCreatibutorsPanel($(this));
+});
+
+$(".creatibutors-landing-modal").modal({
+  closable: true,
+  onHidden() {
+    $(this).find(".creatibutors-filter-input").val("").trigger("input");
+  },
+});
+
+$(document).on("click", ".creatibutors-show-all-link", function (e) {
+  e.preventDefault();
+  $($(this).data("target")).modal("show");
+});
+
 $("#record-doi-badge").on("click", function () {
   $("#doi-modal").modal("show");
 });

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
@@ -49,4 +49,46 @@ h3.ui.small.header.creatibutors-header + ul.creatibutors {
       margin: 0 .1rem 0 .2rem;
     }
   }
+
+}
+
+.creatibutor-et-al {
+  color: @mutedTextColor;
+
+  .creatibutors-show-all-link {
+    margin-left: 0.35rem;
+  }
+}
+
+.creatibutors-landing-modal {
+  .creatibutors-modal-search {
+    border-bottom: 1px solid lighten(@borderColor, 40%);
+    padding-bottom: 0.75rem;
+  }
+
+  .creatibutors li.hidden,
+  .creatibutors-modal-list > div.hidden {
+    display: none;
+  }
+}
+
+.creatibutors-panel-affiliations {
+  margin-top: 1rem;
+
+  &.hidden {
+    display: none;
+  }
+
+  li.hidden {
+    display: none;
+  }
+
+  ul {
+    list-style-type: none;
+    background-color: lighten(@borderColor, 72%);
+    color: @textMutedColorDarken;
+    font-size: @font-size-small;
+    padding: 1rem 1.5rem;
+    margin: 0;
+  }
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/landing_page/creatibutors.less
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+// Landing page CSS
+
 h3.ui.small.header.creatibutors-header {
   display: inline-block;
   color: @mutedTextColor;
@@ -30,10 +32,6 @@ h3.ui.small.header.creatibutors-header + ul.creatibutors {
   li {
     display: inline-block;
     margin: 0 0.25rem 0 0;
-
-    &.hidden {
-      display: none;
-    }
   }
 
   .creatibutor-wrap {
@@ -63,26 +61,10 @@ h3.ui.small.header.creatibutors-header + ul.creatibutors {
 .creatibutors-landing-modal {
   .creatibutors-modal-search {
     border-bottom: 1px solid lighten(@borderColor, 40%);
-    padding-bottom: 0.75rem;
-  }
-
-  .creatibutors li.hidden,
-  .creatibutors-modal-list > div.hidden {
-    display: none;
   }
 }
 
 .creatibutors-panel-affiliations {
-  margin-top: 1rem;
-
-  &.hidden {
-    display: none;
-  }
-
-  li.hidden {
-    display: none;
-  }
-
   ul {
     list-style-type: none;
     background-color: lighten(@borderColor, 72%);
@@ -91,4 +73,106 @@ h3.ui.small.header.creatibutors-header + ul.creatibutors {
     padding: 1rem 1.5rem;
     margin: 0;
   }
+}
+
+// Deposit form CSS
+
+@keyframes creatibutor-highlight-fade {
+  0%, 70% { background-color: fade(@focusedFormBorderColor, 12%); }
+  100%     { background-color: transparent; }
+}
+
+.creatibutors-filter-input {
+  width: 50% !important;
+}
+
+.creatibutors-count-bar {
+  display: flex;
+  align-items: center;
+  font-size: 0.9em;
+  color: @mutedTextColor;
+}
+
+.creatibutors-action-bar {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.creatibutors-scroll-wrapper {
+  position: relative;
+
+  .creatibutors-scroll-container {
+    &.scrollable {
+      overflow-y: auto;
+      max-height: 30vh;
+
+      // Keep first and last items clear of the fade overlays.
+      .deposit-drag-listitem:first-child { padding-top: 2.25rem; }
+      .deposit-drag-listitem:last-child  { padding-bottom: 2.25rem; }
+    }
+  }
+
+  // Fades are hidden by default; .can-scroll-up / .can-scroll-down are toggled
+  // on this wrapper by a lightweight scroll listener — no React state, no re-renders.
+  .creatibutors-scroll-fade {
+    display: none;
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 2.25rem;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    z-index: 1;
+
+    &.start {
+      top: 0;
+      background: linear-gradient(to bottom, @pageBackground 30%, transparent 100%);
+    }
+
+    &.end {
+      bottom: 0;
+      background: linear-gradient(to top, @pageBackground 30%, transparent 100%);
+    }
+  }
+
+  &.can-scroll-up   .creatibutors-scroll-fade.start { display: flex; }
+  &.can-scroll-down .creatibutors-scroll-fade.end   { display: flex; }
+
+  .creatibutors-scroll-btn.ui.button {
+    pointer-events: auto;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    color: @mutedTextColor !important;
+
+    &:hover,
+    &:focus {
+      background: @subtleTransparentBlack !important;
+      color: @textColor !important;
+    }
+  }
+}
+
+.file-import-dropzone {
+  cursor: pointer;
+
+  &--loading {
+    cursor: not-allowed;
+  }
+}
+
+.creatibutors-import-example {
+  display: block;
+  text-align: left;
+  max-height: 12rem;
+  overflow: auto;
+  font-size: 0.8em;
+  margin: 0.5rem 0 0;
+  padding: 0.75rem;
+  background: lighten(@borderColor, 72%);
+  border-radius: 4px;
+  white-space: pre;
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/list.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/list.overrides
@@ -4,28 +4,17 @@
 
 /* Deposit license field */
 
-@keyframes creatibutor-highlight-fade {
-  0%,
-  70% {
-    background-color: rgba(33, 133, 208, 0.12);
-  }
-
-  100% {
-    background-color: transparent;
-  }
-}
-
 .item.deposit-drag-listitem {
   padding: 0.3rem 0.3rem 0.15rem 0.3rem !important;
   border-radius: 0.3rem;
   transition: background-color 0.5s ease, box-shadow 0.5s ease;
 
-  &.hidden {
+  &.drag-ghost {
     opacity: 0;
   }
 
-  &:hover:not(highlighted) {
-    background-color: rgba(0, 0, 0, 0.04);
+  &:hover:not(.highlighted) {
+    background-color: @transparentBlack;
   }
 
   &.highlighted {
@@ -35,89 +24,6 @@
   .drag-anchor {
     cursor: move;
   }
-}
-
-.creatibutors-filter-input {
-  width: 50% !important;
-}
-
-.creatibutors-count-bar {
-  display: flex;
-  align-items: center;
-  font-size: 0.9em;
-  color: rgba(0, 0, 0, 0.55);
-}
-
-.creatibutors-action-bar {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-.creatibutors-scroll-wrapper {
-  position: relative;
-
-  .creatibutors-scroll-container {
-    &.scrollable {
-      overflow-y: auto;
-      max-height: 30vh;
-
-      .deposit-drag-listitem {
-        scroll-margin-top: 2.25rem;
-        scroll-margin-bottom: 2.25rem;
-      }
-    }
-  }
-
-  .creatibutors-scroll-fade {
-    position: absolute;
-    left: 0;
-    right: 0;
-    height: 2.25rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    pointer-events: none;
-    z-index: 1;
-
-    &.start {
-      top: 0;
-      background: linear-gradient(to bottom, @pageBackground 30%, transparent 100%);
-    }
-
-    &.end {
-      bottom: 0;
-      background: linear-gradient(to top, @pageBackground 30%, transparent 100%);
-    }
-  }
-
-  .creatibutors-scroll-btn.ui.button {
-    pointer-events: auto;
-    background: transparent !important;
-    border: none !important;
-    box-shadow: none !important;
-    color: rgba(0, 0, 0, 0.4) !important;
-
-    &:hover,
-    &:focus {
-      background: rgba(0, 0, 0, 0.06) !important;
-      color: rgba(0, 0, 0, 0.85) !important;
-    }
-  }
-}
-
-.creatibutors-import-example {
-  display: block;
-  text-align: left;
-  max-height: 12rem;
-  overflow: auto;
-  font-size: 0.8em;
-  margin: 0.5rem 0 0;
-  padding: 0.75rem;
-  background: lighten(@borderColor, 72%);
-  border-radius: 4px;
-  white-space: pre;
 }
 
 .ui.list .disabled {

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/list.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/elements/list.overrides
@@ -4,11 +4,32 @@
 
 /* Deposit license field */
 
+@keyframes creatibutor-highlight-fade {
+  0%,
+  70% {
+    background-color: rgba(33, 133, 208, 0.12);
+  }
+
+  100% {
+    background-color: transparent;
+  }
+}
+
 .item.deposit-drag-listitem {
-  margin-bottom: 5px;
+  padding: 0.3rem 0.3rem 0.15rem 0.3rem !important;
+  border-radius: 0.3rem;
+  transition: background-color 0.5s ease, box-shadow 0.5s ease;
 
   &.hidden {
     opacity: 0;
+  }
+
+  &:hover:not(highlighted) {
+    background-color: rgba(0, 0, 0, 0.04);
+  }
+
+  &.highlighted {
+    animation: creatibutor-highlight-fade 2s ease forwards;
   }
 
   .drag-anchor {
@@ -16,6 +37,88 @@
   }
 }
 
+.creatibutors-filter-input {
+  width: 50% !important;
+}
+
+.creatibutors-count-bar {
+  display: flex;
+  align-items: center;
+  font-size: 0.9em;
+  color: rgba(0, 0, 0, 0.55);
+}
+
+.creatibutors-action-bar {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.creatibutors-scroll-wrapper {
+  position: relative;
+
+  .creatibutors-scroll-container {
+    &.scrollable {
+      overflow-y: auto;
+      max-height: 30vh;
+
+      .deposit-drag-listitem {
+        scroll-margin-top: 2.25rem;
+        scroll-margin-bottom: 2.25rem;
+      }
+    }
+  }
+
+  .creatibutors-scroll-fade {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 2.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    z-index: 1;
+
+    &.start {
+      top: 0;
+      background: linear-gradient(to bottom, @pageBackground 30%, transparent 100%);
+    }
+
+    &.end {
+      bottom: 0;
+      background: linear-gradient(to top, @pageBackground 30%, transparent 100%);
+    }
+  }
+
+  .creatibutors-scroll-btn.ui.button {
+    pointer-events: auto;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    color: rgba(0, 0, 0, 0.4) !important;
+
+    &:hover,
+    &:focus {
+      background: rgba(0, 0, 0, 0.06) !important;
+      color: rgba(0, 0, 0, 0.85) !important;
+    }
+  }
+}
+
+.creatibutors-import-example {
+  display: block;
+  text-align: left;
+  max-height: 12rem;
+  overflow: auto;
+  font-size: 0.8em;
+  margin: 0.5rem 0 0;
+  padding: 0.75rem;
+  background: lighten(@borderColor, 72%);
+  border-radius: 4px;
+  white-space: pre;
+}
 
 .ui.list .disabled {
   opacity: 0.5;

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -50,6 +50,11 @@ body {
   }
 }
 
+// Generic display-toggle utility used by jQuery toggleClass("hidden", ...) everywhere
+.hidden {
+  display: none !important;
+}
+
 button:focus-visible, a:focus-visible {
   outline: 3px solid @focusedFormBorderColor !important;
 }

--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/modal.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/modules/modal.overrides
@@ -125,6 +125,12 @@
       background: transparent;
       padding: 0;
     }
+
+    .ui.list .content {
+      background: transparent;
+      width: auto;
+      padding: 0;
+    }
   }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
   "invenio-collections>=10.0.0,<11.0.0",
   "invenio-communities>=29.0.0,<30.0.0",
   "invenio-pages>=10.0.0,<11.0.0",
-  "invenio-rdm-records>=33.0.0,<34.0.0",
+  "invenio-rdm-records>=34.0.0,<35.0.0",
   "invenio-sitemap>=0.1.0,<2.0.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Closes: #3006 
Requires: https://github.com/inveniosoftware/invenio-rdm-records/pull/2359

  * On the record landing page, long author/contributor lists show "et al." with a searchable modal instead of rendering every name inline.
  * Pass creatibutors_inline_list_threshold and creatibutors_render_batch_size from deposits.py into the deposit form

<img width="1373" height="669" alt="Screenshot 2026-06-10 at 16 10 26" src="https://github.com/user-attachments/assets/aa194acc-1e9c-4264-ae07-add8aec2c80c" />
