### PR TITLE
fix: additional pre-migration steps

### DIFF
--- a/invenio_app_rdm/upgrade_scripts/prepare_migration_13_0_to_14_0.py
+++ b/invenio_app_rdm/upgrade_scripts/prepare_migration_13_0_to_14_0.py
@@ -56,6 +56,14 @@ def table_exist(connection, table_name):
     return inspect(connection).has_table(table_name)
 
 
+def column_exists(connection, table_name, column_name):
+    """Check if the given column exists on the given table."""
+    return any(
+        column["name"] == column_name
+        for column in inspect(connection).get_columns(table_name)
+    )
+
+
 def add_head_if_package_installed(connection, package_name, head, require_tables=None):
     """Add the given head to the alembic table if not already present."""
     if not _is_installed(package_name):
@@ -154,6 +162,43 @@ def remove_obsolete_files_index(connection):
     connection.execute(text("DROP INDEX IF EXISTS ix_uq_partial_files_object_is_head"))
 
 
+def remove_user_id_from_transaction(connection):
+    """Remove the user_id column from transaction table.
+
+    Repositories generated later than 5 years ago already do not have this column, older repositories
+    might have. We drop it to avoid schema conflicts between the model and the database only if it does
+    not contain values.
+
+    ALEMBIC_DIFF_COUNT:3
+    - ('remove_index', Index('ix_transaction_user_id', Column('user_id', INTEGER(), table=<transaction>)))
+    - ('remove_fk',
+       ForeignKeyConstraint(<sqlalchemy.sql.base.ReadOnlyColumnCollection object at 0x1162cae30>, None, name='fk_transaction_user_id_accounts_user', table=Table('transaction', MetaData(), Column('user_id', NullType(), ForeignKey('accounts_user.id'), table=<transaction>), schema=None)))
+    - ('remove_column',
+       None,
+       'transaction',
+       Column('user_id', INTEGER(), ForeignKey('accounts_user.id'), ForeignKey('accounts_user.id'), table=<transaction>))
+    """
+    print("Checking whether the transaction table should be migrated...")
+    if not column_exists(connection, "transaction", "user_id"):
+        print("The transaction table has no user_id column, nothing to do.")
+        return
+
+    result = connection.execute(
+        text("select count(1) from transaction where user_id is not null")
+    )
+    if result.fetchone()[0] > 0:
+        print(
+            "The transaction.user_id column contains non-null values, keeping it. "
+            "The database will remain inconsistent (but working) with the invenio-db "
+            "model until this is resolved manually. Please contact the Invenio team "
+            "on Discord for help.",
+            file=sys.stderr,
+        )
+    else:
+        print("Dropping the empty transaction.user_id column")
+        connection.execute(text("ALTER TABLE transaction DROP COLUMN user_id CASCADE"))
+
+
 class FailureReporter:
     """Report failures during the upgrade process."""
 
@@ -181,6 +226,7 @@ if __name__ == "__main__":
             fix_invenio_webhooks(connection)
             fix_invenio_github(connection)
             remove_obsolete_files_index(connection)
+            remove_user_id_from_transaction(connection)
             connection.commit()
 
     # fmt: off

--- a/invenio_app_rdm/upgrade_scripts/prepare_migration_13_0_to_14_0.py
+++ b/invenio_app_rdm/upgrade_scripts/prepare_migration_13_0_to_14_0.py
@@ -58,6 +58,8 @@ def table_exist(connection, table_name):
 
 def column_exists(connection, table_name, column_name):
     """Check if the given column exists on the given table."""
