### PR TITLE
feat(search): add overridable id for result item labels row

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/RecordsResultsListItem.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/components/RecordsResultsListItem.js
@@ -97,26 +97,37 @@ class RecordsResultsListItem extends Component {
             {/* FIXME: Uncomment to enable themed banner */}
             {/* <DisplayVerifiedCommunity communities={result.parent?.communities} /> */}
             <Item.Extra className="labels-actions">
-              <Label horizontal size="small" className="primary theme-primary">
-                {publicationDate} ({version})
-              </Label>
-              <Label
-                horizontal
-                size="small"
-                className="neutral"
-                as="a"
-                href={`${window.location.pathname}?q=&f=${resourceTypeFilter}`}
+              <Overridable
+                id={buildUID("RecordsResultsListItem.labels", "", appName)}
+                result={result}
               >
-                {resourceType}
-              </Label>
-              <Label
-                horizontal
-                size="small"
-                className={`access-status ${accessStatusId}`}
-              >
-                {accessStatusIcon && <Icon name={accessStatusIcon} />}
-                {accessStatus}
-              </Label>
+                <>
+                  <Label horizontal size="small" className="primary theme-primary">
+                    {publicationDate} ({version})
+                  </Label>
+                  <Label
+                    horizontal
+                    size="small"
+                    className="neutral"
+                    as="a"
+                    href={`${window.location.pathname}?q=&f=${resourceTypeFilter}`}
+                  >
+                    {resourceType}
+                  </Label>
+                  <Label
+                    horizontal
+                    size="small"
+                    className={`access-status ${accessStatusId}`}
+                  >
+                    {accessStatusIcon && <Icon name={accessStatusIcon} />}
+                    {accessStatus}
+                  </Label>
+                </>
+              </Overridable>
+              <Overridable
+                id={buildUID("RecordsResultsListItem.labels.after", "", appName)}
+                result={result}
+              />
             </Item.Extra>
             <Item.Header as="h2" className="theme-primary-text">
               <a href={viewLink}>{titleTruncated}</a>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
Closes: https://github.com/CERNDocumentServer/cds-rdm/issues/888
Related pr: https://github.com/CERNDocumentServer/cds-rdm/pull/890

Adds `RecordsResultsListItem.labels` around the search result badge row (same pattern as `description`), plus an empty `RecordsResultsListItem.labels.after` slot so instances can append extra labels without replacing the defaults. Needed in CDS-RDM for the EP number badge.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the copyright holder(s) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).