### PR TITLE
Fixes ZIP previewer race condition

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/theme.js
@@ -138,19 +138,66 @@ $statsInfoPopup.on("blur", function (event) {
 
 // ZIP Previewer
 
-const broadcastChannel = new BroadcastChannel("invenio-previewer-zip");
+const previewIframe = $("#preview-iframe");
+const iframeEl = previewIframe?.[0];
+if (iframeEl) {
+  let channel;
+  const channelId = `invenio-previewer-zip-${crypto.randomUUID()}`;
 
-broadcastChannel.onmessage = (e) => {
-  const previewIframe = $("#preview-iframe");
-  $("#preview-file-title").html(`
-  <div class="ui breadcrumb">
-    <a class="section preview-link" href="${e.data.containerPreviewUrl}" target="preview-iframe" data-file-key="${e.data.containerFileKey}">${e.data.containerFileKey}</a>
-    <i class="divider">/</i>
-    <div class="active section">${e.data.fileKey}</div>
-  </div>
-  `);
-  $(".preview-link").on("click", function (event) {
-    $("#preview-file-title").html(event.target.dataset.fileKey);
+  const checkIsZipPreview = (url) => {
+    let isZip = false;
+    try {
+      // Use URL to reliably extract pathname
+      const parsed = new URL(url, window.location.origin);
+      isZip = parsed.pathname.toLowerCase().endsWith(".zip");
+      // Fallback: strip query/hash and test with regex
+      if (!isZip) {
+        const pathOnly = url.split(/[?#]/)[0];
+        isZip = /\.zip$/i.test(pathOnly);
+      }
+      return isZip;
+    } catch (err) {
+      console.error("Error while checking URL for .zip:", err);
+      return false;
+    }
+  }
+
+  const onIframeMessage = (e) => {
+    if (!e.data?.type || e.data?.type !== "invenio-previewer-zip" || e.data?.channelId !== channelId) {
+      return;
+    }
+    $("#preview-file-title").html(`
+    <div class="ui breadcrumb">
+      <a class="section preview-link" href="${e.data.containerPreviewUrl}" target="preview-iframe" data-file-key="${e.data.containerFileKey}">${e.data.containerFileKey}</a>
+      <i class="divider">/</i>
+      <div class="active section">${e.data.fileKey}</div>
+    </div>
+    `);
+    $(".preview-link").on("click", function (event) {
+      $("#preview-file-title").html(event.target.dataset.fileKey);
+    });
+    previewIframe.attr("src", e.data.previewUrl);
+  };
+
+  const origin = window.location.href.split(/[?#]/)[0];
+  iframeEl.addEventListener("load", function () {
+    const win = iframeEl.contentWindow || iframeEl.contentDocument?.defaultView;
+    // Check whether the iframe's location path ends with .zip (ignore query/hash)
+    let isZip = false;
+    if (typeof win?.location.href === "string") {
+      isZip = checkIsZipPreview(win.location.href);
+    }
+
+    if (!isZip) return;
+
+    if (iframeEl.getAttribute("src") !== win.location.href) {
+      iframeEl.setAttribute("src", win.location.href);
+    }
+    
+    // Always create the channel and register handler; only transfer the port when iframe is a .zip
+    channel = new MessageChannel();
+    channel.port1.onmessage = onIframeMessage;
+
+    win.postMessage({ type: "invenio-previewer-zip", channelId: channelId }, origin, [channel.port2]);
   });
-  previewIframe.attr("src", e.data.previewUrl);
-};
+}

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -1,6 +1,1 @@
-/*
- * SPDX-FileCopyrightText: 2023-2025 CERN.
- * SPDX-License-Identifier: MIT
- */
-
-export const overriddenComponents = {};
+/home/martin/Projects/CESNET/Invenio/invenio-dev-latest/assets/js/invenio_app_rdm/overridableRegistry/mapping.js

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/previewer/previewable_zip.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/previewer/previewable_zip.js
@@ -5,21 +5,31 @@
 
 import $ from "jquery";
 
-const channel = new BroadcastChannel("invenio-previewer-zip");
+window.addEventListener("message", onMessage);
 
-$(".preview-link").on("click", function (e) {
-  e.preventDefault();
-  const fileKey = $(this).data("file-key");
-  const previewUrl = $(this).data("preview-url");
-  const containerFileKey = $(this).data("container-file-key");
-  const containerPreviewUrl = window.location.href;
-  channel.postMessage({
-    fileKey: fileKey,
-    previewUrl: previewUrl,
-    containerFileKey: containerFileKey,
-    containerPreviewUrl: containerPreviewUrl,
+function onMessage(msg) {
+  if (msg.origin !== window.location.origin || !msg.ports.length || msg.data?.type !== "invenio-previewer-zip") return;
+
+  const channelId = msg.data?.channelId;
+  if (!channelId) return;
+
+  $(".preview-link").on("click", function (e) {
+    e.preventDefault();
+    const fileKey = $(this).data("file-key");
+    const previewUrl = $(this).data("preview-url");
+    const containerFileKey = $(this).data("container-file-key");
+    const containerPreviewUrl = window.location.href;
+    
+    msg.ports[0].postMessage({
+      type: "invenio-previewer-zip",
+      channelId: channelId,
+      fileKey: fileKey,
+      previewUrl: previewUrl,
+      containerFileKey: containerFileKey,
+      containerPreviewUrl: containerPreviewUrl,
+    });
+    console.log(
+      `[${containerFileKey} at ${containerPreviewUrl}] Requested preview for fileKey: ${fileKey} with URL: ${previewUrl}`
+    );
   });
-  console.log(
-    `[${containerFileKey} at ${containerPreviewUrl}] Requested preview for fileKey: ${fileKey} with URL: ${previewUrl}`
-  );
-});
+}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

This pull request resolves a race condition that could occur during the handling of ZIP file previews. It refactors the communication mechanism between the parent page and the iframe displaying the ZIP contents from using a global `BroadcastChannel` to a more targeted and secure `MessageChannel`.

Key changes include:
*   **Targeted Communication:** Replaces `BroadcastChannel` with `MessageChannel` for direct parent-iframe communication, eliminating potential conflicts from other scripts or previewers.
*   **Unique Channel Identification:** Introduces a unique channel ID for each previewer instance, ensuring messages are processed by the correct listener.
*   **Conditional Channel Setup:** Establishes the `MessageChannel` only when the iframe's content is confirmed to be a ZIP previewer, optimizing resource usage and preventing unintended behavior.
*   **Improved URL Parsing:** Adds robust URL parsing to accurately determine if an iframe's content is a ZIP file.

This change enhances the reliability and stability of the ZIP file preview functionality, preventing issues where preview requests might not be correctly handled.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.