+    if not table_exist(connection, table_name):
+        return False
     return any(
         column["name"] == column_name
         for column in inspect(connection).get_columns(table_name)
@@ -199,6 +201,29 @@ def remove_user_id_from_transaction(connection):
         connection.execute(text("ALTER TABLE transaction DROP COLUMN user_id CASCADE"))
 
 
+def fix_system_created_server_default(connection):
+    """Add the missing server_default to oaiserver_set.system_created.
+
+    invenio-oaiserver's migration that adds this column has always set
+    server_default=false, but the SQLAlchemy model didn't set one until it was fixed in
+    https://github.com/inveniosoftware/invenio-oaiserver/commit/d2faa0d780a6cbcdf1e9fea4375e75176a68863e.
+    Instances that got the column via `db create` (built from the model, before that fix)
+    are missing the server default. We backfill it here with the column's own default
+    value, so it's safe to apply regardless of when the repository was created.
+
+    ALEMBIC_DIFF_COUNT:1
+    - ('modify_default', None, 'oaiserver_set', 'system_created', {'existing_nullable': False, 'existing_type': BOOLEAN()}, None, Column('system_created', Boolean(), table=<oaiserver_set>, server_default=DefaultClause(<sqlalchemy.sql.elements.ColumnClause object at 0x1162cae30>, for_update=False)))
+    """
+    if not column_exists(connection, "oaiserver_set", "system_created"):
+        print("The oaiserver_set table has no system_created column, nothing to do.")
+        return
+
+    print("Setting the server default for oaiserver_set.system_created")
+    connection.execute(
+        text("ALTER TABLE oaiserver_set ALTER COLUMN system_created SET DEFAULT false")
+    )
+
+
 class FailureReporter:
     """Report failures during the upgrade process."""
 
@@ -227,6 +252,7 @@ if __name__ == "__main__":
             fix_invenio_github(connection)
             remove_obsolete_files_index(connection)
             remove_user_id_from_transaction(connection)
+            fix_system_created_server_default(connection)
             connection.commit()
 
     # fmt: off

--- a/invenio_app_rdm/upgrade_scripts/prepare_migration_13_0_to_14_0.py
+++ b/invenio_app_rdm/upgrade_scripts/prepare_migration_13_0_to_14_0.py
@@ -261,7 +261,7 @@ if __name__ == "__main__":
 
     Please run:
 
-        invenio alembic upgrade heads
+        invenio alembic upgrade
 
     to finish the database structure migration process. Then continue with the data migration script.
     """)


### PR DESCRIPTION
### Description

#### Obsolete `user_id` column on `transaction`

Invenio-app-rdm has contained this setting for a long time:

```
# Disable logging user information in SQLAlchemy-Continuum. This setting is not
# documented on purpose, since we don't want administrators to be aware of the
# setting.
DB_VERSIONING_USER_MODEL = None
Now, here is how it is handled:
```

In [invenio-db](https://github.com/inveniosoftware/invenio-db/blob/master/invenio_db/ext.py#L228), if the DB_VERSIONING_USER_MODEL setting is not in app.config, an attempt is made to determine whether the invenio-accounts package is installed, and if so, its User model is used as the DB_VERSIONING_USER_MODEL. If the DB_VERSIONING_USER_MODEL setting is present in app.config, it is used as-is. This means that, at the DB level, the user is not logged for invenio-app-rdm.

In [invenio-accounts](https://github.com/inveniosoftware/invenio-accounts/blob/master/invenio_accounts/alembic/9848d0149abd_create_accounts_tables.py#L82), there previously was a piece of code that always added a user_id column to the transaction table when creating accounts tables.

To align this with the handling in invenio-db, a condition has been added requiring DB_VERSIONING_USER_MODEL either not to be present in app.config or to be set to a class; only then is the user_id column added to transaction.

The problem now is that if a repository was generated before this change (v13 and earlier), the transaction table already has a user_id column, so the database has an additional field and is inconsistent with the actual model.

This PR fixes that by looking if this column has any values and if not, removing the column.

#### Inconsistent migration in `invenio-oaiserver`

This PR adds a server default setting for `oaiserver_set.system_created` - it is already fixed in code, but repositories older than 2 months do not have the server default set.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
