### PR TITLE
admin: make request type facet filter match results

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -27,6 +27,7 @@ WARNING: An instance should NOT install multiple flavour extensions since
          there would be no guarantee of priority anymore.
 """
 
+from copy import copy
 from datetime import datetime, timedelta
 
 import invenio_communities.notifications.builders as community_notifications
@@ -1598,6 +1599,27 @@ APP_RDM_MODERATION_REQUEST_FACETS = {
     "is_open": {"facet": facets.is_open, "ui": {"field": "is_open"}},
 }
 """Available facets defined for this module."""
+
+# Apply request type filters as query filters so aggregations (facet counts)
+# match the result list. By default, type is a post_filter which leaves facet
+# counts from other request types visible while hiding them from hits.
+_request_type_facet = copy(facets.type)
+_request_type_facet.post_filter = False
+REQUESTS_FACETS = {
+    "type": {
+        "facet": _request_type_facet,
+        "ui": {
+            "field": "type",
+        },
+    },
+    "status": {
+        "facet": facets.status,
+        "ui": {
+            "field": "status",
+        },
+    },
+}
+"""Request facets with type filtering applied to aggregations and hits."""
 
 # Invenio-VCS
 # ===========


### PR DESCRIPTION

### Description

## Summary
Fixed facet/result mismatch when filtering requests by type.
The request `type` facet was applied as a `post_filter`, so facet counts could include other request types while the results list did not. This change applies type filters as query filters so aggregations and hits stay consistent.

For #3508, the admin Moderation → Requests page remains scoped to record-deletion for now. Additional admin request types can be added later once there is consensus.

Fixes #3508

## Test plan
- [x] With only draft-review requests: admin Requests list/facets consistent (no mismatch)
- [x] With a record-deletion request: appears in admin Requests with matching Status count
- [x] Smoke test: `./run-tests.sh tests/test_version.py -v`


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).


**Frontend**
N/A — no frontend changes in this PR.

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.

