### PR TITLE
config: fix citation styles for Vancouver and Chicago with csl 1.0.2

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -1121,8 +1121,8 @@ RDM_CITATION_STYLES = [
     ("apa", _("APA")),
     ("harvard-cite-them-right", _("Harvard")),
     ("modern-language-association", _("MLA")),
-    ("vancouver", _("Vancouver")),
-    ("chicago-fullnote-bibliography", _("Chicago")),
+    ("nlm-citation-sequence", _("Vancouver")),
+    ("chicago-notes-bibliography", _("Chicago")),
     ("ieee", _("IEEE")),
 ]
 """List of citation style """


### PR DESCRIPTION
Related PRs:
* citeproc-py/citeproc-py#192
* inveniosoftware/invenio-rdm-records#2382

Two of the default citations styles are broken with csl 1.0.2:
* Vancouver, which got renamed from `vancouver` to `nlm-citation-sequence` in https://github.com/citation-style-language/styles/pull/8026
* Chicago, which got renamed from `chicago-fullnote-bibliography` to `chicago-notes-bibliography` https://github.com/citation-style-language/styles/pull/7424

On a side note, somebody contacted us last month on Zenodo support, asking us to add support for NLM. When I told them that Vancouver and NLM was the same thing, they responded:

> The Vancouver citation style is indeed similar [...]. I found a few key differences:
> 1. Vancouver style truncates the author list. It lists the first 6 and adds "et al." for the remaining authors. NLM style lists all authors.
> 2. The Vancouver style on Zenodo appears to list the names as First Name Last Name, but both Vancouver and NLM style list the Last name first, followed by the First and Middle Initials. Maybe this is a limitation of Zenodo being unable to distinguish first names from last names? I'm citing software like https://zenodo.org/records/18880164
> 3. Vancouver style hides DOI, but NLM adds DOI as "doi: xx/xx" at or near the end.
>  
> There might be other differences regarding citation dates and tags in square brackets, but the above three were the ones that I changed from Vancouver to get NLM (or close enough to NLM) when citing resources on Zenodo. It would be great to add an NLM option with at least those changes!