### PR TITLE
fix: optionally chain user in RecordManagement.recordOwnerID to account for system records

### DIFF
--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
@@ -36,7 +36,7 @@ function renderRecordManagement(element) {
           recordManagementAppDiv.dataset.isPreviewSubmissionRequest
         )}
         currentUserId={recordManagementAppDiv.dataset.currentUserId}
-        recordOwnerID={record.parent.access.owned_by.user}
+        recordOwnerID={record.parent.access.owned_by?.user}
         groupsEnabled={JSON.parse(recordManagementAppDiv.dataset.groupsEnabled)}
         recordDeletion={JSON.parse(recordManagementAppDiv.dataset.recordDeletion)}
         recordDeletionOptions={JSON.parse(


### PR DESCRIPTION
Without this fix, records with `record.parent.access.owned_by == null` (typical of System created records) will raise an error and break all JS on the record's landing page.

We need this fix as a large portion of our collection is System records.

I will backport this to v14.