### PR TITLE
config: remove unused APP_RDM_RECORDS_EXPORT_URL config

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -938,8 +938,6 @@ def github_link_render(record):
     ...
 """
 
-APP_RDM_RECORDS_EXPORT_URL = "/records/<pid_value>/export/<export_format>"
-
 APP_RDM_DEPOSIT_NG_FILES_UI_ENABLED = False
 """
 Feature toggle to enable the next-generation (NG) file uploader UI in the deposit form.


### PR DESCRIPTION
* The config used for this route is `record_export` in `APP_RDM_ROUTES`.
* I did not find any other traces of this config in the code or in the docs.
