### PR TITLE
fix(theme): keep details-list custom field links inline

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
+++ b/invenio_app_rdm/theme/assets/semantic-ui/less/invenio_app_rdm/theme/globals/site.overrides
@@ -597,10 +597,8 @@ dl.details-list {
   justify-content: space-between;
 }
 
-/* Prevent long values and links from overflowing in details lists */
-dl.details-list dd,
-dl.details-list a {
-  display: block;
+/* Prevent long values from overflowing in details lists */
+dl.details-list dd {
   max-width: 100%;
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -611,9 +609,7 @@ dl.details-list a {
 .stackable.mobile.reversed.grid > .column:last-child {
   min-width: 0;
 
-  a,
   dd {
-    display: block;
     max-width: 100%;
     overflow-wrap: anywhere;
     word-break: break-word;


### PR DESCRIPTION
Stop forcing details-list anchors to display:block so multi-value custom fields like experiments stay on one line while still wrapping long values on dd.

:heart: Thank you for your contribution!

### Description
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/880

<img width="1031" height="185" alt="image" src="https://github.com/user-attachments/assets/b82ae070-1bef-4b37-abca-dc3eb604c7e0" />


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
