### PR TITLE
fix(admin): show clear error in View Changes modal on 403

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/auditLogs/ViewRecentChanges.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/administration/auditLogs/ViewRecentChanges.js
@@ -81,7 +81,13 @@ export class ViewRecentChanges extends Component {
       });
     } catch (error) {
       if (error === "UNMOUNTED") return;
-      this.setState({ error: error, loading: false });
+      this.setState({
+        error:
+          error.response?.data?.message ||
+          error.message ||
+          i18next.t("Unable to fetch revisions."),
+        loading: false,
+      });
       console.error(error);
     }
   }
@@ -107,9 +113,11 @@ export class ViewRecentChanges extends Component {
             />
           </Modal.Content>
         )}
-        <Modal.Content scrolling>
-          <RevisionsDiffViewer diff={diff} />
-        </Modal.Content>
+        {!error && (
+          <Modal.Content scrolling>
+            <RevisionsDiffViewer diff={diff} />
+          </Modal.Content>
+        )}
         <Modal.Actions>
           <Grid>
             <Grid.Column floated="left" width={8} textAlign="left">


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes https://github.com/CERNDocumentServer/cds-rdm/issues/788

- Show a clear error message in the View Changes modal when the revisions API returns 403, instead of a blank modal

<img width="2089" height="802" alt="image" src="https://github.com/user-attachments/assets/b64ed329-c6dc-4eb2-9871-f7c26f0f2ff8" />





### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
