### PR TITLE
fix: display preview error for ZIP files

### DIFF
--- a/invenio_app_rdm/records_ui/previewer/previewable_zip.py
+++ b/invenio_app_rdm/records_ui/previewer/previewable_zip.py
@@ -120,9 +120,17 @@ def can_preview(file):
 
 def preview(file):
     """Return the appropriate template and pass the file and an embed flag."""
-    tree_raw = current_rdm_records_service.files.list_container(
-        system_identity, file.record["id"], file.filename
-    ).to_dict()
+    error = None
+    try:
+        tree_raw = current_rdm_records_service.files.list_container(
+            system_identity, file.record["id"], file.filename
+        ).to_dict()
+    except Exception as e:
+        error = e
+        tree_raw = {
+            "entries": [],
+            "directories": [],
+        }
 
     converted_tree = convert_zip_list_container(
         tree_raw["entries"], tree_raw["directories"], file.record["id"], file.filename
@@ -133,7 +141,7 @@ def preview(file):
         file=file,
         tree=tree_list,
         limit_reached=False,
-        error=None,
+        error=error,
         js_bundles=current_previewer.js_bundles + ["previewable-zip.js"],
         css_bundles=current_previewer.css_bundles + ["zip_css.css"],
     )


### PR DESCRIPTION
### Description

When previewing a ZIP file, an exception may be raised, for example when the maximum uncompressed size is exceeded. As a result, the preview window does not render the file preview and displays the landing page for its record instead.

This PR fixes the problem by catching the exception and displaying its error message inside the preview window. This allows the user to see the actual reason why the ZIP file preview cannot be displayed.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
