### PR TITLE
fix(versions): text for disabled version depends on flag

### DIFF
--- a/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/manage_menu.html
+++ b/invenio_app_rdm/records_ui/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/manage_menu.html
@@ -27,6 +27,7 @@
          {% if config.RDM_DETAIL_SIDE_BAR_MANAGE_ATTRIBUTES_EXTENSION_TEMPLATE %}
           {% include config.RDM_DETAIL_SIDE_BAR_MANAGE_ATTRIBUTES_EXTENSION_TEMPLATE %}
          {% endif %}
+         data-allow-external-doi-versions='{{ config.RDM_ALLOW_EXTERNAL_DOI_VERSIONING | tojson }}'
          >
       <div class="ui placeholder">
         <div class="header">

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -423,6 +423,7 @@ def get_form_config(**kwargs):
         default_transfer_type=current_transfer_registry.default_transfer_type,
         enabled_transfer_types=list(current_transfer_registry.get_transfer_types()),
         transfer_types=file_transfer_type()["transfer_types"],
+        allow_external_doi_versions=conf["RDM_ALLOW_EXTERNAL_DOI_VERSIONING"],
         **kwargs,
     )
 

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/RecordManagement.js
@@ -37,6 +37,7 @@ export class RecordManagement extends Component {
       recordDeletion,
       recordDeletionOptions,
       auditLogsEnabled,
+      allowExternalDoiVersions,
     } = this.props;
     const { error } = this.state;
     const { id: recid } = record;
@@ -86,6 +87,7 @@ export class RecordManagement extends Component {
                 record={record}
                 onError={handleError}
                 disabled={!permissions?.can_new_version}
+                allowExternalDoiVersions={allowExternalDoiVersions}
               />
             </Grid.Column>
 
@@ -131,9 +133,11 @@ RecordManagement.propTypes = {
   recordDeletion: PropTypes.object,
   recordDeletionOptions: PropTypes.array.isRequired,
   auditLogsEnabled: PropTypes.bool,
+  allowExternalDoiVersions: PropTypes.bool,
 };
 
 RecordManagement.defaultProps = {
   recordDeletion: {},
   auditLogsEnabled: false,
+  allowExternalDoiVersions: true,
 };

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/landing_page/index.js
@@ -43,6 +43,9 @@ function renderRecordManagement(element) {
           recordManagementAppDiv.dataset.recordDeletionOptions
         )}
         auditLogsEnabled={JSON.parse(recordManagementAppDiv.dataset.auditLogsEnabled)}
+        allowExternalDoiVersions={JSON.parse(
+          recordManagementAppDiv.dataset.allowExternalDoiVersions
+        )}
       />
     </OverridableContext.Provider>,
     element


### PR DESCRIPTION
### Description

Pass the config flag RDM_ALLOW_EXTERNAL_DOI_VERSIONING value to the frontend so the message for disabled new versions gives more details.

Related to: https://github.com/inveniosoftware/invenio-rdm-records/pull/2343
Closes issue https://github.com/zenodo/zenodo-rdm/issues/1369

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
