### PR TITLE
files: improve external file size display

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/macros/files.html
@@ -144,13 +144,15 @@ To access its content, please download it and open it locally.') }}
             </small>
             {%- endif %}
           </td>
-          <td>{%- if is_remote_file %}{{_("N/A (external)")}}{%- else -%}{{ file.size|filesizeformat(binary=binary_sizes) }}{%- endif %}</td>
+	  <td>{{ file.size|filesizeformat(binary=binary_sizes) or _("N/A")}}</td>
           <td class="right aligned">
             <span>
               {% if with_preview and file_type|lower is previewable and not is_remote_file %}
                 <a role="button" class="ui compact mini button preview-link" href="{{ file_url_preview }}" target="preview-iframe" data-file-key="{{file.key}}">
                   <i class="eye icon" aria-hidden="true"></i>{{_("Preview")}}
                 </a>
+	      {%- elif is_remote_file %}
+	      <span class="item"> {{_("(external)")}}</span>
               {% endif %}
               <a role="button" class="ui compact mini button" href="{{ file_url_download }}">
                 <i class="download icon" aria-hidden="true"></i>{{_('Download')}}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Currently file sizes aren't displayed for external files, even though they may be available. The external tag also fits better where the preview button normally is.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
