### PR TITLE
fix: licenses - using url directly as image source if it exists

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/licenses.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/licenses.html
@@ -37,9 +37,13 @@
                    aria-label="{{ license.title_l10n }}"
               >
                 {% if license.icon %}
-                  {% set iconFile = 'icons/licenses/{}.svg'.format(license.icon) %}
+                  {% if license.icon.lower().startswith(('http://', 'https://')) %}
+                    {% set iconSrc = license.icon %}
+                  {% else %}
+                    {% set iconSrc = url_for('static', filename='icons/licenses/{}.svg'.format(license.icon)) %}
+                  {% endif %}
                   <span class="icon-wrap">
-                  <img class="icon" src="{{ url_for('static', filename=iconFile) }}"
+                  <img class="icon" src="{{ iconSrc }}"
                        alt="{{ license.id }} icon"/>
                 </span>
                 {% endif %}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The license information in the sidebar, expects that you have specific images for each license in your static folder. It is very brittle and requires fiddling with static folder whenever your vocabulary changes. This fix addresses the issue, whereby, it uses the URL directly (if right.icon is url) uses it as the source, otherwise falls back to old behavior.

Please let us know if you would merge this. We would like to backport it to 14 too and are willing to do the work, just let us know if this is something you are interested in.

Thank you,

Dusan S
