### PR TITLE
fix: CommunityRecordsSearchBarElement crashing if no headerSearchBar

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/communityRecordsSearch/CommunityRecordsSearchBarElement.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/communityRecordsSearch/CommunityRecordsSearchBarElement.js
@@ -12,7 +12,7 @@ import { CommunityRecordsSingleSearchBarElement } from "./CommunityRecordsSingle
 
 export const CommunityRecordsSearchBarElement = ({ queryString, onInputChange }) => {
   const headerSearchbar = document.getElementById("header-search-bar");
-  const searchbarOptions = headerSearchbar.dataset.options
+  const searchbarOptions = headerSearchbar?.dataset?.options
     ? JSON.parse(headerSearchbar.dataset.options)
     : [];
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.


In communities UI, where CommunityRecordsSearchBarElement is used 

```
 const searchbarOptions = headerSearchbar.dataset.options
    ? JSON.parse(headerSearchbar.dataset.options)
    : [];
    ```
this conditional just crashes the entire app and fallback is never reached. This is for cases where you dont define searchbar in the header. 