### PR TITLE
fix(share): use modal for creating access links, matching people/grou…

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessLinks/AddAccessLinkModal.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessLinks/AddAccessLinkModal.js
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: 2026 CERN.
+ * SPDX-License-Identifier: MIT
+ */
+
+import React, { Component } from "react";
+import { Button, Modal, Table } from "semantic-ui-react";
+import { i18next } from "@translations/invenio_app_rdm/i18next";
+import PropTypes from "prop-types";
+import { CreateAccessLink } from "./CreateAccessLink";
+
+export class AddAccessLinkModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { open: false };
+  }
+
+  handleOpenModal = () => this.setState({ open: true });
+  handleCloseModal = () => this.setState({ open: false });
+
+  handleCreationAndClose = async (permission, expiresAt, description) => {
+    const { handleCreation } = this.props;
+    const success = await handleCreation(permission, expiresAt, description);
+    if (success) {
+      this.handleCloseModal();
+    }
+  };
+
+  render() {
+    const {
+      record,
+      hasLinkExpirationError,
+      loading,
+      dropdownOptions,
+      isAccessLinksExpirationRequired,
+      isComputer,
+    } = this.props;
+    const { open } = this.state;
+    const addButtonText = i18next.t("Create link");
+
+    return (
+      <Modal
+        role="dialog"
+        closeIcon
+        onClose={this.handleCloseModal}
+        onOpen={this.handleOpenModal}
+        closeOnDimmerClick={false}
+        open={open}
+        aria-label={addButtonText}
+        trigger={
+          <Button
+            className={!isComputer ? "mobile only tablet only mb-15" : ""}
+            content={addButtonText}
+            positive
+            size="medium"
+            icon="plus"
+            labelPosition="left"
+            floated={!isComputer ? "right" : undefined}
+          />
+        }
+      >
+        <Modal.Header as="h2">{addButtonText}</Modal.Header>
+        <Modal.Content>
+          <Table>
+            <Table.Body>
+              <CreateAccessLink
+                hasLinkExpirationError={hasLinkExpirationError}
+                handleCreation={this.handleCreationAndClose}
+                loading={loading}
+                record={record}
+                dropdownOptions={dropdownOptions}
+                isAccessLinksExpirationRequired={isAccessLinksExpirationRequired}
+              />
+            </Table.Body>
+          </Table>
+        </Modal.Content>
+      </Modal>
+    );
+  }
+}
+
+AddAccessLinkModal.propTypes = {
+  record: PropTypes.object.isRequired,
+  hasLinkExpirationError: PropTypes.bool.isRequired,
+  handleCreation: PropTypes.func.isRequired,
+  loading: PropTypes.bool.isRequired,
+  dropdownOptions: PropTypes.array.isRequired,
+  isAccessLinksExpirationRequired: PropTypes.bool.isRequired,
+  isComputer: PropTypes.bool.isRequired,
+};

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessLinks/LinksSearchResultContainer.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/ShareOptions/AccessLinks/LinksSearchResultContainer.js
@@ -9,7 +9,7 @@ import { Table, Message, Loader } from "semantic-ui-react";
 import PropTypes from "prop-types";
 import { withCancel } from "react-invenio-forms";
 import { http } from "react-invenio-forms";
-import { CreateAccessLink } from "./CreateAccessLink";
+import { AddAccessLinkModal } from "./AddAccessLinkModal";
 import { LinksSearchItem } from "./LinksSearchItem";
 import { dropdownOptionsGenerator } from "react-invenio-forms";
 import _cloneDeep from "lodash/cloneDeep";
@@ -107,13 +107,15 @@ export class LinksSearchResultContainer extends Component {
       await this.cancellableAction.promise;
       onItemAddedOrDeleted(record.links.access_links, "links");
       this.setState({ loading: false, error: undefined });
+      return true;
     } catch (error) {
-      if (error === "UNMOUNTED") return;
+      if (error === "UNMOUNTED") return false;
       this.setState({
         loading: false,
         error: error,
       });
       console.error(error);
+      return false;
     }
   };
 
@@ -161,6 +163,16 @@ export class LinksSearchResultContainer extends Component {
       <>
         {error && this.errorMessage()}
 
+        <AddAccessLinkModal
+          isComputer={false}
+          hasLinkExpirationError={hasLinkExpirationDateError}
+          handleCreation={this.handleCreation}
+          loading={loading}
+          record={record}
+          dropdownOptions={this.generateDropdownOptions()}
+          isAccessLinksExpirationRequired={isAccessLinksExpirationRequired}
+        />
+
         <Table className="fixed-header">
           <Table.Header>
             <Table.Row>
@@ -176,7 +188,17 @@ export class LinksSearchResultContainer extends Component {
               <Table.HeaderCell data-label="Access" width={3}>
                 {i18next.t("Access")}
               </Table.HeaderCell>
-              <Table.HeaderCell width={4} />
+              <Table.HeaderCell textAlign="center" width={4}>
+                <AddAccessLinkModal
+                  isComputer
+                  hasLinkExpirationError={hasLinkExpirationDateError}
+                  handleCreation={this.handleCreation}
+                  loading={loading}
+                  record={record}
+                  dropdownOptions={this.generateDropdownOptions()}
+                  isAccessLinksExpirationRequired={isAccessLinksExpirationRequired}
+                />
+              </Table.HeaderCell>
             </Table.Row>
           </Table.Header>
           <Table.Body>
@@ -207,17 +229,6 @@ export class LinksSearchResultContainer extends Component {
               </Table.Row>
             )}
           </Table.Body>
-        </Table>
-
-        <Table color="green">
-          <CreateAccessLink
-            hasLinkExpirationError={hasLinkExpirationDateError}
-            handleCreation={this.handleCreation}
-            loading={loading}
-            record={record}
-            dropdownOptions={this.generateDropdownOptions()}
-            isAccessLinksExpirationRequired={isAccessLinksExpirationRequired}
-          />
         </Table>
       </>
     );


### PR DESCRIPTION
fix(share): use modal for creating access links, matching people/groups tabs

Harmonizes the Links tab's "create link" UI with the People and Groups tabs, which grant access via a modal opened by a + button rather than an always-visible inline form.

### Description

> Please describe briefly your pull request.

New `AddAccessLinkModal.js`, following the same modal-behind-a-`+`-button
  pattern as `AddUserGroupAccessModal.js`, wrapping the existing
  `CreateAccessLink` form.
- `LinksSearchResultContainer.js`: removed the always-visible inline
  form, added the modal trigger button in the table header (desktop)
  and above the table (mobile), mirroring `AccessUsersGroups.js`.
- `handleCreation` now returns a boolean so the modal can auto-close on
  successful link creation.

Tested locally: created a link via the new modal, confirmed it appears
in the list, and confirmed the People/Groups tabs are unaffected.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
