### PR TITLE
feat(requests): show record version on community submission request

### DIFF
--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/community-submission/index.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/community-submission/index.html
@@ -33,6 +33,7 @@
   {{ inclusion_request_header(
       request=invenio_request,
       record=record,
+      record_ui=record_ui,
       accepted=request_is_accepted,
       back_button_url=back_button_url,
       back_button_text=_("Back to requests")

--- a/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/macros/request_header.html
+++ b/invenio_app_rdm/requests_ui/templates/semantic-ui/invenio_requests/macros/request_header.html
@@ -54,12 +54,13 @@
 {% endmacro %}
 
 
-{% macro inclusion_request_header(back_button_url=None, back_button_text=None, request=None, record=None, accepted=False) %}
+{% macro inclusion_request_header(back_button_url=None, back_button_text=None, request=None, record=None, record_ui=None, accepted=False) %}
 {#
   Renders the record inclusion request header block with:
   - a back button
   - a `View record` button, when accepted
   - the request's title
+  - the record's version, when record_ui is passed
   - the record's creators, when record is passed
 #}
   <div class="computer-flex-header rel-mt-2">
@@ -88,6 +89,9 @@
 
   <div class="rel-mt-2">
     <h2 class="ui header request-header">{{ request.title }}</h2>
+    {% if record_ui and record_ui.get("ui", {}).get("version") %}
+      <p class="label text-muted">{{ _('Version {version_number}').format(version_number=record_ui["ui"]["version"]) }}</p>
+    {% endif %}
     <p class="ui header">{{ request.description|safe }}</p>
     {% if record %}
       <ul class="creatibutors" aria-label="{{ _('Creators') }}">


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes inveniosoftware/invenio-rdm-records#2358

Display the record version under the request title on community submission pages, using record_ui already provided by the view. 

<img width="1023" height="277" alt="image" src="https://github.com/user-attachments/assets/1beba966-c7b7-4829-8e47-f0a012779938" />



UPDATE: Moved the version to the sidebar, new prs: https://github.com/inveniosoftware/invenio-requests/pull/613. 
https://github.com/inveniosoftware/invenio-rdm-records/pull/2365
### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
